### PR TITLE
Add Rednote (Xiaohongshu) column type

### DIFF
--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -20,6 +20,7 @@ import { meta as mentions } from "./mentions/plugin";
 import { meta as farcaster } from "./farcaster/plugin";
 import { meta as youtube } from "./youtube/plugin";
 import { meta as newsnow } from "./newsnow/plugin";
+import { meta as rednote } from "./rednote/plugin";
 
 export const PLUGIN_METAS = [
   grokAsk,
@@ -38,6 +39,7 @@ export const PLUGIN_METAS = [
   farcaster,
   youtube,
   newsnow,
+  rednote,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/plugins/rednote/client.tsx
+++ b/lib/columns/plugins/rednote/client.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LinkItem } from "@/lib/columns/shared/link-renderer";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type RednoteConfig, type RednoteMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<RednoteConfig>) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="rednote-q">Keyword or URL</Label>
+      <Input
+        id="rednote-q"
+        placeholder="brand name, hashtag, or xiaohongshu.com URL"
+        value={value.query}
+        onChange={(e) => onChange({ query: e.target.value })}
+      />
+      <p className="text-xs text-muted-foreground">
+        Searches Xiaohongshu (小红书) via Grok web search. Coverage is
+        best-effort — xhs blocks anonymous scraping, so only pages indexed by
+        public crawlers and shared xhslink.com URLs surface.
+      </p>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<RednoteMeta>) {
+  return (
+    <LinkItem
+      item={item}
+      badgeLabel="Rednote"
+      badgeClass="bg-[#ff2442]/15 text-foreground ring-1 ring-black/5"
+    />
+  );
+}
+
+export const column = defineColumnUI<RednoteConfig, RednoteMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/rednote/plugin.ts
+++ b/lib/columns/plugins/rednote/plugin.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { BookHeart } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+});
+
+export type RednoteConfig = z.infer<typeof schema>;
+
+export interface RednoteMeta {
+  source: string;
+  kind: "rednote";
+}
+
+export const meta: PluginMeta<RednoteConfig, RednoteMeta> = {
+  id: "rednote",
+  label: "Rednote · Mentions",
+  description: "Latest Xiaohongshu (小红书) posts mentioning a keyword or URL.",
+  icon: BookHeart,
+  accent: "#ff2442",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `Rednote · ${c.query.trim()}` : "Rednote · Mentions",
+  capabilities: {
+    requiresEnv: ["XAI_API_KEY"],
+    rateLimitHint:
+      "Xiaohongshu has no public API. Results come from Grok web search scoped to xhs domains; coverage depends on what crawlers can index.",
+  },
+};

--- a/lib/columns/plugins/rednote/server.ts
+++ b/lib/columns/plugins/rednote/server.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+// Path: site:xiaohongshu.com web search via Grok (no public xhs API). Swap to
+// a paid scraper later by editing lib/integrations/rednote.ts only.
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchRednoteMentions } from "@/lib/integrations/rednote";
+import { meta, type RednoteConfig, type RednoteMeta } from "./plugin";
+
+const fetch: ServerFetcher<RednoteConfig, RednoteMeta> = async (config) => {
+  const items = (await fetchRednoteMentions(
+    config.query,
+  )) as FeedItem<RednoteMeta>[];
+  return { items };
+};
+
+export const server = defineColumnServer<RednoteConfig, RednoteMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -28,6 +28,7 @@ import { column as mentions } from "@/lib/columns/plugins/mentions/client";
 import { column as farcaster } from "@/lib/columns/plugins/farcaster/client";
 import { column as youtube } from "@/lib/columns/plugins/youtube/client";
 import { column as newsnow } from "@/lib/columns/plugins/newsnow/client";
+import { column as rednote } from "@/lib/columns/plugins/rednote/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -49,6 +50,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   farcaster,
   youtube,
   newsnow,
+  rednote,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -24,6 +24,7 @@ import { server as mentions } from "@/lib/columns/plugins/mentions/server";
 import { server as farcaster } from "@/lib/columns/plugins/farcaster/server";
 import { server as youtube } from "@/lib/columns/plugins/youtube/server";
 import { server as newsnow } from "@/lib/columns/plugins/newsnow/server";
+import { server as rednote } from "@/lib/columns/plugins/rednote/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "grok-ask": grokAsk,
@@ -42,6 +43,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   farcaster,
   youtube,
   newsnow,
+  rednote,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/rednote.ts
+++ b/lib/integrations/rednote.ts
@@ -1,0 +1,28 @@
+import type { FeedItem } from "@/lib/columns/types";
+import { grokWebSearch } from "@/lib/integrations/xai";
+
+// Rednote (Xiaohongshu / 小红书 / xhs) has no public API and aggressively
+// blocks anonymous scraping. The official open API is invitation-only for
+// brand partners. Best-effort path: scope a Grok web search to xhs domains.
+// Coverage is limited to pages indexed by public crawlers + shared
+// xhslink.com short URLs. To upgrade to a paid scraper (Bright Data, Apify,
+// RapidAPI), add a `process.env`-gated branch above the grok fallback —
+// callers don't change.
+const REDNOTE_DOMAINS =
+  "site:xiaohongshu.com OR site:xhs.cn OR site:xhslink.com";
+
+export async function fetchRednoteMentions(
+  query: string,
+  limit = 10,
+): Promise<FeedItem[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  const scoped = `${trimmed} (${REDNOTE_DOMAINS})`;
+  const items = await grokWebSearch(scoped, limit);
+
+  return items.map((item) => ({
+    ...item,
+    meta: { source: item.author.name, kind: "rednote" as const },
+  }));
+}


### PR DESCRIPTION
## Summary
- New `rednote` column plugin: surfaces Xiaohongshu (小红书 / xhs) posts mentioning a keyword or URL.
- Implementation routes through Grok `web_search` scoped to `site:xiaohongshu.com OR site:xhs.cn OR site:xhslink.com` (xhs has no public API + aggressive anti-scraping, and newsnow's aggregator does not cover xhs — verified).
- HTTP client in `lib/integrations/rednote.ts` so a paid scraper (Bright Data / Apify / RapidAPI) can later be env-gated in one place without changing the plugin.

## Files
- `lib/columns/plugins/rednote/{plugin,client,server}.ts(x)` — `BookHeart` icon, `#ff2442` accent, `social` category, `requiresEnv: ["XAI_API_KEY"]`, reuses the shared `LinkItem` renderer.
- `lib/integrations/rednote.ts` — wraps `grokWebSearch` with the xhs site scope.
- `lib/columns/plugins/manifest.ts`, `lib/columns/registry.ts`, `lib/columns/server-registry.ts` — one import + one entry each.

## Test plan
- [x] `npm run build` — registry parity check passes, TypeScript clean.
- [ ] In dev: add a "Rednote" column with a real-world keyword (e.g. a brand or hashtag) and confirm items render via the shared `LinkItem`.
- [ ] Confirm the AddColumnDialog warns about missing `XAI_API_KEY` when it isn't set.
- [ ] Try a `xiaohongshu.com/explore/...` URL as the query and verify results are scoped to xhs domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)