### PR TITLE
Add Instagram column type

### DIFF
--- a/lib/columns/plugins/instagram/client.tsx
+++ b/lib/columns/plugins/instagram/client.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LinkItem } from "@/lib/columns/shared/link-renderer";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type InstagramConfig, type InstagramMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<InstagramConfig>) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="ig-q">Keyword or URL</Label>
+      <Input
+        id="ig-q"
+        placeholder='claude code  ·  https://example.com'
+        value={value.query}
+        onChange={(e) => onChange({ query: e.target.value })}
+      />
+      <p className="text-xs text-muted-foreground">
+        Surfaces public Instagram posts (via web search) that mention your
+        keyword, hashtag, or URL.
+      </p>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<InstagramMeta>) {
+  return (
+    <LinkItem
+      item={item}
+      badgeLabel="Instagram"
+      badgeClass="bg-[#e1306c]/20 text-foreground ring-1 ring-black/5"
+    />
+  );
+}
+
+export const column = defineColumnUI<InstagramConfig, InstagramMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/instagram/plugin.ts
+++ b/lib/columns/plugins/instagram/plugin.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+// `Instagram` brand icon was dropped from lucide-react v1.x; `Aperture` is
+// the camera-lens substitute used by other dashboards.
+import { Aperture } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+});
+
+export type InstagramConfig = z.infer<typeof schema>;
+
+export interface InstagramMeta {
+  source: string;
+  kind: "web" | "news";
+}
+
+export const meta: PluginMeta<InstagramConfig, InstagramMeta> = {
+  id: "instagram",
+  label: "Instagram",
+  description: "Public Instagram posts mentioning a keyword or URL.",
+  icon: Aperture,
+  accent: "#e1306c",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `Instagram · ${c.query.trim()}` : "Instagram",
+  capabilities: {
+    requiresEnv: ["XAI_API_KEY"],
+    rateLimitHint:
+      "Indexed via web search — only public posts already crawled by search engines are returned.",
+  },
+};

--- a/lib/columns/plugins/instagram/server.ts
+++ b/lib/columns/plugins/instagram/server.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+// Backend choice: Grok web_search with site:instagram.com — IG's Graph API
+// has no public hashtag/keyword search, so web search is the easiest path.
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchInstagram } from "@/lib/integrations/instagram";
+import { meta, type InstagramConfig, type InstagramMeta } from "./plugin";
+
+const fetch: ServerFetcher<InstagramConfig, InstagramMeta> = async (config) => {
+  const items = (await fetchInstagram(config.query)) as FeedItem<InstagramMeta>[];
+  return { items };
+};
+
+export const server = defineColumnServer<InstagramConfig, InstagramMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -18,6 +18,7 @@ import { meta as rss } from "./rss/plugin";
 import { meta as googleNews } from "./google-news/plugin";
 import { meta as mentions } from "./mentions/plugin";
 import { meta as farcaster } from "./farcaster/plugin";
+import { meta as instagram } from "./instagram/plugin";
 import { meta as youtube } from "./youtube/plugin";
 import { meta as newsnow } from "./newsnow/plugin";
 
@@ -36,6 +37,7 @@ export const PLUGIN_METAS = [
   googleNews,
   mentions,
   farcaster,
+  instagram,
   youtube,
   newsnow,
 ];

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -26,6 +26,7 @@ import { column as rss } from "@/lib/columns/plugins/rss/client";
 import { column as googleNews } from "@/lib/columns/plugins/google-news/client";
 import { column as mentions } from "@/lib/columns/plugins/mentions/client";
 import { column as farcaster } from "@/lib/columns/plugins/farcaster/client";
+import { column as instagram } from "@/lib/columns/plugins/instagram/client";
 import { column as youtube } from "@/lib/columns/plugins/youtube/client";
 import { column as newsnow } from "@/lib/columns/plugins/newsnow/client";
 
@@ -47,6 +48,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "google-news": googleNews,
   mentions,
   farcaster,
+  instagram,
   youtube,
   newsnow,
 };

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -22,6 +22,7 @@ import { server as rss } from "@/lib/columns/plugins/rss/server";
 import { server as googleNews } from "@/lib/columns/plugins/google-news/server";
 import { server as mentions } from "@/lib/columns/plugins/mentions/server";
 import { server as farcaster } from "@/lib/columns/plugins/farcaster/server";
+import { server as instagram } from "@/lib/columns/plugins/instagram/server";
 import { server as youtube } from "@/lib/columns/plugins/youtube/server";
 import { server as newsnow } from "@/lib/columns/plugins/newsnow/server";
 
@@ -40,6 +41,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "google-news": googleNews,
   mentions,
   farcaster,
+  instagram,
   youtube,
   newsnow,
 };

--- a/lib/integrations/instagram.ts
+++ b/lib/integrations/instagram.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import type { FeedItem } from "@/lib/columns/types";
+import { grokWebSearch } from "./xai";
+
+// Instagram has no public hashtag/keyword search — Graph API requires per-user
+// OAuth + Business/Creator accounts (locked down 2018). This module wraps
+// grokWebSearch with a site:instagram.com filter as the default fetcher.
+//
+// To swap in a paid scraper later (Apify / Bright Data / Phantombuster /
+// RapidAPI), replace the body of `fetchInstagram` and update the plugin's
+// `capabilities.requiresEnv`. The signature is the seam — callers don't care
+// which backend produced the items.
+export async function fetchInstagram(query: string): Promise<FeedItem[]> {
+  const q = query.trim();
+  if (!q) return [];
+  const isUrl = /^https?:\/\//i.test(q);
+  const filter = isUrl
+    ? `site:instagram.com ${JSON.stringify(q)}`
+    : `site:instagram.com ${q}`;
+  return grokWebSearch(filter);
+}


### PR DESCRIPTION
## Summary
- New `instagram` column surfaces public Instagram posts mentioning a keyword or URL.
- Backend: Grok `web_search` with a `site:instagram.com` filter — Instagram's Graph API has no public hashtag/keyword search (Business/Creator OAuth only, locked down 2018), and Grok reuses the existing `XAI_API_KEY` we already require for `web-search`.
- The fetcher lives in `lib/integrations/instagram.ts` as a single seam, so a paid scraper (Apify / Bright Data / Phantombuster / RapidAPI) can be swapped in later without touching the plugin contract.

## Notes
- Lucide-react v1.x dropped the `Instagram` brand icon (trademark cleanup); using `Aperture` as the camera-lens substitute, consistent with how `farcaster` uses `Hash` and `github` uses `GitGraph`.
- `capabilities.requiresEnv: ["XAI_API_KEY"]` plus a `rateLimitHint` noting that only search-engine-indexed posts are returned.
- Renderer reuses `lib/columns/shared/link-renderer.tsx` with a pink (`#e1306c`) badge.

## Test plan
- [x] `npm run build` passes — registry parity check, TypeScript, static page generation all green.
- [ ] Manual: add an Instagram column from the picker, configure with both a keyword (e.g. `claude code`) and a URL (e.g. `https://example.com`), verify items render via `LinkItem`.
- [ ] Manual: confirm the missing-`XAI_API_KEY` warning appears when the env var isn't set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)