### PR TITLE
Add hacker-news-search column for keyword/URL mention monitoring

### DIFF
--- a/lib/columns/plugins/hacker-news-search/client.tsx
+++ b/lib/columns/plugins/hacker-news-search/client.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { ArrowBigUp, MessageSquareText, MessageCircle } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type HNSearchConfig, type HNSearchMeta } from "./plugin";
+
+function compact(n: number): string {
+  if (Math.abs(n) < 1000) return String(n);
+  if (Math.abs(n) < 1_000_000)
+    return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+function ConfigForm({ value, onChange }: ConfigFormProps<HNSearchConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="hns-q">Keyword or URL</Label>
+        <Input
+          id="hns-q"
+          placeholder="anthropic.com, claude code, https://..."
+          value={value.query}
+          onChange={(e) => onChange({ ...value, query: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          URLs are matched against the story link; everything else searches
+          full text.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Scope</Label>
+        <Select
+          value={value.scope}
+          onValueChange={(v) =>
+            onChange({ ...value, scope: v as HNSearchConfig["scope"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Stories &amp; comments</SelectItem>
+            <SelectItem value="stories">Stories only</SelectItem>
+            <SelectItem value="comments">Comments only</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Sort</Label>
+        <Select
+          value={value.sort}
+          onValueChange={(v) =>
+            onChange({ ...value, sort: v as HNSearchConfig["sort"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="date">Newest first</SelectItem>
+            <SelectItem value="relevance">Most relevant</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<HNSearchMeta>) {
+  const m = item.meta;
+  const kind = m?.kind ?? "story";
+  const points = m?.points ?? 0;
+  const comments = m?.comments ?? 0;
+  const commentsUrl = m?.commentsUrl ?? item.url;
+
+  const isComment = kind === "comment";
+  const headline = isComment
+    ? (m?.storyTitle ?? "(comment)")
+    : item.content.split("\n\n")[0];
+  const body = isComment
+    ? item.content
+    : item.content.split("\n\n").slice(1).join("\n\n").trim();
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(255, 102, 0, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[9px] font-bold leading-none text-white"
+            style={{ backgroundColor: "#ff6600" }}
+          >
+            Y
+          </span>
+          {isComment ? "HN comment" : "HN story"}
+        </span>
+        <span className="text-muted-foreground/80">
+          by{" "}
+          <span className="text-foreground/90">
+            {item.author.handle ?? item.author.name}
+          </span>
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+        >
+          {isComment ? `Re: ${headline}` : headline}
+        </h3>
+      </a>
+      {body && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {body}
+        </p>
+      )}
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        {isComment ? (
+          <a
+            href={commentsUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-1 transition-colors hover:text-foreground"
+          >
+            <MessageCircle className="size-3.5" />
+            <span>View thread</span>
+          </a>
+        ) : (
+          <>
+            <span className="flex items-center gap-1">
+              <ArrowBigUp className="size-4" />
+              <span className="tabular-nums">{compact(points)}</span>
+            </span>
+            <a
+              href={commentsUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1 transition-colors hover:text-foreground"
+            >
+              <MessageSquareText className="size-3.5" />
+              <span className="tabular-nums">{compact(comments)}</span>
+            </a>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<HNSearchConfig, HNSearchMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/hacker-news-search/plugin.ts
+++ b/lib/columns/plugins/hacker-news-search/plugin.ts
@@ -1,0 +1,39 @@
+// Dedicated mention monitor for HN — separate from the existing hacker-news
+// plugin so URL detection, comment scope, and date sort don't bloat that
+// plugin's ConfigForm (which serves the front-page/Ask/Show/keyword UX).
+
+import { z } from "zod";
+import { Eye } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+  scope: z.enum(["all", "stories", "comments"]).default("all"),
+  sort: z.enum(["relevance", "date"]).default("date"),
+});
+
+export type HNSearchConfig = z.infer<typeof schema>;
+
+export interface HNSearchMeta {
+  points: number;
+  comments: number;
+  commentsUrl: string;
+  externalUrl?: string;
+  kind: "story" | "comment";
+  storyTitle?: string;
+}
+
+export const meta: PluginMeta<HNSearchConfig, HNSearchMeta> = {
+  id: "hacker-news-search",
+  label: "HN Mentions",
+  description:
+    "Watch Hacker News for keyword or URL mentions across stories and comments.",
+  icon: Eye,
+  accent: "#ff6600",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `HN watch · ${c.query.trim()}` : "HN watch",
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/hacker-news-search/server.ts
+++ b/lib/columns/plugins/hacker-news-search/server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { searchHackerNewsByUrlOrKeyword } from "@/lib/integrations/hackernews";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type HNSearchConfig, type HNSearchMeta } from "./plugin";
+
+const fetch: ServerFetcher<HNSearchConfig, HNSearchMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await searchHackerNewsByUrlOrKeyword(config.query, {
+    scope: config.scope,
+    sort: config.sort,
+    limit: PAGE_SIZE,
+    page,
+  });
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<HNSearchConfig, HNSearchMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -13,6 +13,7 @@ import { meta as webSearch } from "./web-search/plugin";
 import { meta as newsSearch } from "./news-search/plugin";
 import { meta as reddit } from "./reddit/plugin";
 import { meta as hackerNews } from "./hacker-news/plugin";
+import { meta as hackerNewsSearch } from "./hacker-news-search/plugin";
 import { meta as github } from "./github/plugin";
 import { meta as rss } from "./rss/plugin";
 import { meta as googleNews } from "./google-news/plugin";
@@ -31,6 +32,7 @@ export const PLUGIN_METAS = [
   newsSearch,
   reddit,
   hackerNews,
+  hackerNewsSearch,
   github,
   rss,
   googleNews,

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -21,6 +21,7 @@ import { column as webSearch } from "@/lib/columns/plugins/web-search/client";
 import { column as newsSearch } from "@/lib/columns/plugins/news-search/client";
 import { column as reddit } from "@/lib/columns/plugins/reddit/client";
 import { column as hackerNews } from "@/lib/columns/plugins/hacker-news/client";
+import { column as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/client";
 import { column as github } from "@/lib/columns/plugins/github/client";
 import { column as rss } from "@/lib/columns/plugins/rss/client";
 import { column as googleNews } from "@/lib/columns/plugins/google-news/client";
@@ -42,6 +43,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "news-search": newsSearch,
   reddit,
   "hacker-news": hackerNews,
+  "hacker-news-search": hackerNewsSearch,
   github,
   rss,
   "google-news": googleNews,

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -17,6 +17,7 @@ import { server as webSearch } from "@/lib/columns/plugins/web-search/server";
 import { server as newsSearch } from "@/lib/columns/plugins/news-search/server";
 import { server as reddit } from "@/lib/columns/plugins/reddit/server";
 import { server as hackerNews } from "@/lib/columns/plugins/hacker-news/server";
+import { server as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/server";
 import { server as github } from "@/lib/columns/plugins/github/server";
 import { server as rss } from "@/lib/columns/plugins/rss/server";
 import { server as googleNews } from "@/lib/columns/plugins/google-news/server";
@@ -35,6 +36,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "news-search": newsSearch,
   reddit,
   "hacker-news": hackerNews,
+  "hacker-news-search": hackerNewsSearch,
   github,
   rss,
   "google-news": googleNews,

--- a/lib/integrations/hackernews.ts
+++ b/lib/integrations/hackernews.ts
@@ -18,6 +18,8 @@ interface AlgoliaHit {
   created_at?: string;
   created_at_i?: number;
   story_text?: string;
+  comment_text?: string;
+  story_id?: number;
   _tags?: string[];
 }
 
@@ -126,4 +128,147 @@ export async function fetchHackerNews(
 ): Promise<FeedItem[]> {
   const { items } = await fetchHackerNewsPage(mode, query, limit, 0);
   return items;
+}
+
+// ---- Mentions search ------------------------------------------------------
+
+export type HNSearchScope = "all" | "stories" | "comments";
+export type HNSearchSort = "relevance" | "date";
+
+export interface HNSearchHitMeta {
+  points: number;
+  comments: number;
+  commentsUrl: string;
+  externalUrl?: string;
+  kind: "story" | "comment";
+  storyTitle?: string;
+}
+
+function looksLikeUrl(s: string): boolean {
+  const t = s.trim();
+  if (!t) return false;
+  if (/^https?:\/\//i.test(t)) return true;
+  if (/^www\./i.test(t)) return true;
+  // bare domain or domain+path: at least one dot, recognizable TLD-ish suffix.
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)+(\/[^\s]*)?$/i.test(t);
+}
+
+function normalizeUrlForSearch(s: string): string {
+  return s
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/\/+$/, "");
+}
+
+function decodeSnippet(s: string | undefined): string {
+  return (
+    s
+      ?.replace(/<[^>]+>/g, "")
+      .replace(/&#x27;/g, "'")
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, "&")
+      .trim() ?? ""
+  );
+}
+
+function isCommentHit(h: AlgoliaHit): boolean {
+  if (Array.isArray(h._tags) && h._tags.includes("comment")) return true;
+  return typeof h.comment_text === "string" && h.comment_text.length > 0;
+}
+
+function mapSearchHit(h: AlgoliaHit): FeedItem<HNSearchHitMeta> {
+  const comment = isCommentHit(h);
+  const storyTitle = h.story_title ?? h.title ?? "(untitled)";
+  const externalUrl = h.url ?? h.story_url;
+  const itemUrl = `https://news.ycombinator.com/item?id=${h.objectID}`;
+  const author = h.author ?? "anonymous";
+  const createdMs =
+    typeof h.created_at_i === "number"
+      ? h.created_at_i * 1000
+      : h.created_at
+        ? Date.parse(h.created_at)
+        : Date.now();
+
+  const snippet = decodeSnippet(comment ? h.comment_text : h.story_text);
+  const content = comment
+    ? snippet || `Comment on “${storyTitle}”`
+    : snippet
+      ? `${storyTitle}\n\n${snippet}`
+      : storyTitle;
+
+  return {
+    id: h.objectID,
+    author: {
+      name: author,
+      handle: author,
+      avatarUrl: `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(author)}`,
+    },
+    content,
+    url: comment ? itemUrl : (externalUrl ?? itemUrl),
+    createdAt: new Date(createdMs).toISOString(),
+    meta: {
+      points: h.points ?? 0,
+      comments: h.num_comments ?? 0,
+      commentsUrl: itemUrl,
+      externalUrl: externalUrl ?? undefined,
+      kind: comment ? "comment" : "story",
+      storyTitle: comment ? storyTitle : undefined,
+    },
+  };
+}
+
+export async function searchHackerNewsByUrlOrKeyword(
+  input: string,
+  opts: {
+    scope: HNSearchScope;
+    sort: HNSearchSort;
+    limit: number;
+    page: number;
+  },
+): Promise<{ items: FeedItem<HNSearchHitMeta>[]; hasMore: boolean }> {
+  const { scope, sort, limit, page } = opts;
+  const trimmed = input.trim();
+  if (!trimmed) return { items: [], hasMore: false };
+
+  const params = new URLSearchParams({
+    hitsPerPage: String(limit),
+    page: String(page),
+  });
+
+  const isUrl = looksLikeUrl(trimmed);
+  if (isUrl) {
+    params.set("query", normalizeUrlForSearch(trimmed));
+    // Algolia attribute scoping — only match against the indexed URL field
+    // so domain queries don't get diluted by title/comment matches.
+    params.set("restrictSearchableAttributes", "url");
+  } else {
+    params.set("query", trimmed);
+  }
+
+  switch (scope) {
+    case "stories":
+      params.set("tags", "story");
+      break;
+    case "comments":
+      params.set("tags", "comment");
+      break;
+    case "all":
+      params.set("tags", "(story,comment)");
+      break;
+  }
+
+  const path = sort === "date" ? "search_by_date" : "search";
+  const res = await fetch(`${ALGOLIA}/${path}?${params}`, {
+    headers: { accept: "application/json" },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`HN ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  const json = (await res.json()) as AlgoliaResponse;
+  const hits = json.hits ?? [];
+  const totalPages = typeof json.nbPages === "number" ? json.nbPages : 1;
+  const hasMore = page + 1 < totalPages && hits.length === limit;
+  return { items: hits.slice(0, limit).map(mapSearchHit), hasMore };
 }


### PR DESCRIPTION
## Summary
- New `hacker-news-search` plugin: dedicated mention monitor for HN with URL detection, comment-vs-story scope, and date-vs-relevance sort.
- Kept separate from the existing `hacker-news` plugin so its ConfigForm stays focused on front-page/Ask/Show/keyword browsing rather than ballooning with mention-watch conditionals.
- Wraps Algolia HN Search via a new `searchHackerNewsByUrlOrKeyword` helper in `lib/integrations/hackernews.ts` — URL inputs are normalized (scheme/`www.`/trailing slash stripped) and scoped via `restrictSearchableAttributes=url` so domain queries don't dilute against title/comment text.

## Test plan
- [ ] `npm run build` (parity check + TypeScript)
- [ ] Add an "HN Mentions" column with a keyword (e.g. `anthropic`) — verify stories + comments arrive, newest-first by default
- [ ] Add a column with a URL (e.g. `anthropic.com`) — verify hits link to that domain
- [ ] Toggle scope to "Comments only" and confirm the renderer shows "Re: <story title>" with a "View thread" link
- [ ] Toggle sort to "Most relevant" and confirm ordering changes
- [ ] Click "Load more" — confirm pagination advances

🤖 Generated with [Claude Code](https://claude.com/claude-code)