### PR TITLE
Plugin-style column types + local-first PGlite default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
-# Neon Postgres — Drizzle client + migrations
-# Get this from https://console.neon.tech → your project → Connection string
-DATABASE_URL=postgresql://user:pass@host/db?sslmode=require&channel_binding=require
+# Database — OPTIONAL. When unset, Minitor uses an embedded PGlite instance
+# stored at .minitor/pgdata (real Postgres compiled to WASM, no setup needed).
+# Set this only when you want to point at a remote / shared DB:
+#   - Neon:        postgresql://…@…neon.tech/…?sslmode=require
+#   - Local PG:    postgresql://user:pass@localhost:5432/minitor
+# DATABASE_URL=
 
 # xAI (Grok) API key — powers every X / Web / News / Grok Ask column.
 # Create at https://console.x.ai

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local PGlite database (default when DATABASE_URL is unset)
+/.minitor/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Visually inspired by Cursor's warm-minimalism system (cream surfaces, warm near-
 
 - **Next.js 16** (App Router, Turbopack) + **React 19** + **TypeScript**
 - **Tailwind v4** + **shadcn/ui** (`base-nova` style on `@base-ui/react`) + **blocks.so** registry
-- **Neon Postgres** via `@neondatabase/serverless` and **Drizzle ORM**
+- **Postgres** via **Drizzle ORM**, with three driver choices picked at runtime by `DATABASE_URL`:
+  - default (no env): **PGlite** — embedded Postgres compiled to WASM, file-backed at `.minitor/pgdata/`. Zero setup.
+  - any `postgres://` URL: **node-postgres** pool.
+  - any `*.neon.tech` URL: **`@neondatabase/serverless`** HTTP driver.
 - **xAI Agent Tools API** (`/v1/responses` with `x_search` + `web_search`) — the Grok-powered backbone
 - **zustand** for client state with server-action writes (no localStorage)
 - **@dnd-kit** for sortable decks + columns
@@ -37,22 +40,42 @@ Columns are pure plugins. A `ColumnType` is a config form + item renderer + fetc
 
 ## Setup
 
+The fastest path needs nothing but Node — no Docker, no Postgres install, no
+hosted DB account. The default Drizzle client is PGlite (real Postgres
+compiled to WASM, persisted at `.minitor/pgdata/`).
+
 ```bash
 # 1. Install
 npm install
 
-# 2. Env
+# 2. Optional — only if you want non-keyless columns (Grok / X / News /
+# Farcaster / YouTube search). Skip this for purely-keyless dev (Reddit,
+# HN, RSS, Google News, NewsNow, GitHub, YouTube channel/playlist).
 cp .env.example .env.local
-# Fill in DATABASE_URL (Neon) and XAI_API_KEY (xAI)
+# Fill in XAI_API_KEY etc. Leave DATABASE_URL commented out for local PGlite.
 
-# 3. Create the schema on Neon
-npm run db:migrate     # applies drizzle/0000_*.sql via the Neon HTTP driver
+# 3. Create the schema
+npm run db:migrate     # PGlite by default; honors DATABASE_URL when set
 
 # 4. Dev
 npm run dev
 ```
 
-Then open http://localhost:3000. First run drops you into an onboarding screen — name the first deck, pick 2–3 column types to seed.
+Then open http://localhost:3000. First run drops you into an onboarding
+screen — name the first deck, pick 2–3 column types to seed.
+
+### Pointing at a different database
+
+Set `DATABASE_URL` in `.env.local`:
+
+| URL form | Driver picked |
+|---|---|
+| *unset* / `pglite:` / `file:` / `memory:` | PGlite (file at `.minitor/pgdata/`) |
+| `postgres://user:pass@localhost/minitor` | node-postgres |
+| `postgresql://…@…neon.tech/…?sslmode=require` | `@neondatabase/serverless` HTTP |
+
+`npm run db:migrate` and the runtime client both honor the same selector
+(`lib/db/client.ts:resolveDatabaseConfig`).
 
 ## Scripts
 

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,11 +1,10 @@
 "use server";
 
-import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { columns, decks, feedItems } from "@/lib/db/schema";
 import type { Column, Deck, FeedItem } from "@/lib/columns/types";
