### PR TITLE
Add weibo-search column for keyword/URL mention monitoring

### DIFF
--- a/lib/columns/plugins/github-search/client.tsx
+++ b/lib/columns/plugins/github-search/client.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import {
+  CircleDot,
+  FileCode2,
+  GitBranch,
+  GitCommit,
+  GitMerge,
+  GitPullRequest,
+  MessageSquareText,
+  Star,
+} from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type GHSearchConfig, type GHSearchMeta } from "./plugin";
+
+function compact(n: number): string {
+  if (Math.abs(n) < 1000) return String(n);
+  if (Math.abs(n) < 1_000_000)
+    return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+function ConfigForm({ value, onChange }: ConfigFormProps<GHSearchConfig>) {
+  const isUrl = /^https?:\/\//i.test(value.query.trim());
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Scope</Label>
+        <Select
+          value={value.scope}
+          onValueChange={(v) =>
+            onChange({ ...value, scope: v as GHSearchConfig["scope"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="repositories">Repositories</SelectItem>
+            <SelectItem value="issues">Issues / PRs</SelectItem>
+            <SelectItem value="code">Code</SelectItem>
+            <SelectItem value="commits">Commits</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghs-q">Keyword or URL</Label>
+        <Input
+          id="ghs-q"
+          placeholder='"yourdomain.com", "your-product", or any GitHub query'
+          value={value.query}
+          onChange={(e) => onChange({ ...value, query: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          {isUrl
+            ? "URL will be auto-quoted for an exact match."
+            : "Quote phrases for exact match. Full GitHub search syntax (org:, repo:, language:, path:, is:open, ...) is supported."}
+        </p>
+      </div>
+
+      {value.scope === "code" && (
+        <p className="rounded-md border border-border bg-surface/40 px-3 py-2 text-[11.5px] text-muted-foreground">
+          Code search requires{" "}
+          <code className="rounded bg-foreground/[0.06] px-1 py-px text-foreground/90">
+            GITHUB_TOKEN
+          </code>{" "}
+          in your env. Other scopes work without one.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ScopeBadge({ m }: { m: GHSearchMeta }) {
+  if (m.scope === "issues") {
+    const state = m.state ?? "open";
+    const Icon =
+      m.isPr ? (state === "closed" ? GitMerge : GitPullRequest) : CircleDot;
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{
+          backgroundColor:
+            state === "closed"
+              ? "rgba(192, 168, 221, 0.32)"
+              : "rgba(223, 168, 143, 0.28)",
+        }}
+      >
+        <Icon className="size-3" />
+        {m.isPr ? "PR" : "issue"}
+      </span>
+    );
+  }
+  if (m.scope === "code") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(159, 187, 224, 0.32)" }}
+      >
+        <FileCode2 className="size-3" />
+        code
+      </span>
+    );
+  }
+  if (m.scope === "commits") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(159, 201, 162, 0.28)" }}
+      >
+        <GitCommit className="size-3" />
+        commit
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+      style={{ backgroundColor: "rgba(159, 187, 224, 0.32)" }}
+    >
+      <GitBranch className="size-3" />
+      repo
+    </span>
+  );
+}
+
+function MetaRow({ m }: { m: GHSearchMeta }) {
+  if (m.scope === "repositories") {
+    const stars = m.stars ?? 0;
+    const forks = m.forks ?? 0;
+    return (
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <Star className="size-3.5" />
+          <span className="tabular-nums">{compact(stars)}</span>
+        </span>
+        <span className="flex items-center gap-1">
+          <GitBranch className="size-3.5" />
+          <span className="tabular-nums">{compact(forks)}</span>
+        </span>
+        {m.language && (
+          <span className="truncate text-foreground/70">{m.language}</span>
+        )}
+      </div>
+    );
+  }
+  if (m.scope === "issues") {
+    const comments = m.comments ?? 0;
+    return (
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        {m.number !== undefined && (
+          <span className="tabular-nums text-foreground/70">#{m.number}</span>
+        )}
+        <span className="flex items-center gap-1">
+          <MessageSquareText className="size-3.5" />
+          <span className="tabular-nums">{compact(comments)}</span>
+        </span>
+        {m.repo && (
+          <span className="truncate text-foreground/70">{m.repo}</span>
+        )}
+      </div>
+    );
+  }
+  if (m.scope === "commits" && m.sha) {
+    return (
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="font-mono text-foreground/70">
+          {m.sha.slice(0, 7)}
+        </span>
+        {m.repo && (
+          <span className="truncate text-foreground/70">{m.repo}</span>
+        )}
+      </div>
+    );
+  }
+  return null;
+}
+
+function ItemRenderer({ item }: ItemRendererProps<GHSearchMeta>) {
+  const m = item.meta ?? ({ scope: "repositories" } as GHSearchMeta);
+  const [title, ...rest] = item.content.split("\n\n");
+  const snippet = rest.join("\n\n").trim();
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <ScopeBadge m={m} />
+        <span className="truncate text-foreground/80">
+          {item.author.handle ?? item.author.name}
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {title}
+      </h3>
+      {snippet && (
+        <p
+          className={`mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words ${
+            m.scope === "code" ? "font-mono whitespace-pre" : "whitespace-pre-line"
+          }`}
+        >
+          {snippet}
+        </p>
+      )}
+      <MetaRow m={m} />
+    </a>
+  );
+}
+
+export const column = defineColumnUI<GHSearchConfig, GHSearchMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-search/plugin.ts
+++ b/lib/columns/plugins/github-search/plugin.ts
@@ -1,0 +1,62 @@
+// Separate from the `github` plugin: that one is feed-style (trending /
+// releases / issue search). This one is mention-monitoring — free-form
+// keyword/URL search across repos, issues, code, and commits with one
+// switchable scope. Different config form, different renderer concerns.
+
+import { z } from "zod";
+import { SearchCode } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  scope: z
+    .enum(["repositories", "issues", "code", "commits"])
+    .default("issues"),
+  query: z.string().default(""),
+});
+
+export type GHSearchConfig = z.infer<typeof schema>;
+
+export interface GHSearchMeta {
+  scope: "repositories" | "issues" | "code" | "commits";
+  repo?: string;
+  stars?: number;
+  forks?: number;
+  language?: string;
+  number?: number;
+  state?: string;
+  comments?: number;
+  isPr?: boolean;
+  path?: string;
+  sha?: string;
+}
+
+const SCOPE_LABEL: Record<GHSearchConfig["scope"], string> = {
+  repositories: "Repos",
+  issues: "Issues / PRs",
+  code: "Code",
+  commits: "Commits",
+};
+
+export const meta: PluginMeta<GHSearchConfig, GHSearchMeta> = {
+  id: "github-search",
+  label: "GitHub search",
+  description:
+    "Watch GitHub for mentions of a keyword or URL across repos, issues, code, or commits.",
+  icon: SearchCode,
+  accent: "#1f2328",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const label = SCOPE_LABEL[c.scope];
+    const q = c.query.trim();
+    return q ? `GH ${label} · ${q}` : `GitHub · ${label}`;
+  },
+  capabilities: {
+    paginated: true,
+    // GITHUB_TOKEN is genuinely optional — fetcher upgrades automatically when
+    // it's set — so it's not in requiresEnv (which renders as "Requires:" in UI).
+    rateLimitHint:
+      "60 req/hr without GITHUB_TOKEN, 5000 with. Code search requires the token.",
+  },
+};

--- a/lib/columns/plugins/github-search/server.ts
+++ b/lib/columns/plugins/github-search/server.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { searchGitHub } from "@/lib/integrations/github";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type GHSearchConfig, type GHSearchMeta } from "./plugin";
+
+const fetch: ServerFetcher<GHSearchConfig, GHSearchMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 1 : 1;
+  const items = (await searchGitHub(
+    config.scope,
+    config.query,
+    PAGE_SIZE,
+    page,
+  )) as FeedItem<GHSearchMeta>[];
+  return {
+    items,
+    nextCursor: items.length === PAGE_SIZE ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<GHSearchConfig, GHSearchMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/hacker-news-search/client.tsx
+++ b/lib/columns/plugins/hacker-news-search/client.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { ArrowBigUp, MessageSquareText, MessageCircle } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type HNSearchConfig, type HNSearchMeta } from "./plugin";
+
+function compact(n: number): string {
+  if (Math.abs(n) < 1000) return String(n);
+  if (Math.abs(n) < 1_000_000)
+    return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+function ConfigForm({ value, onChange }: ConfigFormProps<HNSearchConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="hns-q">Keyword or URL</Label>
+        <Input
+          id="hns-q"
+          placeholder="anthropic.com, claude code, https://..."
+          value={value.query}
+          onChange={(e) => onChange({ ...value, query: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          URLs are matched against the story link; everything else searches
+          full text.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Scope</Label>
+        <Select
+          value={value.scope}
+          onValueChange={(v) =>
+            onChange({ ...value, scope: v as HNSearchConfig["scope"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Stories &amp; comments</SelectItem>
+            <SelectItem value="stories">Stories only</SelectItem>
+            <SelectItem value="comments">Comments only</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Sort</Label>
+        <Select
+          value={value.sort}
+          onValueChange={(v) =>
+            onChange({ ...value, sort: v as HNSearchConfig["sort"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="date">Newest first</SelectItem>
+            <SelectItem value="relevance">Most relevant</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<HNSearchMeta>) {
+  const m = item.meta;
+  const kind = m?.kind ?? "story";
+  const points = m?.points ?? 0;
+  const comments = m?.comments ?? 0;
+  const commentsUrl = m?.commentsUrl ?? item.url;
+
+  const isComment = kind === "comment";
+  const headline = isComment
+    ? (m?.storyTitle ?? "(comment)")
+    : item.content.split("\n\n")[0];
+  const body = isComment
+    ? item.content
+    : item.content.split("\n\n").slice(1).join("\n\n").trim();
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(255, 102, 0, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[9px] font-bold leading-none text-white"
+            style={{ backgroundColor: "#ff6600" }}
+          >
+            Y
+          </span>
+          {isComment ? "HN comment" : "HN story"}
+        </span>
+        <span className="text-muted-foreground/80">
+          by{" "}
+          <span className="text-foreground/90">
+            {item.author.handle ?? item.author.name}
+          </span>
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+        >
+          {isComment ? `Re: ${headline}` : headline}
+        </h3>
+      </a>
+      {body && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {body}
+        </p>
+      )}
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        {isComment ? (
+          <a
+            href={commentsUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-1 transition-colors hover:text-foreground"
+          >
+            <MessageCircle className="size-3.5" />
+            <span>View thread</span>
+          </a>
+        ) : (
+          <>
+            <span className="flex items-center gap-1">
+              <ArrowBigUp className="size-4" />
+              <span className="tabular-nums">{compact(points)}</span>
+            </span>
+            <a
+              href={commentsUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1 transition-colors hover:text-foreground"
+            >
+              <MessageSquareText className="size-3.5" />
+              <span className="tabular-nums">{compact(comments)}</span>
+            </a>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<HNSearchConfig, HNSearchMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/hacker-news-search/plugin.ts
+++ b/lib/columns/plugins/hacker-news-search/plugin.ts
@@ -1,0 +1,39 @@
+// Dedicated mention monitor for HN — separate from the existing hacker-news
+// plugin so URL detection, comment scope, and date sort don't bloat that
+// plugin's ConfigForm (which serves the front-page/Ask/Show/keyword UX).
+
+import { z } from "zod";
+import { Eye } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+  scope: z.enum(["all", "stories", "comments"]).default("all"),
+  sort: z.enum(["relevance", "date"]).default("date"),
+});
+
+export type HNSearchConfig = z.infer<typeof schema>;
+
+export interface HNSearchMeta {
+  points: number;
+  comments: number;
+  commentsUrl: string;
+  externalUrl?: string;
+  kind: "story" | "comment";
+  storyTitle?: string;
+}
+
+export const meta: PluginMeta<HNSearchConfig, HNSearchMeta> = {
+  id: "hacker-news-search",
+  label: "HN Mentions",
+  description:
+    "Watch Hacker News for keyword or URL mentions across stories and comments.",
+  icon: Eye,
+  accent: "#ff6600",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `HN watch · ${c.query.trim()}` : "HN watch",
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/hacker-news-search/server.ts
+++ b/lib/columns/plugins/hacker-news-search/server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { searchHackerNewsByUrlOrKeyword } from "@/lib/integrations/hackernews";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type HNSearchConfig, type HNSearchMeta } from "./plugin";
+
+const fetch: ServerFetcher<HNSearchConfig, HNSearchMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await searchHackerNewsByUrlOrKeyword(config.query, {
+    scope: config.scope,
+    sort: config.sort,
+    limit: PAGE_SIZE,
+    page,
+  });
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<HNSearchConfig, HNSearchMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -15,6 +15,7 @@ import { meta as reddit } from "./reddit/plugin";
 import { meta as hackerNews } from "./hacker-news/plugin";
 import { meta as hackerNewsSearch } from "./hacker-news-search/plugin";
 import { meta as github } from "./github/plugin";
+import { meta as githubSearch } from "./github-search/plugin";
 import { meta as rss } from "./rss/plugin";
 import { meta as googleNews } from "./google-news/plugin";
 import { meta as mentions } from "./mentions/plugin";
@@ -34,6 +35,7 @@ export const PLUGIN_METAS = [
   hackerNews,
   hackerNewsSearch,
   github,
+  githubSearch,
   rss,
   googleNews,
   mentions,

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -13,6 +13,7 @@ import { meta as webSearch } from "./web-search/plugin";
 import { meta as newsSearch } from "./news-search/plugin";
 import { meta as reddit } from "./reddit/plugin";
 import { meta as hackerNews } from "./hacker-news/plugin";
+import { meta as hackerNewsSearch } from "./hacker-news-search/plugin";
 import { meta as github } from "./github/plugin";
 import { meta as rss } from "./rss/plugin";
 import { meta as googleNews } from "./google-news/plugin";
@@ -31,6 +32,7 @@ export const PLUGIN_METAS = [
   newsSearch,
   reddit,
   hackerNews,
+  hackerNewsSearch,
   github,
   rss,
   googleNews,

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -22,6 +22,7 @@ import { meta as mentions } from "./mentions/plugin";
 import { meta as farcaster } from "./farcaster/plugin";
 import { meta as youtube } from "./youtube/plugin";
 import { meta as newsnow } from "./newsnow/plugin";
+import { meta as weiboSearch } from "./weibo-search/plugin";
 
 export const PLUGIN_METAS = [
   grokAsk,
@@ -42,6 +43,7 @@ export const PLUGIN_METAS = [
   farcaster,
   youtube,
   newsnow,
+  weiboSearch,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/plugins/weibo-search/client.tsx
+++ b/lib/columns/plugins/weibo-search/client.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { TweetItem } from "@/lib/columns/shared/tweet-renderer";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+} from "@/lib/columns/types";
+import { meta, type WeiboSearchConfig, type WeiboSearchMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<WeiboSearchConfig>) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="weibo-q">Keyword or URL</Label>
+      <Input
+        id="weibo-q"
+        placeholder="anthropic, claude, https://example.com..."
+        value={value.query}
+        onChange={(e) => onChange({ query: e.target.value })}
+      />
+      <p className="text-xs text-muted-foreground">
+        Searches Weibo posts (微博) mentioning your query. The mobile search
+        endpoint is keyless but may return empty results from non-CN egress
+        IPs.
+      </p>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<WeiboSearchConfig, WeiboSearchMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer: TweetItem,
+});

--- a/lib/columns/plugins/weibo-search/plugin.ts
+++ b/lib/columns/plugins/weibo-search/plugin.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { MessageSquare } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+import type { WeiboSearchMeta } from "@/lib/integrations/weibo";
+
+export const schema = z.object({
+  query: z.string().default(""),
+});
+
+export type WeiboSearchConfig = z.infer<typeof schema>;
+
+export type { WeiboSearchMeta };
+
+export const meta: PluginMeta<WeiboSearchConfig, WeiboSearchMeta> = {
+  id: "weibo-search",
+  label: "Weibo · Search",
+  description: "Watch Weibo (微博) for posts mentioning a keyword or URL.",
+  icon: MessageSquare,
+  accent: "#e6162d",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `微博 · ${c.query.trim()}` : "Weibo · Search",
+  capabilities: {
+    rateLimitHint:
+      "m.weibo.cn is fronted by CN-only infrastructure — requests from non-CN egress IPs may return empty results or rate-limit. Best run from a Chinese region.",
+  },
+};

--- a/lib/columns/plugins/weibo-search/server.ts
+++ b/lib/columns/plugins/weibo-search/server.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+// Keyless path: m.weibo.cn mobile JSON search. Chosen over s.weibo.com HTML
+// scrape (brittle DOM) and Grok web_search (requires XAI_API_KEY).
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { searchWeibo } from "@/lib/integrations/weibo";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type WeiboSearchConfig, type WeiboSearchMeta } from "./plugin";
+
+const fetch: ServerFetcher<WeiboSearchConfig, WeiboSearchMeta> = async (
+  config,
+) => {
+  const items = await searchWeibo(config.query, PAGE_SIZE);
+  return { items };
+};
+
+export const server = defineColumnServer<WeiboSearchConfig, WeiboSearchMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -23,6 +23,7 @@ import { column as reddit } from "@/lib/columns/plugins/reddit/client";
 import { column as hackerNews } from "@/lib/columns/plugins/hacker-news/client";
 import { column as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/client";
 import { column as github } from "@/lib/columns/plugins/github/client";
+import { column as githubSearch } from "@/lib/columns/plugins/github-search/client";
 import { column as rss } from "@/lib/columns/plugins/rss/client";
 import { column as googleNews } from "@/lib/columns/plugins/google-news/client";
 import { column as mentions } from "@/lib/columns/plugins/mentions/client";
@@ -45,6 +46,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "hacker-news": hackerNews,
   "hacker-news-search": hackerNewsSearch,
   github,
+  "github-search": githubSearch,
   rss,
   "google-news": googleNews,
   mentions,

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -30,6 +30,7 @@ import { column as mentions } from "@/lib/columns/plugins/mentions/client";
 import { column as farcaster } from "@/lib/columns/plugins/farcaster/client";
 import { column as youtube } from "@/lib/columns/plugins/youtube/client";
 import { column as newsnow } from "@/lib/columns/plugins/newsnow/client";
+import { column as weiboSearch } from "@/lib/columns/plugins/weibo-search/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -53,6 +54,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   farcaster,
   youtube,
   newsnow,
+  "weibo-search": weiboSearch,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -21,6 +21,7 @@ import { column as webSearch } from "@/lib/columns/plugins/web-search/client";
 import { column as newsSearch } from "@/lib/columns/plugins/news-search/client";
 import { column as reddit } from "@/lib/columns/plugins/reddit/client";
 import { column as hackerNews } from "@/lib/columns/plugins/hacker-news/client";
+import { column as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/client";
 import { column as github } from "@/lib/columns/plugins/github/client";
 import { column as rss } from "@/lib/columns/plugins/rss/client";
 import { column as googleNews } from "@/lib/columns/plugins/google-news/client";
@@ -42,6 +43,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "news-search": newsSearch,
   reddit,
   "hacker-news": hackerNews,
+  "hacker-news-search": hackerNewsSearch,
   github,
   rss,
   "google-news": googleNews,

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -19,6 +19,7 @@ import { server as reddit } from "@/lib/columns/plugins/reddit/server";
 import { server as hackerNews } from "@/lib/columns/plugins/hacker-news/server";
 import { server as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/server";
 import { server as github } from "@/lib/columns/plugins/github/server";
+import { server as githubSearch } from "@/lib/columns/plugins/github-search/server";
 import { server as rss } from "@/lib/columns/plugins/rss/server";
 import { server as googleNews } from "@/lib/columns/plugins/google-news/server";
 import { server as mentions } from "@/lib/columns/plugins/mentions/server";
@@ -38,6 +39,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "hacker-news": hackerNews,
   "hacker-news-search": hackerNewsSearch,
   github,
+  "github-search": githubSearch,
   rss,
   "google-news": googleNews,
   mentions,

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -26,6 +26,7 @@ import { server as mentions } from "@/lib/columns/plugins/mentions/server";
 import { server as farcaster } from "@/lib/columns/plugins/farcaster/server";
 import { server as youtube } from "@/lib/columns/plugins/youtube/server";
 import { server as newsnow } from "@/lib/columns/plugins/newsnow/server";
+import { server as weiboSearch } from "@/lib/columns/plugins/weibo-search/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "grok-ask": grokAsk,
@@ -46,6 +47,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   farcaster,
   youtube,
   newsnow,
+  "weibo-search": weiboSearch,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -17,6 +17,7 @@ import { server as webSearch } from "@/lib/columns/plugins/web-search/server";
 import { server as newsSearch } from "@/lib/columns/plugins/news-search/server";
 import { server as reddit } from "@/lib/columns/plugins/reddit/server";
 import { server as hackerNews } from "@/lib/columns/plugins/hacker-news/server";
+import { server as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/server";
 import { server as github } from "@/lib/columns/plugins/github/server";
 import { server as rss } from "@/lib/columns/plugins/rss/server";
 import { server as googleNews } from "@/lib/columns/plugins/google-news/server";
@@ -35,6 +36,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "news-search": newsSearch,
   reddit,
   "hacker-news": hackerNews,
+  "hacker-news-search": hackerNewsSearch,
   github,
   rss,
   "google-news": googleNews,

--- a/lib/integrations/github.ts
+++ b/lib/integrations/github.ts
@@ -4,6 +4,8 @@ const API = "https://api.github.com";
 
 export type GHMode = "trending" | "releases" | "issues";
 
+export type GHSearchScope = "repositories" | "issues" | "code" | "commits";
+
 interface GHRepo {
   id: number;
   full_name: string;
@@ -242,5 +244,264 @@ export async function fetchGitHub(
         : "week") as "day" | "week" | "month";
       return fetchTrending(config.language ?? "", period, limit, page);
     }
+  }
+}
+
+// ---- Free-form search across scopes (used by github-search plugin) ---------
+
+interface GHCodeResult {
+  sha: string;
+  name: string;
+  path: string;
+  html_url: string;
+  repository: {
+    full_name: string;
+    pushed_at?: string;
+    owner?: { login: string; avatar_url?: string };
+  };
+  text_matches?: Array<{ fragment?: string }>;
+}
+
+interface GHCommitResult {
+  sha: string;
+  html_url: string;
+  commit: {
+    message: string;
+    author?: { name?: string; email?: string; date?: string };
+  };
+  author?: { login: string; avatar_url?: string } | null;
+  repository: { full_name: string };
+}
+
+function buildQuery(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+  // GitHub indexes URLs in code/issues but tokenizes on punctuation, so a
+  // bare URL becomes many separate matches. Quote it for an exact match —
+  // unless the user already wrapped it themselves.
+  if (/^https?:\/\//i.test(trimmed) && !/^".*"$/.test(trimmed)) {
+    return `"${trimmed}"`;
+  }
+  return trimmed;
+}
+
+async function searchRepos(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  const params = new URLSearchParams({
+    q: query,
+    sort: "updated",
+    order: "desc",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const json = await ghFetch<GHSearchResponse<GHRepo>>(
+    `${API}/search/repositories?${params}`,
+  );
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((r) => {
+    const owner = r.owner?.login ?? r.full_name.split("/")[0] ?? "github";
+    return {
+      id: `ghs-repo-${r.id}`,
+      author: {
+        name: owner,
+        handle: owner,
+        avatarUrl:
+          r.owner?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(owner)}`,
+      },
+      content: r.description
+        ? `${r.full_name}\n\n${r.description}`
+        : r.full_name,
+      url: r.html_url,
+      createdAt: r.pushed_at ?? r.created_at,
+      meta: {
+        scope: "repositories" as const,
+        repo: r.full_name,
+        stars: r.stargazers_count,
+        forks: r.forks_count,
+        language: r.language ?? undefined,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+async function searchIssuesScope(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  const params = new URLSearchParams({
+    q: query,
+    sort: "updated",
+    order: "desc",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const json = await ghFetch<GHSearchResponse<GHIssue>>(
+    `${API}/search/issues?${params}`,
+  );
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((i) => {
+    const user = i.user?.login ?? "anonymous";
+    const isPr = !!i.pull_request;
+    const repo = i.repository_url.replace(`${API}/repos/`, "");
+    const body = (i.body ?? "").trim();
+    const trimmed =
+      body.length > 400 ? `${body.slice(0, 400).trimEnd()}…` : body;
+    return {
+      id: `ghs-iss-${i.id}`,
+      author: {
+        name: user,
+        handle: user,
+        avatarUrl:
+          i.user?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(user)}`,
+      },
+      content: trimmed ? `${i.title}\n\n${trimmed}` : i.title,
+      url: i.html_url,
+      createdAt: i.updated_at ?? i.created_at,
+      meta: {
+        scope: "issues" as const,
+        repo,
+        number: i.number,
+        state: i.state,
+        comments: i.comments,
+        isPr,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+async function searchCode(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error(
+      "GitHub code search requires a token. Set GITHUB_TOKEN in your env (read-only public scope is enough).",
+    );
+  }
+  const params = new URLSearchParams({
+    q: query,
+    per_page: String(limit),
+    page: String(page),
+  });
+  const res = await fetch(`${API}/search/code?${params}`, {
+    headers: {
+      ...(headers() as Record<string, string>),
+      // text-match returns a `fragment` snippet around each hit
+      accept: "application/vnd.github.text-match+json",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as GHSearchResponse<GHCodeResult>;
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((c) => {
+    const owner =
+      c.repository.owner?.login ??
+      c.repository.full_name.split("/")[0] ??
+      "github";
+    const fragment = (c.text_matches?.[0]?.fragment ?? "").trim();
+    const snippet =
+      fragment.length > 400
+        ? `${fragment.slice(0, 400).trimEnd()}…`
+        : fragment;
+    const title = `${c.repository.full_name} · ${c.path}`;
+    return {
+      id: `ghs-code-${c.repository.full_name}-${c.sha}-${c.path}`,
+      author: {
+        name: owner,
+        handle: owner,
+        avatarUrl:
+          c.repository.owner?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(owner)}`,
+      },
+      content: snippet ? `${title}\n\n${snippet}` : title,
+      url: c.html_url,
+      createdAt: c.repository.pushed_at ?? new Date().toISOString(),
+      meta: {
+        scope: "code" as const,
+        repo: c.repository.full_name,
+        path: c.path,
+        sha: c.sha,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+async function searchCommits(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  const params = new URLSearchParams({
+    q: query,
+    sort: "author-date",
+    order: "desc",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const json = await ghFetch<GHSearchResponse<GHCommitResult>>(
+    `${API}/search/commits?${params}`,
+  );
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((c) => {
+    const handle =
+      c.author?.login ?? c.commit.author?.name ?? "unknown";
+    const message = (c.commit.message ?? "").trim();
+    const [firstLine, ...rest] = message.split("\n");
+    const restJoined = rest.join("\n").trim();
+    const trimmed =
+      restJoined.length > 400
+        ? `${restJoined.slice(0, 400).trimEnd()}…`
+        : restJoined;
+    return {
+      id: `ghs-commit-${c.sha}`,
+      author: {
+        name: handle,
+        handle,
+        avatarUrl:
+          c.author?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(handle)}`,
+      },
+      content: trimmed ? `${firstLine}\n\n${trimmed}` : firstLine,
+      url: c.html_url,
+      createdAt: c.commit.author?.date ?? new Date().toISOString(),
+      meta: {
+        scope: "commits" as const,
+        repo: c.repository.full_name,
+        sha: c.sha,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+export async function searchGitHub(
+  scope: GHSearchScope,
+  rawQuery: string,
+  limit = 12,
+  page = 1,
+): Promise<FeedItem[]> {
+  const query = buildQuery(rawQuery);
+  if (!query) {
+    throw new Error("Query is required for GitHub search.");
+  }
+  switch (scope) {
+    case "repositories":
+      return searchRepos(query, limit, page);
+    case "issues":
+      return searchIssuesScope(query, limit, page);
+    case "code":
+      return searchCode(query, limit, page);
+    case "commits":
+      return searchCommits(query, limit, page);
   }
 }

--- a/lib/integrations/hackernews.ts
+++ b/lib/integrations/hackernews.ts
@@ -18,6 +18,8 @@ interface AlgoliaHit {
   created_at?: string;
   created_at_i?: number;
   story_text?: string;
+  comment_text?: string;
+  story_id?: number;
   _tags?: string[];
 }
 
@@ -126,4 +128,147 @@ export async function fetchHackerNews(
 ): Promise<FeedItem[]> {
   const { items } = await fetchHackerNewsPage(mode, query, limit, 0);
   return items;
+}
+
+// ---- Mentions search ------------------------------------------------------
+
+export type HNSearchScope = "all" | "stories" | "comments";
+export type HNSearchSort = "relevance" | "date";
+
+export interface HNSearchHitMeta {
+  points: number;
+  comments: number;
+  commentsUrl: string;
+  externalUrl?: string;
+  kind: "story" | "comment";
+  storyTitle?: string;
+}
+
+function looksLikeUrl(s: string): boolean {
+  const t = s.trim();
+  if (!t) return false;
+  if (/^https?:\/\//i.test(t)) return true;
+  if (/^www\./i.test(t)) return true;
+  // bare domain or domain+path: at least one dot, recognizable TLD-ish suffix.
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)+(\/[^\s]*)?$/i.test(t);
+}
+
+function normalizeUrlForSearch(s: string): string {
+  return s
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/\/+$/, "");
+}
+
+function decodeSnippet(s: string | undefined): string {
+  return (
+    s
+      ?.replace(/<[^>]+>/g, "")
+      .replace(/&#x27;/g, "'")
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, "&")
+      .trim() ?? ""
+  );
+}
+
+function isCommentHit(h: AlgoliaHit): boolean {
+  if (Array.isArray(h._tags) && h._tags.includes("comment")) return true;
+  return typeof h.comment_text === "string" && h.comment_text.length > 0;
+}
+
+function mapSearchHit(h: AlgoliaHit): FeedItem<HNSearchHitMeta> {
+  const comment = isCommentHit(h);
+  const storyTitle = h.story_title ?? h.title ?? "(untitled)";
+  const externalUrl = h.url ?? h.story_url;
+  const itemUrl = `https://news.ycombinator.com/item?id=${h.objectID}`;
+  const author = h.author ?? "anonymous";
+  const createdMs =
+    typeof h.created_at_i === "number"
+      ? h.created_at_i * 1000
+      : h.created_at
+        ? Date.parse(h.created_at)
+        : Date.now();
+
+  const snippet = decodeSnippet(comment ? h.comment_text : h.story_text);
+  const content = comment
+    ? snippet || `Comment on “${storyTitle}”`
+    : snippet
+      ? `${storyTitle}\n\n${snippet}`
+      : storyTitle;
+
+  return {
+    id: h.objectID,
+    author: {
+      name: author,
+      handle: author,
+      avatarUrl: `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(author)}`,
+    },
+    content,
+    url: comment ? itemUrl : (externalUrl ?? itemUrl),
+    createdAt: new Date(createdMs).toISOString(),
+    meta: {
+      points: h.points ?? 0,
+      comments: h.num_comments ?? 0,
+      commentsUrl: itemUrl,
+      externalUrl: externalUrl ?? undefined,
+      kind: comment ? "comment" : "story",
+      storyTitle: comment ? storyTitle : undefined,
+    },
+  };
+}
+
+export async function searchHackerNewsByUrlOrKeyword(
+  input: string,
+  opts: {
+    scope: HNSearchScope;
+    sort: HNSearchSort;
+    limit: number;
+    page: number;
+  },
+): Promise<{ items: FeedItem<HNSearchHitMeta>[]; hasMore: boolean }> {
+  const { scope, sort, limit, page } = opts;
+  const trimmed = input.trim();
+  if (!trimmed) return { items: [], hasMore: false };
+
+  const params = new URLSearchParams({
+    hitsPerPage: String(limit),
+    page: String(page),
+  });
+
+  const isUrl = looksLikeUrl(trimmed);
+  if (isUrl) {
+    params.set("query", normalizeUrlForSearch(trimmed));
+    // Algolia attribute scoping — only match against the indexed URL field
+    // so domain queries don't get diluted by title/comment matches.
+    params.set("restrictSearchableAttributes", "url");
+  } else {
+    params.set("query", trimmed);
+  }
+
+  switch (scope) {
+    case "stories":
+      params.set("tags", "story");
+      break;
+    case "comments":
+      params.set("tags", "comment");
+      break;
+    case "all":
+      params.set("tags", "(story,comment)");
+      break;
+  }
+
+  const path = sort === "date" ? "search_by_date" : "search";
+  const res = await fetch(`${ALGOLIA}/${path}?${params}`, {
+    headers: { accept: "application/json" },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`HN ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  const json = (await res.json()) as AlgoliaResponse;
+  const hits = json.hits ?? [];
+  const totalPages = typeof json.nbPages === "number" ? json.nbPages : 1;
+  const hasMore = page + 1 < totalPages && hits.length === limit;
+  return { items: hits.slice(0, limit).map(mapSearchHit), hasMore };
 }

--- a/lib/integrations/weibo.ts
+++ b/lib/integrations/weibo.ts
@@ -1,0 +1,196 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// m.weibo.cn — Weibo's mobile site exposes a JSON search endpoint with no auth.
+// Far more parseable than scraping s.weibo.com HTML, but the host blocks most
+// non-CN egress IPs and rate-limits aggressively. Errors bubble up so the
+// column card can surface "no results" or the upstream message.
+
+const SEARCH_URL = "https://m.weibo.cn/api/container/getIndex";
+
+interface WeiboUser {
+  id?: number;
+  screen_name?: string;
+  profile_image_url?: string;
+  profile_url?: string;
+}
+
+interface WeiboMblog {
+  id?: string;
+  idstr?: string;
+  bid?: string;
+  mid?: string;
+  text?: string;
+  created_at?: string;
+  user?: WeiboUser;
+  reposts_count?: number;
+  comments_count?: number;
+  attitudes_count?: number;
+  source?: string;
+  retweeted_status?: WeiboMblog;
+}
+
+interface WeiboCard {
+  card_type?: number;
+  mblog?: WeiboMblog;
+  card_group?: WeiboCard[];
+}
+
+interface WeiboSearchResponse {
+  ok?: number;
+  msg?: string;
+  data?: {
+    cardlistInfo?: { total?: number; page?: number };
+    cards?: WeiboCard[];
+  };
+}
+
+export interface WeiboSearchMeta {
+  likes: number;
+  retweets: number;
+  replies: number;
+}
+
+function* iterMblogs(cards: WeiboCard[]): Generator<WeiboMblog> {
+  for (const c of cards) {
+    if (c.mblog) yield c.mblog;
+    if (c.card_group) {
+      for (const inner of c.card_group) {
+        if (inner.mblog) yield inner.mblog;
+      }
+    }
+  }
+}
+
+const HTML_ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&nbsp;": " ",
+};
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&(?:amp|lt|gt|quot|#39|nbsp);/g, (m) => HTML_ENTITIES[m] ?? m)
+    .trim();
+}
+
+function parseWeiboDate(raw: string | undefined): string {
+  const now = new Date();
+  if (!raw) return now.toISOString();
+  const s = raw.trim();
+
+  if (s === "刚刚") return now.toISOString();
+
+  const min = s.match(/^(\d+)\s*分钟前$/);
+  if (min) return new Date(now.getTime() - Number(min[1]) * 60_000).toISOString();
+
+  const hour = s.match(/^(\d+)\s*小时前$/);
+  if (hour) return new Date(now.getTime() - Number(hour[1]) * 3_600_000).toISOString();
+
+  const day = s.match(/^(\d+)\s*天前$/);
+  if (day) return new Date(now.getTime() - Number(day[1]) * 86_400_000).toISOString();
+
+  const yesterday = s.match(/^昨天\s+(\d{1,2}):(\d{2})$/);
+  if (yesterday) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - 1);
+    d.setHours(Number(yesterday[1]), Number(yesterday[2]), 0, 0);
+    return d.toISOString();
+  }
+
+  const md = s.match(/^(\d{1,2})-(\d{1,2})(?:\s+(\d{1,2}):(\d{2}))?$/);
+  if (md) {
+    const d = new Date(
+      now.getFullYear(),
+      Number(md[1]) - 1,
+      Number(md[2]),
+      md[3] ? Number(md[3]) : 0,
+      md[4] ? Number(md[4]) : 0,
+    );
+    return d.toISOString();
+  }
+
+  const parsed = new Date(s);
+  if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+
+  return now.toISOString();
+}
+
+function toFeedItem(m: WeiboMblog): FeedItem<WeiboSearchMeta> | null {
+  const text = stripHtml(m.text ?? "");
+  if (!text) return null;
+  const id = m.idstr ?? m.id ?? m.mid;
+  const bid = m.bid ?? id;
+  if (!id || !bid) return null;
+
+  const user = m.user ?? {};
+  const userId = user.id !== undefined ? String(user.id) : "";
+  const handle = user.screen_name ?? userId;
+
+  return {
+    id: `weibo-${id}`,
+    author: {
+      name: user.screen_name ?? "微博用户",
+      handle: handle || undefined,
+      avatarUrl: user.profile_image_url,
+    },
+    content: text,
+    url: userId ? `https://weibo.com/${userId}/${bid}` : `https://m.weibo.cn/status/${bid}`,
+    createdAt: parseWeiboDate(m.created_at),
+    meta: {
+      likes: Number(m.attitudes_count ?? 0),
+      retweets: Number(m.reposts_count ?? 0),
+      replies: Number(m.comments_count ?? 0),
+    },
+  };
+}
+
+export async function searchWeibo(
+  query: string,
+  limit = 20,
+): Promise<FeedItem<WeiboSearchMeta>[]> {
+  const q = query.trim();
+  if (!q) return [];
+
+  // 100103type=61 = post-only search (vs type=1 which mixes users & topics).
+  const containerid = `100103type=61&q=${q}`;
+  const url = `${SEARCH_URL}?containerid=${encodeURIComponent(containerid)}&page_type=searchall`;
+
+  const res = await fetch(url, {
+    headers: {
+      "user-agent":
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+      accept: "application/json, text/plain, */*",
+      "accept-language": "zh-CN,zh;q=0.9,en;q=0.8",
+      referer: `https://m.weibo.cn/search?containerid=${encodeURIComponent(containerid)}`,
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(`Weibo ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+
+  const json = (await res.json()) as WeiboSearchResponse;
+  if (json.ok !== 1) {
+    if (json.msg) throw new Error(`Weibo: ${json.msg}`);
+    return [];
+  }
+  const cards = json.data?.cards ?? [];
+
+  const items: FeedItem<WeiboSearchMeta>[] = [];
+  const seen = new Set<string>();
+  for (const m of iterMblogs(cards)) {
+    const item = toFeedItem(m);
+    if (!item) continue;
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    items.push(item);
+    if (items.length >= limit) break;
+  }
+  return items;
+}


### PR DESCRIPTION
## Summary
- New `weibo-search` column type that surfaces Weibo (微博) posts mentioning a keyword or URL.
- Keyless integration via `m.weibo.cn/api/container/getIndex` (mobile JSON search) — chosen over s.weibo.com HTML scrape (brittle DOM) and Grok `web_search` (requires `XAI_API_KEY`).
- Reuses the shared `TweetItem` renderer since Weibo's likes/reposts/comments map cleanly onto `TweetMeta`'s likes/retweets/replies.
- Handles Weibo's mixed date formats (`刚刚`, `X分钟前`, `昨天 HH:MM`, `MM-DD`, RFC dates) and strips inline HTML from post bodies.

## Caveats
- `m.weibo.cn` is fronted by CN-only infrastructure — non-CN egress IPs may get empty results or rate-limit. The column's `rateLimitHint` surfaces this in the config form.
- If running outside China proves too unreliable in practice, swap the integration call in `server.ts` for `grokWebSearch` with a `site:weibo.com` prefix and add `requiresEnv: ["XAI_API_KEY"]`.

## Test plan
- [x] `npm run build` — parity check + TypeScript both clean.
- [ ] Manual: from a CN-friendly egress, add a `weibo-search` column with a known Chinese keyword (e.g. `北京`) and confirm posts render with author / content / engagement counts.
- [ ] Manual: confirm URL queries (e.g. `anthropic.com`) return matching posts when present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)