-
-const MAX_ITEMS_PER_COLUMN = 200;
+import { MAX_ITEMS_PER_COLUMN } from "@/lib/columns/constants";
 
 export interface Snapshot {
   decks: Record<string, Deck>;
@@ -13,14 +12,38 @@ export interface Snapshot {
   columns: Record<string, Column>;
 }
 
+type ItemRow = {
+  id: string;
+  column_id: string;
+  author: FeedItem["author"];
+  content: string;
+  url: string | null;
+  created_at: string;
+  meta: Record<string, unknown> | null;
+};
+
 export async function loadSnapshot(): Promise<Snapshot> {
-  const [deckRows, columnRows, itemRows] = await Promise.all([
+  // Page items at the DB instead of slicing in memory: window-function with
+  // row_number() returns at most MAX_ITEMS_PER_COLUMN per column, ordered
+  // newest-first within each partition.
+  const itemQuery = db.execute(sql`
+    SELECT id, column_id, author, content, url, created_at, meta
+    FROM (
+      SELECT *,
+        row_number() OVER (PARTITION BY column_id ORDER BY created_at DESC) AS rn
+      FROM feed_items
+    ) t
+    WHERE rn <= ${MAX_ITEMS_PER_COLUMN}
+    ORDER BY column_id, created_at DESC
+  `);
+
+  const [deckRows, columnRows, itemResult] = await Promise.all([
     db.select().from(decks).orderBy(asc(decks.position), asc(decks.createdAt)),
     db
       .select()
       .from(columns)
       .orderBy(asc(columns.position), asc(columns.createdAt)),
-    db.select().from(feedItems).orderBy(desc(feedItems.createdAt)),
+    itemQuery,
   ]);
 
   const decksById: Record<string, Deck> = {};
@@ -43,17 +66,19 @@ export async function loadSnapshot(): Promise<Snapshot> {
     decksById[c.deckId]?.columnIds.push(c.id);
   }
 
+  const itemRows: ItemRow[] = Array.isArray(itemResult)
+    ? (itemResult as ItemRow[])
+    : ((itemResult as unknown as { rows?: ItemRow[] }).rows ?? []);
   for (const item of itemRows) {
-    const col = columnsById[item.columnId];
+    const col = columnsById[item.column_id];
     if (!col) continue;
-    if (col.items.length >= MAX_ITEMS_PER_COLUMN) continue;
     col.items.push({
       id: item.id,
-      author: item.author as FeedItem["author"],
+      author: item.author,
       content: item.content,
       url: item.url ?? undefined,
-      createdAt: item.createdAt.toISOString(),
-      meta: (item.meta as Record<string, unknown>) ?? undefined,
+      createdAt: new Date(item.created_at).toISOString(),
+      meta: item.meta ?? undefined,
     });
   }
 
@@ -77,11 +102,16 @@ export async function deleteDeck(id: string): Promise<void> {
 
 export async function reorderDecks(orderedIds: string[]): Promise<void> {
   if (orderedIds.length === 0) return;
-  await Promise.all(
-    orderedIds.map((id, position) =>
-      db.update(decks).set({ position }).where(eq(decks.id, id)),
-    ),
+  const values = sql.join(
+    orderedIds.map((id, i) => sql`(${id}::text, ${i}::int)`),
+    sql`, `,
   );
+  await db.execute(sql`
+    UPDATE decks
+    SET position = v.position
+    FROM (VALUES ${values}) AS v(id, position)
+    WHERE decks.id = v.id
+  `);
 }
 
 export async function createColumn(
@@ -125,14 +155,16 @@ export async function reorderColumnsInDeck(
   orderedIds: string[],
 ): Promise<void> {
   if (orderedIds.length === 0) return;
-  await Promise.all(
-    orderedIds.map((id, position) =>
-      db
-        .update(columns)
-        .set({ position, deckId })
-        .where(eq(columns.id, id)),
-    ),
+  const values = sql.join(
+    orderedIds.map((id, i) => sql`(${id}::text, ${i}::int)`),
+    sql`, `,
   );
+  await db.execute(sql`
+    UPDATE columns
+    SET position = v.position, deck_id = ${deckId}
+    FROM (VALUES ${values}) AS v(id, position)
+    WHERE columns.id = v.id
+  `);
 }
 
 export async function persistFetchedItems(

--- a/app/api/columns/[type]/route.ts
+++ b/app/api/columns/[type]/route.ts
@@ -1,35 +1,5 @@
 import { NextResponse } from "next/server";
-import { fetchSubredditPage } from "@/lib/integrations/reddit";
-import {
-  fetchHackerNewsPage,
-  type HNMode,
-} from "@/lib/integrations/hackernews";
-import { fetchGitHub, type GHMode } from "@/lib/integrations/github";
-import { fetchFeed, googleNewsUrl } from "@/lib/integrations/rss";
-import { fetchMentions } from "@/lib/integrations/mentions";
-import {
-  fetchFarcasterUser,
-  fetchFarcasterSearch,
-} from "@/lib/integrations/farcaster";
-import {
-  fetchYouTube,
-  fetchSearchPage as fetchYouTubeSearchPage,
-  type YTMode,
-} from "@/lib/integrations/youtube";
-import {
-  fetchNewsNow,
-  type NewsNowPlatform,
-} from "@/lib/integrations/newsnow";
-import {
-  grokAsk,
-  grokNewsSearch,
-  grokWebSearch,
-  grokXMentions,
-  grokXSearch,
-  grokXTrending,
-  grokXUser,
-} from "@/lib/integrations/xai";
-import type { FeedItem } from "@/lib/columns/types";
+import { getServerFetcher } from "@/lib/columns/server-registry";
 
 // Grok calls are slow and expensive — don't cache, always fresh on refresh.
 export const dynamic = "force-dynamic";
@@ -37,180 +7,29 @@ export const maxDuration = 60;
 
 type RouteContext = { params: Promise<{ type: string }> };
 
-function text(value: unknown, fallback = ""): string {
-  return typeof value === "string" ? value : fallback;
-}
-
-const PAGE_SIZE = 12;
-
 export async function POST(req: Request, context: RouteContext) {
   const { type } = await context.params;
+  const fetcher = getServerFetcher(type);
+  if (!fetcher) {
+    return NextResponse.json(
+      { error: `Unknown column type: ${type}` },
+      { status: 404 },
+    );
+  }
+
   const body = await req.json().catch(() => ({}));
   const config = (body?.config ?? {}) as Record<string, unknown>;
-  const op = body?.op === "loadMore" ? "loadMore" : "fetch";
   const cursor =
-    typeof body?.cursor === "string" ? (body.cursor as string) : undefined;
+    body?.op === "loadMore" && typeof body?.cursor === "string"
+      ? (body.cursor as string)
+      : undefined;
 
   try {
-    // Paginated types first — return {items, nextCursor?}.
-    if (type === "hacker-news") {
-      const page = op === "loadMore" ? Number(cursor ?? "1") || 1 : 0;
-      const r = await fetchHackerNewsPage(
-        text(config.mode, "top") as HNMode,
-        text(config.query, ""),
-        PAGE_SIZE,
-        page,
-      );
-      return NextResponse.json({
-        items: r.items,
-        nextCursor: r.hasMore ? String(page + 1) : undefined,
-      });
-    }
-
-    if (type === "reddit") {
-      const r = await fetchSubredditPage(
-        text(config.subreddit, "popular"),
-        text(config.sortBy, "hot"),
-        PAGE_SIZE,
-        op === "loadMore" ? cursor : undefined,
-      );
-      return NextResponse.json({
-        items: r.items,
-        nextCursor: r.nextAfter,
-      });
-    }
-
-    if (type === "github") {
-      const page = op === "loadMore" ? Number(cursor ?? "2") || 2 : 1;
-      const items = await fetchGitHub(
-        text(config.mode, "trending") as GHMode,
-        {
-          language: text(config.language, ""),
-          period: text(config.period, "week"),
-          repo: text(config.repo, ""),
-          query: text(config.query, ""),
-        },
-        PAGE_SIZE,
-        page,
-      );
-      return NextResponse.json({
-        items,
-        nextCursor:
-          items.length === PAGE_SIZE ? String(page + 1) : undefined,
-      });
-    }
-
-    if (type === "youtube") {
-      const mode = text(config.mode, "search") as YTMode;
-      // Only the search mode supports cursor pagination via Data API v3.
-      if (mode === "search") {
-        const r = await fetchYouTubeSearchPage(
-          text(config.query, ""),
-          text(config.order, "date") as
-            | "date"
-            | "relevance"
-            | "viewCount"
-            | "rating",
-          PAGE_SIZE,
-          op === "loadMore" ? cursor : undefined,
-        );
-        return NextResponse.json({
-          items: r.items,
-          nextCursor: r.nextPageToken,
-        });
-      }
-      const items = await fetchYouTube(mode, {
-        query: text(config.query, ""),
-        order: text(config.order, "date"),
-        channel: text(config.channel, ""),
-        playlist: text(config.playlist, ""),
-      });
-      return NextResponse.json({ items });
-    }
-
-    // Non-paginated types — only initial fetch is supported.
-    if (op === "loadMore") {
-      return NextResponse.json(
-        { error: `Pagination not supported for ${type}` },
-        { status: 400 },
-      );
-    }
-
-    let items: FeedItem[];
-    switch (type) {
-      case "x-search":
-      case "x-mentions-search":
-        items = await grokXSearch(text(config.query));
-        break;
-      case "x-mentions":
-        items = await grokXMentions(text(config.handle));
-        break;
-      case "x-user":
-        items = await grokXUser(text(config.handle));
-        break;
-      case "x-trending":
-        items = await grokXTrending(text(config.topic));
-        break;
-      case "web-search":
-        items = await grokWebSearch(text(config.query));
-        break;
-      case "news-search":
-        items = await grokNewsSearch(text(config.query));
-        break;
-      case "grok-ask":
-        items = await grokAsk(text(config.prompt));
-        break;
-      case "rss":
-        items = await fetchFeed(text(config.url, ""));
-        break;
-      case "google-news":
-        items = await fetchFeed(
-          googleNewsUrl(
-            text(config.query, ""),
-            text(config.hl, "en-US"),
-            text(config.gl, "US"),
-          ),
-        );
-        break;
-      case "mentions": {
-        const sources = (config.sources ?? {}) as Record<string, unknown>;
-        items = await fetchMentions({
-          query: text(config.query, ""),
-          sources: {
-            hn: sources.hn !== false,
-            reddit: sources.reddit !== false,
-            "google-news": sources["google-news"] !== false,
-            "bing-news": sources["bing-news"] === true,
-          },
-        });
-        break;
-      }
-      case "farcaster": {
-        const fcMode = text(config.mode, "user");
-        if (fcMode === "search") {
-          items = await fetchFarcasterSearch(text(config.query, ""));
-        } else {
-          items = await fetchFarcasterUser(text(config.username, ""));
-        }
-        break;
-      }
-      case "newsnow":
-        items = await fetchNewsNow(
-          text(config.platform, "weibo") as NewsNowPlatform,
-        );
-        break;
-      default:
-        return NextResponse.json(
-          { error: `Unknown column type: ${type}` },
-          { status: 404 },
-        );
-    }
-
-    return NextResponse.json({ items });
+    const result = await fetcher(config, cursor);
+    return NextResponse.json(result);
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Unknown error";
     console.error(`[api/columns/${type}]`, msg);
     return NextResponse.json({ error: msg }, { status: 502 });
   }
 }
-

--- a/components/column/add-column-dialog.tsx
+++ b/components/column/add-column-dialog.tsx
@@ -15,7 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { listColumnTypes } from "@/lib/columns/registry";
 import { useDeckStore } from "@/lib/store/use-deck-store";
-import type { ColumnType } from "@/lib/columns/types";
+import type { AnyColumnType } from "@/lib/columns/types";
 import {
   Tooltip,
   TooltipContent,
@@ -33,7 +33,7 @@ export function AddColumnDialog({ open, onOpenChange, deckId }: Props) {
   const autoFetchColumn = useDeckStore((s) => s.autoFetchColumn);
   const types = useMemo(() => listColumnTypes(), []);
 
-  const [selectedType, setSelectedType] = useState<ColumnType | null>(null);
+  const [selectedType, setSelectedType] = useState<AnyColumnType | null>(null);
   const [config, setConfig] = useState<Record<string, unknown>>({});
   const [title, setTitle] = useState("");
 
@@ -48,7 +48,7 @@ export function AddColumnDialog({ open, onOpenChange, deckId }: Props) {
     onOpenChange(next);
   }
 
-  function pickType(type: ColumnType) {
+  function pickType(type: AnyColumnType) {
     setSelectedType(type);
     setConfig({ ...(type.defaultConfig as Record<string, unknown>) });
     setTitle(type.defaultTitle(type.defaultConfig as never));
@@ -57,9 +57,9 @@ export function AddColumnDialog({ open, onOpenChange, deckId }: Props) {
   function commit() {
     if (!selectedType) return;
     const finalTitle = title.trim() || selectedType.defaultTitle(config as never);
-    const newId = addColumn(deckId, selectedType.id, finalTitle, config);
+    const { id, ready } = addColumn(deckId, selectedType.id, finalTitle, config);
     handleOpenChange(false);
-    void autoFetchColumn(newId, selectedType);
+    void autoFetchColumn(id, selectedType, ready);
   }
 
   return (

--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -27,7 +27,10 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { getColumnType } from "@/lib/columns/registry";
+import { callColumnApi } from "@/lib/columns/api-client";
 import { useDeckStore } from "@/lib/store/use-deck-store";
+import { useMinDuration } from "@/hooks/use-min-duration";
+import { BEAM_MIN_DURATION_MS } from "@/lib/columns/constants";
 import type { Column } from "@/lib/columns/types";
 import { ConfigureColumnDialog } from "@/components/column/configure-column-dialog";
 import { RenameDialog } from "@/components/dialogs/rename-dialog";
@@ -38,9 +41,11 @@ export function ColumnCard({ column }: { column: Column }) {
   const removeColumn = useDeckStore((s) => s.removeColumn);
   const applyFetchedItems = useDeckStore((s) => s.applyFetchedItems);
   const renameColumn = useDeckStore((s) => s.renameColumn);
-  const isAutoFetching = useDeckStore((s) => s.autoFetchingIds.has(column.id));
+  const isAutoFetchingRaw = useDeckStore((s) => s.autoFetchingIds.has(column.id));
 
-  const [isFetching, setIsFetching] = useState(false);
+  const [isFetchingRaw, setIsFetching] = useState(false);
+  const isFetching = useMinDuration(isFetchingRaw, BEAM_MIN_DURATION_MS);
+  const isAutoFetching = useMinDuration(isAutoFetchingRaw, BEAM_MIN_DURATION_MS);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   // undefined = unknown (initial state, never fetched OR no pagination support)
   // string = ready to load that page
@@ -80,20 +85,14 @@ export function ColumnCard({ column }: { column: Column }) {
   async function onRefresh() {
     if (!type) return;
     setIsFetching(true);
-    const started = Date.now();
     try {
-      let items;
-      let cursor: string | undefined;
-      if (type.fetchPage) {
-        const r = await type.fetchPage(column.config as never);
-        items = r.items;
-        cursor = r.nextCursor;
-      } else {
-        items = await type.fetch(column.config as never);
-      }
+      const { items, nextCursor: cursor } = await callColumnApi(
+        type.id,
+        column.config,
+      );
       const count = await applyFetchedItems(column.id, items);
       // Reset pagination cursor on a fresh refresh.
-      setNextCursor(type.fetchPage ? (cursor ?? null) : undefined);
+      setNextCursor(type.paginated ? (cursor ?? null) : undefined);
       toast.success(count > 0 ? `${count} new item${count === 1 ? "" : "s"}` : "No new items", {
         description: column.title,
       });
@@ -102,22 +101,16 @@ export function ColumnCard({ column }: { column: Column }) {
         description: err instanceof Error ? err.message : "Unknown error",
       });
     } finally {
-      // Keep the beam visible for a minimum duration so the animation registers.
-      const elapsed = Date.now() - started;
-      const remaining = Math.max(0, 1800 - elapsed);
-      if (remaining > 0) {
-        await new Promise((r) => setTimeout(r, remaining));
-      }
       setIsFetching(false);
     }
   }
 
   async function onLoadMore() {
-    if (!type?.fetchPage) return;
+    if (!type?.paginated) return;
     if (typeof nextCursor !== "string") return;
     setIsLoadingMore(true);
     try {
-      const r = await type.fetchPage(column.config as never, nextCursor);
+      const r = await callColumnApi(type.id, column.config, nextCursor);
       await applyFetchedItems(column.id, r.items);
       setNextCursor(r.nextCursor ?? null);
     } catch (err) {
@@ -255,7 +248,7 @@ export function ColumnCard({ column }: { column: Column }) {
               {column.items.map((item) => (
                 <ItemRenderer key={item.id} item={item} />
               ))}
-              {type.fetchPage && typeof nextCursor === "string" && (
+              {type.paginated && typeof nextCursor === "string" && (
                 <button
                   type="button"
                   onClick={onLoadMore}
@@ -272,7 +265,7 @@ export function ColumnCard({ column }: { column: Column }) {
                   )}
                 </button>
               )}
-              {type.fetchPage && nextCursor === null && (
+              {type.paginated && nextCursor === null && (
                 <div className="px-3.5 py-3 text-center text-[11.5px] text-muted-foreground/70">
                   End of results
                 </div>

--- a/components/deck/deck-tabs.tsx
+++ b/components/deck/deck-tabs.tsx
@@ -78,7 +78,7 @@ export function DeckTabs() {
                     name={deck.name}
                     columnCount={deck.columnIds.length}
                     active={id === activeDeckId}
-                    onClick={() => setActiveDeck(id)}
+                    onSelect={() => setActiveDeck(id)}
                   />
                 );
               })}

--- a/components/onboarding/welcome.tsx
+++ b/components/onboarding/welcome.tsx
@@ -9,7 +9,7 @@ import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { listColumnTypes, getColumnType } from "@/lib/columns/registry";
 import { useDeckStore } from "@/lib/store/use-deck-store";
-import type { ColumnType } from "@/lib/columns/types";
+import type { AnyColumnType } from "@/lib/columns/types";
 
 interface Suggestion {
   typeId: string;
@@ -72,7 +72,7 @@ export function Onboarding() {
   const [picked, setPicked] = useState<Set<number>>(() => new Set([0, 1]));
 
   const types = useMemo(() => {
-    const m = new Map<string, ColumnType>();
+    const m = new Map<string, AnyColumnType>();
     for (const t of listColumnTypes()) m.set(t.id, t);
     return m;
   }, []);
@@ -97,8 +97,8 @@ export function Onboarding() {
       if (!s) continue;
       const type = getColumnType(s.typeId);
       if (!type) continue;
-      const colId = addColumn(id, s.typeId, s.title, s.config);
-      void autoFetchColumn(colId, type);
+      const { id: colId, ready } = addColumn(id, s.typeId, s.title, s.config);
+      void autoFetchColumn(colId, type, ready);
     }
   }
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,16 @@
 import type { Config } from "drizzle-kit";
 
+const url = (process.env.DATABASE_URL ?? "").trim();
+
+// drizzle-kit's `generate` doesn't need credentials; `studio` does. Pass a
+// dummy URL when DATABASE_URL is missing so `generate` works in the local
+// PGlite default — `studio` will surface the missing var if you run it.
 export default {
   schema: "./lib/db/schema.ts",
   out: "./drizzle",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url: url || "postgres://placeholder@localhost/placeholder",
   },
   strict: true,
 } satisfies Config;

--- a/hooks/use-min-duration.ts
+++ b/hooks/use-min-duration.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Holds a `true` value visible for at least `ms` milliseconds, even if the
+ * source flips to `false` sooner. Lets fast fetches still register the
+ * fetching/beam animation.
+ */
+export function useMinDuration(value: boolean, ms: number): boolean {
+  const [held, setHeld] = useState(value);
+  // React's blessed pattern for deriving state from props: compare to the
+  // previous value during render. When `value` flips true, immediately set
+  // `held = true`; the false transition is deferred to the timer below.
+  const [prev, setPrev] = useState(value);
+  const startedAtRef = useRef<number | null>(null);
+
+  if (prev !== value) {
+    setPrev(value);
+    if (value && !held) setHeld(true);
+  }
+
+  useEffect(() => {
+    if (value) {
+      startedAtRef.current = Date.now();
+      return;
+    }
+    if (startedAtRef.current === null) return;
+    const elapsed = Date.now() - startedAtRef.current;
+    const remaining = Math.max(0, ms - elapsed);
+    const id = setTimeout(() => {
+      startedAtRef.current = null;
+      setHeld(false);
+    }, remaining);
+    return () => clearTimeout(id);
+  }, [value, ms]);
+
+  return held;
+}

--- a/lib/columns/api-client.ts
+++ b/lib/columns/api-client.ts
@@ -1,0 +1,21 @@
+import type { PageResult } from "@/lib/columns/types";
+
+export async function callColumnApi(
+  typeId: string,
+  config: Record<string, unknown>,
+  cursor?: string,
+): Promise<PageResult> {
+  const res = await fetch(`/api/columns/${typeId}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      config,
+      ...(cursor !== undefined ? { op: "loadMore", cursor } : {}),
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+    throw new Error(err.error ?? `HTTP ${res.status}`);
+  }
+  return (await res.json()) as PageResult;
+}

--- a/lib/columns/constants.ts
+++ b/lib/columns/constants.ts
@@ -1,0 +1,5 @@
+export const MAX_ITEMS_PER_COLUMN = 200;
+
+export const PAGE_SIZE = 12;
+
+export const BEAM_MIN_DURATION_MS = 1800;

--- a/lib/columns/farcaster.tsx
+++ b/lib/columns/farcaster.tsx
@@ -167,20 +167,6 @@ function ItemRenderer({ item }: { item: FeedItem }) {
   );
 }
 
-async function fetchItems(config: FCConfig): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/farcaster", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 export const farcasterType: ColumnType<FCConfig> = {
   id: "farcaster",
   label: "Farcaster",
@@ -198,5 +184,4 @@ export const farcasterType: ColumnType<FCConfig> = {
   },
   ConfigForm,
   ItemRenderer,
-  fetch: fetchItems,
 };

--- a/lib/columns/github.tsx
+++ b/lib/columns/github.tsx
@@ -290,30 +290,6 @@ function MetaRow({
   return null;
 }
 
-async function fetchPage(
-  config: GHConfig,
-  cursor?: string,
-): Promise<{ items: FeedItem[]; nextCursor?: string }> {
-  const res = await fetch("/api/columns/github", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      config,
-      ...(cursor !== undefined ? { op: "loadMore", cursor } : {}),
-    }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  return (await res.json()) as { items: FeedItem[]; nextCursor?: string };
-}
-
-async function fetchItems(config: GHConfig): Promise<FeedItem[]> {
-  const { items } = await fetchPage(config);
-  return items;
-}
-
 function defaultTitle(c: GHConfig): string {
   if (c.mode === "releases") {
     return c.repo.trim() ? `Releases · ${c.repo.trim()}` : "GitHub · Releases";
@@ -335,6 +311,5 @@ export const githubType: ColumnType<GHConfig> = {
   defaultTitle,
   ConfigForm,
   ItemRenderer,
-  fetch: fetchItems,
-  fetchPage,
+  paginated: true,
 };

--- a/lib/columns/google-news.tsx
+++ b/lib/columns/google-news.tsx
@@ -70,20 +70,6 @@ function Renderer({ item }: { item: FeedItem }) {
   );
 }
 
-async function fetchItems(config: Config): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/google-news", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 export const googleNewsType: ColumnType<Config> = {
   id: "google-news",
   label: "Google News",
@@ -95,5 +81,4 @@ export const googleNewsType: ColumnType<Config> = {
     c.query.trim() ? `Google · ${c.query.trim()}` : "Google News",
   ConfigForm,
   ItemRenderer: Renderer,
-  fetch: fetchItems,
 };

--- a/lib/columns/grok-ask.tsx
+++ b/lib/columns/grok-ask.tsx
@@ -103,20 +103,6 @@ function ItemRenderer({ item }: { item: FeedItem }) {
   );
 }
 
-async function fetchItems(config: Config): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/grok-ask", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 export const grokAskType: ColumnType<Config> = {
   id: "grok-ask",
   label: "Grok · Ask",
@@ -130,5 +116,4 @@ export const grokAskType: ColumnType<Config> = {
       : "Grok · Ask",
   ConfigForm,
   ItemRenderer,
-  fetch: fetchItems,
 };

--- a/lib/columns/hacker-news.tsx
+++ b/lib/columns/hacker-news.tsx
@@ -155,30 +155,6 @@ function ItemRenderer({ item }: { item: FeedItem }) {
   );
 }
 
-async function fetchPage(
-  config: HNConfig,
-  cursor?: string,
-): Promise<{ items: FeedItem[]; nextCursor?: string }> {
-  const res = await fetch("/api/columns/hacker-news", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      config,
-      ...(cursor !== undefined ? { op: "loadMore", cursor } : {}),
-    }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  return (await res.json()) as { items: FeedItem[]; nextCursor?: string };
-}
-
-async function fetchItems(config: HNConfig): Promise<FeedItem[]> {
-  const { items } = await fetchPage(config);
-  return items;
-}
-
 export const hackerNewsType: ColumnType<HNConfig> = {
   id: "hacker-news",
   label: "Hacker News",
@@ -192,6 +168,5 @@ export const hackerNewsType: ColumnType<HNConfig> = {
       : `HN · ${MODE_LABELS[c.mode]}`,
   ConfigForm,
   ItemRenderer,
-  fetch: fetchItems,
-  fetchPage,
+  paginated: true,
 };

--- a/lib/columns/mentions.tsx
+++ b/lib/columns/mentions.tsx
@@ -146,20 +146,6 @@ function ItemRenderer({ item }: { item: FeedItem }) {
   );
 }
 
-async function fetchItems(config: Config): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/mentions", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 export const mentionsType: ColumnType<Config> = {
   id: "mentions",
   label: "Mentions monitor",
@@ -171,5 +157,4 @@ export const mentionsType: ColumnType<Config> = {
     c.query.trim() ? `Mentions · ${c.query.trim()}` : "Mentions monitor",
   ConfigForm,
   ItemRenderer,
-  fetch: fetchItems,
 };

--- a/lib/columns/news-search.tsx
+++ b/lib/columns/news-search.tsx
@@ -32,20 +32,6 @@ function ConfigForm({
   );
 }
 
-async function fetchItems(config: Config): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/news-search", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 function Renderer({ item }: { item: FeedItem }) {
   return (
     <LinkItem
@@ -66,5 +52,4 @@ export const newsSearchType: ColumnType<Config> = {
   defaultTitle: (c) => (c.query?.trim() ? `News · ${c.query}` : "News · Topic"),
   ConfigForm,
   ItemRenderer: Renderer,
-  fetch: fetchItems,
 };

--- a/lib/columns/newsnow.tsx
+++ b/lib/columns/newsnow.tsx
@@ -141,20 +141,6 @@ function ItemRenderer({ item }: { item: FeedItem }) {
   );
 }
 
-async function fetchItems(config: Config): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/newsnow", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 export const newsnowType: ColumnType<Config> = {
   id: "newsnow",
   label: "China · Hot",
@@ -165,5 +151,4 @@ export const newsnowType: ColumnType<Config> = {
   defaultTitle: (c) => `Hot · ${PLATFORM_LABELS[c.platform] ?? "China"}`,
   ConfigForm,
   ItemRenderer: ItemRenderer,
-  fetch: fetchItems,
 };

--- a/lib/columns/reddit.tsx
+++ b/lib/columns/reddit.tsx
@@ -119,30 +119,6 @@ function ItemRenderer({ item }: { item: FeedItem }) {
   );
 }
 
-async function fetchPage(
-  config: RedditConfig,
-  cursor?: string,
-): Promise<{ items: FeedItem[]; nextCursor?: string }> {
-  const res = await fetch("/api/columns/reddit", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      config,
-      ...(cursor !== undefined ? { op: "loadMore", cursor } : {}),
-    }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  return (await res.json()) as { items: FeedItem[]; nextCursor?: string };
-}
-
-async function fetchItems(config: RedditConfig): Promise<FeedItem[]> {
-  const { items } = await fetchPage(config);
-  return items;
-}
-
 export const redditType: ColumnType<RedditConfig> = {
   id: "reddit",
   label: "Reddit · Subreddit",
@@ -153,6 +129,5 @@ export const redditType: ColumnType<RedditConfig> = {
   defaultTitle: (c) => (c.subreddit?.trim() ? `r/${c.subreddit}` : "Reddit · Subreddit"),
   ConfigForm,
   ItemRenderer,
-  fetch: fetchItems,
-  fetchPage,
+  paginated: true,
 };

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -1,4 +1,4 @@
-import type { ColumnType } from "@/lib/columns/types";
+import { defineColumnType, type AnyColumnType } from "@/lib/columns/types";
 import { xSearchType } from "@/lib/columns/x-search";
 import { xUserType } from "@/lib/columns/x-user";
 import { xMentionsType } from "@/lib/columns/x-mentions";
@@ -17,32 +17,32 @@ import { newsnowType } from "@/lib/columns/newsnow";
 import { grokAskType } from "@/lib/columns/grok-ask";
 
 // Register a new column type by importing it and appending here.
-// Nothing else in the app needs to change.
-const ALL_TYPES: ColumnType[] = [
-  grokAskType as unknown as ColumnType,
-  xSearchType as unknown as ColumnType,
-  xUserType as unknown as ColumnType,
-  xMentionsType as unknown as ColumnType,
-  xTrendingType as unknown as ColumnType,
-  webSearchType as unknown as ColumnType,
-  newsSearchType as unknown as ColumnType,
-  redditType as unknown as ColumnType,
-  hackerNewsType as unknown as ColumnType,
-  githubType as unknown as ColumnType,
-  rssType as unknown as ColumnType,
-  googleNewsType as unknown as ColumnType,
-  mentionsType as unknown as ColumnType,
-  farcasterType as unknown as ColumnType,
-  youtubeType as unknown as ColumnType,
-  newsnowType as unknown as ColumnType,
+// Also add the matching server fetcher in lib/columns/server-registry.ts.
+const ALL_TYPES: AnyColumnType[] = [
+  defineColumnType(grokAskType),
+  defineColumnType(xSearchType),
+  defineColumnType(xUserType),
+  defineColumnType(xMentionsType),
+  defineColumnType(xTrendingType),
+  defineColumnType(webSearchType),
+  defineColumnType(newsSearchType),
+  defineColumnType(redditType),
+  defineColumnType(hackerNewsType),
+  defineColumnType(githubType),
+  defineColumnType(rssType),
+  defineColumnType(googleNewsType),
+  defineColumnType(mentionsType),
+  defineColumnType(farcasterType),
+  defineColumnType(youtubeType),
+  defineColumnType(newsnowType),
 ];
 
 const byId = new Map(ALL_TYPES.map((t) => [t.id, t]));
 
-export function listColumnTypes(): ColumnType[] {
+export function listColumnTypes(): AnyColumnType[] {
   return ALL_TYPES;
 }
 
-export function getColumnType(id: string): ColumnType | undefined {
+export function getColumnType(id: string): AnyColumnType | undefined {
   return byId.get(id);
 }

--- a/lib/columns/rss.tsx
+++ b/lib/columns/rss.tsx
@@ -43,20 +43,6 @@ function Renderer({ item }: { item: FeedItem }) {
   );
 }
 
-async function fetchItems(config: Config): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/rss", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 function defaultTitle(c: Config): string {
   const url = c.url.trim();
   if (!url) return "RSS";
@@ -78,5 +64,4 @@ export const rssType: ColumnType<Config> = {
   defaultTitle,
   ConfigForm,
   ItemRenderer: Renderer,
-  fetch: fetchItems,
 };

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -1,0 +1,159 @@
+import "server-only";
+
+import type { FeedItem, PageResult } from "@/lib/columns/types";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { fetchSubredditPage } from "@/lib/integrations/reddit";
+import { fetchHackerNewsPage, type HNMode } from "@/lib/integrations/hackernews";
+import { fetchGitHub, type GHMode } from "@/lib/integrations/github";
+import { fetchFeed, googleNewsUrl } from "@/lib/integrations/rss";
+import { fetchMentions } from "@/lib/integrations/mentions";
+import {
+  fetchFarcasterUser,
+  fetchFarcasterSearch,
+} from "@/lib/integrations/farcaster";
+import {
+  fetchYouTube,
+  fetchSearchPage as fetchYouTubeSearchPage,
+  type YTMode,
+} from "@/lib/integrations/youtube";
+import {
+  fetchNewsNow,
+  type NewsNowPlatform,
+} from "@/lib/integrations/newsnow";
+import {
+  grokAsk,
+  grokNewsSearch,
+  grokWebSearch,
+  grokXMentions,
+  grokXSearch,
+  grokXTrending,
+  grokXUser,
+} from "@/lib/integrations/xai";
+
+export type ServerFetcher = (
+  config: Record<string, unknown>,
+  cursor?: string,
+) => Promise<PageResult>;
+
+function s(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function oneShot(items: FeedItem[]): PageResult {
+  return { items };
+}
+
+const FETCHERS: Record<string, ServerFetcher> = {
+  // ---- xAI / Grok ---------------------------------------------------------
+  "grok-ask": async (c) => oneShot(await grokAsk(s(c.prompt))),
+  "x-search": async (c) => oneShot(await grokXSearch(s(c.query))),
+  "x-user": async (c) => oneShot(await grokXUser(s(c.handle))),
+  "x-mentions": async (c) => oneShot(await grokXMentions(s(c.handle))),
+  "x-trending": async (c) => oneShot(await grokXTrending(s(c.topic))),
+  "web-search": async (c) => oneShot(await grokWebSearch(s(c.query))),
+  "news-search": async (c) => oneShot(await grokNewsSearch(s(c.query))),
+
+  // ---- RSS-backed ---------------------------------------------------------
+  rss: async (c) => oneShot(await fetchFeed(s(c.url))),
+  "google-news": async (c) =>
+    oneShot(
+      await fetchFeed(googleNewsUrl(s(c.query), s(c.hl, "en-US"), s(c.gl, "US"))),
+    ),
+
+  // ---- Multi-source -------------------------------------------------------
+  mentions: async (c) => {
+    const sources = (c.sources ?? {}) as Record<string, unknown>;
+    return oneShot(
+      await fetchMentions({
+        query: s(c.query),
+        sources: {
+          hn: sources.hn !== false,
+          reddit: sources.reddit !== false,
+          "google-news": sources["google-news"] !== false,
+          "bing-news": sources["bing-news"] === true,
+        },
+      }),
+    );
+  },
+
+  // ---- Farcaster ----------------------------------------------------------
+  farcaster: async (c) => {
+    const mode = s(c.mode, "user");
+    if (mode === "search") {
+      return oneShot(await fetchFarcasterSearch(s(c.query)));
+    }
+    return oneShot(await fetchFarcasterUser(s(c.username)));
+  },
+
+  // ---- NewsNow ------------------------------------------------------------
+  newsnow: async (c) =>
+    oneShot(await fetchNewsNow(s(c.platform, "weibo") as NewsNowPlatform)),
+
+  // ---- Paginated ----------------------------------------------------------
+  "hacker-news": async (c, cursor) => {
+    const page = cursor ? Number(cursor) || 0 : 0;
+    const r = await fetchHackerNewsPage(
+      s(c.mode, "top") as HNMode,
+      s(c.query),
+      PAGE_SIZE,
+      page,
+    );
+    return {
+      items: r.items,
+      nextCursor: r.hasMore ? String(page + 1) : undefined,
+    };
+  },
+
+  reddit: async (c, cursor) => {
+    const r = await fetchSubredditPage(
+      s(c.subreddit, "popular"),
+      s(c.sortBy, "hot"),
+      PAGE_SIZE,
+      cursor,
+    );
+    return { items: r.items, nextCursor: r.nextAfter };
+  },
+
+  github: async (c, cursor) => {
+    const page = cursor ? Number(cursor) || 1 : 1;
+    const items = await fetchGitHub(
+      s(c.mode, "trending") as GHMode,
+      {
+        language: s(c.language),
+        period: s(c.period, "week"),
+        repo: s(c.repo),
+        query: s(c.query),
+      },
+      PAGE_SIZE,
+      page,
+    );
+    return {
+      items,
+      nextCursor: items.length === PAGE_SIZE ? String(page + 1) : undefined,
+    };
+  },
+
+  youtube: async (c, cursor) => {
+    const mode = s(c.mode, "search") as YTMode;
+    if (mode === "search") {
+      const r = await fetchYouTubeSearchPage(
+        s(c.query),
+        s(c.order, "date") as "date" | "relevance" | "viewCount" | "rating",
+        PAGE_SIZE,
+        cursor,
+      );
+      return { items: r.items, nextCursor: r.nextPageToken };
+    }
+    const items = await fetchYouTube(mode, {
+      query: s(c.query),
+      order: s(c.order, "date"),
+      channel: s(c.channel),
+      playlist: s(c.playlist),
+    });
+    return { items };
+  },
+};
+
+export function getServerFetcher(typeId: string): ServerFetcher | undefined {
+  return FETCHERS[typeId];
+}

--- a/lib/columns/types.ts
+++ b/lib/columns/types.ts
@@ -41,18 +41,27 @@ export interface ColumnType<TConfig extends Record<string, unknown> = Record<str
   defaultTitle: (config: TConfig) => string;
   ConfigForm: ComponentType<ConfigFormProps<TConfig>>;
   ItemRenderer: ComponentType<ItemRendererProps>;
-  fetch: (config: TConfig) => Promise<FeedItem[]>;
   /**
-   * Optional pagination. When defined, the column-card will:
-   *  1. Call `fetchPage(config)` for the initial fetch and stash `nextCursor`.
-   *  2. Show a "Load more" button while `nextCursor !== undefined`.
-   *  3. On click, call `fetchPage(config, cursor)` with the latest cursor,
-   *     append items, replace the cursor.
-   *
-   * Integrations that don't paginate naturally (RSS, X-via-Grok, etc.) leave
-   * this undefined — those columns get no Load More button.
+   * If true, the API may return a `nextCursor` and the column card renders
+   * Load more. The same value reaching `null` from the server means
+   * "exhausted". One-shot integrations (Grok, RSS, etc.) leave this false.
    */
-  fetchPage?: (config: TConfig, cursor?: string) => Promise<PageResult>;
+  paginated?: boolean;
+}
+
+/** Config-erased view of a registered column type — what the registry stores. */
+export type AnyColumnType = ColumnType<Record<string, unknown>>;
+
+/**
+ * Registers a typed `ColumnType<T>` as an `AnyColumnType` without sprinkling
+ * `as unknown as` casts at every call site. The cast is unsafe in principle
+ * (TConfig is invariant) but safe in practice because every consumer treats
+ * the config as opaque JSON.
+ */
+export function defineColumnType<TConfig extends Record<string, unknown>>(
+  t: ColumnType<TConfig>,
+): AnyColumnType {
+  return t as unknown as AnyColumnType;
 }
 
 export interface Column {

--- a/lib/columns/web-search.tsx
+++ b/lib/columns/web-search.tsx
@@ -32,20 +32,6 @@ function ConfigForm({
   );
 }
 
-async function fetchItems(config: Config): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/web-search", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 function Renderer({ item }: { item: FeedItem }) {
   return (
     <LinkItem
@@ -66,5 +52,4 @@ export const webSearchType: ColumnType<Config> = {
   defaultTitle: (c) => (c.query?.trim() ? `Web · ${c.query}` : "Web · Search"),
   ConfigForm,
   ItemRenderer: Renderer,
-  fetch: fetchItems,
 };

--- a/lib/columns/x-mentions.tsx
+++ b/lib/columns/x-mentions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AtSign } from "lucide-react";
-import type { ColumnType, FeedItem } from "@/lib/columns/types";
+import type { ColumnType } from "@/lib/columns/types";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { TweetItem } from "@/lib/columns/shared/tweet-renderer";
@@ -34,20 +34,6 @@ function ConfigForm({
   );
 }
 
-async function fetchItems(config: Config): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/x-mentions", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 export const xMentionsType: ColumnType<Config> = {
   id: "x-mentions",
   label: "X · Mentions",
@@ -59,5 +45,4 @@ export const xMentionsType: ColumnType<Config> = {
     c.handle?.trim() ? `@${c.handle.replace(/^@/, "")} mentions` : "X · Mentions",
   ConfigForm,
   ItemRenderer: TweetItem,
-  fetch: fetchItems,
 };

--- a/lib/columns/x-search.tsx
+++ b/lib/columns/x-search.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Search } from "lucide-react";
-import type { ColumnType, FeedItem } from "@/lib/columns/types";
+import type { ColumnType } from "@/lib/columns/types";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { TweetItem } from "@/lib/columns/shared/tweet-renderer";
@@ -33,20 +33,6 @@ function ConfigForm({
   );
 }
 
-async function fetchItems(config: Config): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/x-search", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 export const xSearchType: ColumnType<Config> = {
   id: "x-search",
   label: "X · Search",
@@ -57,5 +43,4 @@ export const xSearchType: ColumnType<Config> = {
   defaultTitle: (c) => (c.query?.trim() ? `X · ${c.query}` : "X · Search"),
   ConfigForm,
   ItemRenderer: TweetItem,
-  fetch: fetchItems,
 };

--- a/lib/columns/x-trending.tsx
+++ b/lib/columns/x-trending.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { TrendingUp } from "lucide-react";
-import type { ColumnType, FeedItem } from "@/lib/columns/types";
+import type { ColumnType } from "@/lib/columns/types";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { TweetItem } from "@/lib/columns/shared/tweet-renderer";
@@ -33,20 +33,6 @@ function ConfigForm({
   );
 }
 
-async function fetchItems(config: Config): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/x-trending", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 export const xTrendingType: ColumnType<Config> = {
   id: "x-trending",
   label: "X · Trending",
@@ -58,5 +44,4 @@ export const xTrendingType: ColumnType<Config> = {
     c.topic?.trim() ? `Trending · ${c.topic}` : "X · Trending",
   ConfigForm,
   ItemRenderer: TweetItem,
-  fetch: fetchItems,
 };

--- a/lib/columns/x-user.tsx
+++ b/lib/columns/x-user.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { UserRound } from "lucide-react";
-import type { ColumnType, FeedItem } from "@/lib/columns/types";
+import type { ColumnType } from "@/lib/columns/types";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { TweetItem } from "@/lib/columns/shared/tweet-renderer";
@@ -34,20 +34,6 @@ function ConfigForm({
   );
 }
 
-async function fetchItems(config: Config): Promise<FeedItem[]> {
-  const res = await fetch("/api/columns/x-user", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ config }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  const json = (await res.json()) as { items: FeedItem[] };
-  return json.items;
-}
-
 export const xUserType: ColumnType<Config> = {
   id: "x-user",
   label: "X · User timeline",
@@ -58,5 +44,4 @@ export const xUserType: ColumnType<Config> = {
   defaultTitle: (c) => (c.handle?.trim() ? `@${c.handle.replace(/^@/, "")}` : "X · User"),
   ConfigForm,
   ItemRenderer: TweetItem,
-  fetch: fetchItems,
 };

--- a/lib/columns/youtube.tsx
+++ b/lib/columns/youtube.tsx
@@ -224,30 +224,6 @@ function ItemRenderer({ item }: { item: FeedItem }) {
   );
 }
 
-async function fetchPage(
-  config: YTConfig,
-  cursor?: string,
-): Promise<{ items: FeedItem[]; nextCursor?: string }> {
-  const res = await fetch("/api/columns/youtube", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      config,
-      ...(cursor !== undefined ? { op: "loadMore", cursor } : {}),
-    }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    throw new Error(err.error ?? `HTTP ${res.status}`);
-  }
-  return (await res.json()) as { items: FeedItem[]; nextCursor?: string };
-}
-
-async function fetchItems(config: YTConfig): Promise<FeedItem[]> {
-  const { items } = await fetchPage(config);
-  return items;
-}
-
 function defaultTitle(c: YTConfig): string {
   if (c.mode === "channel") {
     const ch = c.channel.trim().replace(/^@/, "");
@@ -271,8 +247,7 @@ export const youtubeType: ColumnType<YTConfig> = {
   defaultTitle,
   ConfigForm,
   ItemRenderer,
-  fetch: fetchItems,
-  // Only Search mode actually paginates server-side; Channel/Playlist modes
-  // get the column-card to ignore nextCursor since the route returns none.
-  fetchPage,
+  // Only Search mode actually paginates server-side; the API returns no
+  // nextCursor for Channel/Playlist modes, so the card hides Load more there.
+  paginated: true,
 };

--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -1,13 +1,82 @@
+import "server-only";
+import { join } from "node:path";
 import { neon } from "@neondatabase/serverless";
-import { drizzle } from "drizzle-orm/neon-http";
+import { drizzle as drizzleNeonHttp } from "drizzle-orm/neon-http";
+import { drizzle as drizzleNodePg } from "drizzle-orm/node-postgres";
+import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+import { Pool } from "pg";
+import { PGlite } from "@electric-sql/pglite";
 import * as schema from "@/lib/db/schema";
 
-const url = process.env.DATABASE_URL;
-if (!url) {
-  throw new Error(
-    "DATABASE_URL is not set. Add it to .env.local (Neon connection string).",
-  );
+// `db` is the Drizzle client used by every server action / API route. The
+// concrete driver is picked at module load based on DATABASE_URL:
+//
+//   - missing / "pglite" / "file:" / "memory:"  → PGlite (local file, default)
+//   - host matches *.neon.tech                  → Neon HTTP driver
+//   - any other postgres:// URL                  → node-postgres pool
+//
+// All three return a Drizzle DB whose call surface (.select / .insert /
+// .execute / .update / .delete) is identical, so call sites stay driver-agnostic.
+
+export const LOCAL_PGLITE_DIR = join(process.cwd(), ".minitor", "pgdata");
+
+export type DatabaseKind = "pglite" | "neon" | "postgres";
+
+export interface DatabaseConfig {
+  kind: DatabaseKind;
+  /** Path to the PGlite data directory (only set when kind === "pglite"). */
+  pglitePath?: string;
+  /** Connection string (only set when kind !== "pglite"). */
+  url?: string;
 }
 
-const sql = neon(url);
-export const db = drizzle(sql, { schema });
+export function resolveDatabaseConfig(
+  rawUrl: string | undefined = process.env.DATABASE_URL,
+): DatabaseConfig {
+  const url = (rawUrl ?? "").trim();
+
+  if (
+    !url ||
+    url.startsWith("pglite:") ||
+    url.startsWith("file:") ||
+    url.startsWith("memory:")
+  ) {
+    return { kind: "pglite", pglitePath: LOCAL_PGLITE_DIR };
+  }
+
+  let host = "";
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    // fall through to postgres branch — let the driver surface a real error
+  }
+  if (host.endsWith("neon.tech") || host.endsWith("neon.build")) {
+    return { kind: "neon", url };
+  }
+  return { kind: "postgres", url };
+}
+
+const config = resolveDatabaseConfig();
+
+// We declare `db` as the NodePg shape because it's the most permissive of the
+// three concrete types (the call surface we use is identical across drivers).
+type Db = ReturnType<typeof drizzleNodePg<typeof schema>>;
+
+function buildDb(): Db {
+  switch (config.kind) {
+    case "pglite": {
+      const client = new PGlite(config.pglitePath);
+      return drizzlePglite(client, { schema }) as unknown as Db;
+    }
+    case "neon": {
+      const sql = neon(config.url!);
+      return drizzleNeonHttp(sql, { schema }) as unknown as Db;
+    }
+    case "postgres": {
+      const pool = new Pool({ connectionString: config.url });
+      return drizzleNodePg(pool, { schema });
+    }
+  }
+}
+
+export const db: Db = buildDb();

--- a/lib/integrations/youtube.ts
+++ b/lib/integrations/youtube.ts
@@ -122,8 +122,8 @@ export async function fetchSearchPage(
     if (v.id) detail.set(v.id, v);
   }
 
-  const mapped = items
-    .map((it) => {
+  const mapped: FeedItem[] = items
+    .map((it): FeedItem | null => {
       const videoId = it.id?.videoId;
       const sn = it.snippet;
       if (!videoId || !sn) return null;
@@ -157,7 +157,7 @@ export async function fetchSearchPage(
             ? Number(d.statistics.likeCount)
             : undefined,
         },
-      } satisfies FeedItem;
+      };
     })
     .filter((i): i is FeedItem => i !== null);
   return { items: mapped, nextPageToken: sJson.nextPageToken };

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -3,7 +3,9 @@
 import { create } from "zustand";
 import { nanoid } from "nanoid";
 import { toast } from "sonner";
-import type { Column, ColumnType, Deck, FeedItem } from "@/lib/columns/types";
+import type { AnyColumnType, Column, Deck, FeedItem } from "@/lib/columns/types";
+import { MAX_ITEMS_PER_COLUMN } from "@/lib/columns/constants";
+import { callColumnApi } from "@/lib/columns/api-client";
 import {
   createColumn as serverCreateColumn,
   createDeck as serverCreateDeck,
@@ -17,8 +19,6 @@ import {
   updateColumnConfig as serverUpdateConfig,
   type Snapshot,
 } from "@/app/actions";
-
-const MAX_ITEMS_PER_COLUMN = 200;
 
 interface DeckState {
   hydrated: boolean;
@@ -41,14 +41,18 @@ interface DeckState {
     typeId: string,
     title: string,
     config: Record<string, unknown>,
-  ) => string;
+  ) => { id: string; ready: Promise<void> };
   updateColumnConfig: (columnId: string, config: Record<string, unknown>) => void;
   renameColumn: (columnId: string, title: string) => void;
   removeColumn: (columnId: string) => void;
   reorderColumnsInDeck: (deckId: string, order: string[]) => void;
 
   applyFetchedItems: (columnId: string, items: FeedItem[]) => Promise<number>;
-  autoFetchColumn: (columnId: string, type: ColumnType) => Promise<void>;
+  autoFetchColumn: (
+    columnId: string,
+    type: AnyColumnType,
+    ready?: Promise<void>,
+  ) => Promise<void>;
 }
 
 function fireAndLog<T>(label: string, p: Promise<T>) {
@@ -56,11 +60,6 @@ function fireAndLog<T>(label: string, p: Promise<T>) {
     console.error(`[minitor] server action "${label}" failed:`, err);
   });
 }
-
-// Tracks the in-flight server-side create for each new column id so that
-// auto-fetch (which inserts feed_items referencing column.id via FK) can
-// wait for the column row to actually exist on the server before firing.
-const pendingCreates = new Map<string, Promise<unknown>>();
 
 export const useDeckStore = create<DeckState>()((set, get) => ({
   hydrated: false,
@@ -141,10 +140,9 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
         },
       };
     });
-    const createPromise = serverCreateColumn(id, deckId, typeId, title, config);
-    pendingCreates.set(id, createPromise);
-    fireAndLog("createColumn", createPromise);
-    return id;
+    const ready = serverCreateColumn(id, deckId, typeId, title, config);
+    fireAndLog("createColumn", ready);
+    return { id, ready: ready.then(() => undefined) };
   },
 
   updateColumnConfig: (columnId, config) => {
@@ -193,7 +191,7 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
     fireAndLog("reorderColumnsInDeck", serverReorderColumns(deckId, order));
   },
 
-  autoFetchColumn: async (columnId, type) => {
+  autoFetchColumn: async (columnId, type, ready) => {
     const col = get().columns[columnId];
     if (!col) return;
     set((s) => {
@@ -201,17 +199,12 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
       next.add(columnId);
       return { autoFetchingIds: next };
     });
-    const started = Date.now();
     try {
       // Wait for the server-side INSERT into columns to land before persisting
       // feed_items, otherwise the FK insert in persistFetchedItems races and
       // throws "violates foreign key constraint".
-      const create = pendingCreates.get(columnId);
-      if (create) {
-        await create.catch(() => undefined);
-        pendingCreates.delete(columnId);
-      }
-      const items = await type.fetch(col.config as never);
+      if (ready) await ready.catch(() => undefined);
+      const { items } = await callColumnApi(type.id, col.config);
       const count = await get().applyFetchedItems(columnId, items);
       toast.success(
         count > 0 ? `${count} new item${count === 1 ? "" : "s"}` : "No new items",
@@ -222,9 +215,6 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
         description: err instanceof Error ? err.message : "Unknown error",
       });
     } finally {
-      // Match the manual-refresh minimum so the beam animation registers.
-      const remaining = Math.max(0, 1800 - (Date.now() - started));
-      if (remaining > 0) await new Promise((r) => setTimeout(r, remaining));
       set((s) => {
         const next = new Set(s.autoFetchingIds);
         next.delete(columnId);

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // PGlite ships a WASM binary that the server bundler must leave external.
+  // pg uses native bindings the same way.
+  serverExternalPackages: ["@electric-sql/pglite", "pg", "pg-native"],
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@electric-sql/pglite": "^0.4.5",
         "@neondatabase/serverless": "^1.1.0",
         "@tabler/icons-react": "^3.41.1",
         "border-beam": "^1.0.1",
@@ -25,6 +26,7 @@
         "nanoid": "^5.1.9",
         "next": "16.2.4",
         "next-themes": "^0.4.6",
+        "pg": "^8.20.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "shadcn": "^4.4.0",
@@ -36,6 +38,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/pg": "^8.20.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "dotenv-cli": "^11.0.0",
@@ -804,6 +807,12 @@
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
       }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.5.tgz",
+      "integrity": "sha512-aGG2zGEyZzGWKy8P+9ZoNUV0jxt1+hgbeTf+bVAYyxVZZLXg3/9aFlfLxb08AYZVAfAkQlQIysmWjhc5hwDG8g==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -3812,6 +3821,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -9446,6 +9467,95 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9540,6 +9650,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/powershell-utils": {
@@ -10496,6 +10645,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {
@@ -12087,6 +12245,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "db:generate": "dotenv -e .env.local -- drizzle-kit generate",
-    "db:migrate": "node --env-file=.env.local scripts/db-migrate.mjs",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "node --env-file-if-exists=.env.local scripts/db-migrate.mjs",
     "db:studio": "dotenv -e .env.local -- drizzle-kit studio"
   },
   "dependencies": {
@@ -17,6 +17,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@electric-sql/pglite": "^0.4.5",
     "@neondatabase/serverless": "^1.1.0",
     "@tabler/icons-react": "^3.41.1",
     "border-beam": "^1.0.1",
@@ -29,6 +30,7 @@
     "nanoid": "^5.1.9",
     "next": "16.2.4",
     "next-themes": "^0.4.6",
+    "pg": "^8.20.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.4.0",
@@ -40,6 +42,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/pg": "^8.20.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "dotenv-cli": "^11.0.0",

--- a/scripts/db-migrate.mjs
+++ b/scripts/db-migrate.mjs
@@ -1,49 +1,94 @@
-import { readFile, readdir } from "node:fs/promises";
+import { readFile, readdir, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { neon } from "@neondatabase/serverless";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const url = process.env.DATABASE_URL;
-if (!url) {
-  console.error("DATABASE_URL is not set.");
-  process.exit(1);
+const rawUrl = (process.env.DATABASE_URL ?? "").trim();
+const ROOT = join(__dirname, "..");
+const MIGRATION_DIR = join(ROOT, "drizzle");
+const LOCAL_PGLITE_DIR = join(ROOT, ".minitor", "pgdata");
+
+function resolveKind(url) {
+  if (
+    !url ||
+    url.startsWith("pglite:") ||
+    url.startsWith("file:") ||
+    url.startsWith("memory:")
+  ) {
+    return "pglite";
+  }
+  try {
+    const host = new URL(url).hostname;
+    if (host.endsWith("neon.tech") || host.endsWith("neon.build")) return "neon";
+  } catch {}
+  return "postgres";
 }
 
-const sql = neon(url);
+const kind = resolveKind(rawUrl);
 
-const dir = join(__dirname, "..", "drizzle");
-const files = (await readdir(dir)).filter((f) => f.endsWith(".sql")).sort();
+const files = (await readdir(MIGRATION_DIR))
+  .filter((f) => f.endsWith(".sql"))
+  .sort();
 
 if (files.length === 0) {
   console.log("No migration files found in ./drizzle");
   process.exit(0);
 }
 
-for (const file of files) {
-  const full = join(dir, file);
-  const contents = await readFile(full, "utf8");
-  console.log(`\n--- Applying ${file} ---`);
-  const statements = contents
-    .split("--> statement-breakpoint")
-    .map((s) => s.trim())
-    .filter(Boolean);
-  for (const stmt of statements) {
-    process.stdout.write(`  • ${stmt.split("\n")[0].slice(0, 80)}... `);
-    try {
-      await sql.query(stmt);
-      console.log("ok");
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("already exists")) {
-        console.log("already exists");
-      } else {
-        console.log("FAILED");
-        console.error(msg);
-        process.exit(1);
+let runStatement;
+let cleanup = async () => {};
+
+if (kind === "pglite") {
+  const { PGlite } = await import("@electric-sql/pglite");
+  await mkdir(LOCAL_PGLITE_DIR, { recursive: true });
+  const client = new PGlite(LOCAL_PGLITE_DIR);
+  runStatement = (stmt) => client.exec(stmt);
+  cleanup = () => client.close();
+  console.log(`Using PGlite at ${LOCAL_PGLITE_DIR}`);
+} else if (kind === "neon") {
+  const { neon } = await import("@neondatabase/serverless");
+  const sql = neon(rawUrl);
+  runStatement = (stmt) => sql.query(stmt);
+  console.log(`Using Neon HTTP driver`);
+} else {
+  const { Client } = await import("pg");
+  const client = new Client({ connectionString: rawUrl });
+  await client.connect();
+  runStatement = (stmt) => client.query(stmt);
+  cleanup = () => client.end();
+  console.log(`Using node-postgres`);
+}
+
+try {
+  for (const file of files) {
+    const full = join(MIGRATION_DIR, file);
+    const contents = await readFile(full, "utf8");
+    console.log(`\n--- Applying ${file} ---`);
+    const statements = contents
+      .split("--> statement-breakpoint")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    for (const stmt of statements) {
+      process.stdout.write(`  • ${stmt.split("\n")[0].slice(0, 80)}... `);
+      try {
+        await runStatement(stmt);
+        console.log("ok");
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("already exists")) {
+          console.log("already exists");
+        } else {
+          console.log("FAILED");
+          console.error(msg);
+          process.exitCode = 1;
+          break;
+        }
       }
     }
+    if (process.exitCode) break;
   }
+  if (!process.exitCode) console.log("\nDone.");
+} finally {
+  await cleanup();
 }
-console.log("\nDone.");


### PR DESCRIPTION
## Summary

Two independent improvements landing together. Each is its own commit:

### 1. Plugin-style column types (`57059c9`)
Adding a new source went from "edit 4 files including a 200-line bespoke switch" to "1 fetcher + 1 ColumnType + 2 one-line registrations." Concretely:

- Generic `/api/columns/[type]` route — dispatches via `lib/columns/server-registry.ts` keyed by typeId.
- `callColumnApi()` helper replaces 16 copies of the same POST boilerplate.
- `defineColumnType<T>()` helper kills the `as unknown as ColumnType` cast soup at the registry boundary.
- `loadSnapshot()` uses a window function — Postgres returns ≤ 200 rows per column instead of dumping the whole feed_items table.
- `reorderDecks` / `reorderColumnsInDeck` collapsed from N round-trips to one `UPDATE … FROM (VALUES …)`.
- Dropped the module-level `pendingCreates` Map; `addColumn` returns `{ id, ready }`.
- New `useMinDuration` hook moves beam timing from the data layer to the UI.
- Centralized constants (`MAX_ITEMS_PER_COLUMN`, `PAGE_SIZE`, `BEAM_MIN_DURATION_MS`).
- Fixed two pre-existing strict-TS errors blocking `next build`.

Net: -213 lines despite adding 4 new files.

### 2. Local-first PGlite default (`d6cd8a4`)
`npm install && npm run db:migrate && npm run dev` now works with no env file, no Docker, no hosted DB account. Drizzle picks its driver at runtime from `DATABASE_URL`:

| URL form | Driver |
|---|---|
| *unset* / `pglite:` / `file:` / `memory:` | PGlite at `.minitor/pgdata/` |
| `postgres://…` | node-postgres |
| `*.neon.tech` | `@neondatabase/serverless` HTTP |

Existing Neon deployments keep working — same `DATABASE_URL`, same driver. README updated.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] PGlite path: empty `.env.local` → onboarding → create deck → fetch Reddit → persist → reload survives
- [x] Neon path: existing `DATABASE_URL` → loads existing 5 columns / 94 items normally, refresh hits new generic dispatcher and persists
- [ ] node-postgres path with a local PG (wired but not bench-tested in this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)