### PR TITLE
Add facebook column for keyword/URL mention monitoring

### DIFF
--- a/lib/columns/plugins/facebook/client.tsx
+++ b/lib/columns/plugins/facebook/client.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LinkItem } from "@/lib/columns/shared/link-renderer";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type FacebookConfig, type FacebookMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<FacebookConfig>) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="fb-q">Keyword or URL</Label>
+      <Input
+        id="fb-q"
+        placeholder="anthropic.com, claude code, https://..."
+        value={value.query}
+        onChange={(e) => onChange({ query: e.target.value })}
+      />
+      <p className="text-xs text-muted-foreground">
+        Searches public facebook.com posts and pages for mentions. URLs and
+        keywords both work.
+      </p>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<FacebookMeta>) {
+  return (
+    <LinkItem
+      item={item}
+      badgeLabel="Facebook"
+      badgeClass="bg-[#1877F2]/15 text-foreground ring-1 ring-black/5"
+    />
+  );
+}
+
+export const column = defineColumnUI<FacebookConfig, FacebookMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/facebook/plugin.ts
+++ b/lib/columns/plugins/facebook/plugin.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { ThumbsUp } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+});
+
+export type FacebookConfig = z.infer<typeof schema>;
+
+export interface FacebookMeta {
+  source: string;
+  kind: "web" | "news";
+}
+
+export const meta: PluginMeta<FacebookConfig, FacebookMeta> = {
+  id: "facebook",
+  label: "Facebook mentions",
+  description:
+    "Watch public Facebook posts and pages for mentions of a keyword or URL.",
+  icon: ThumbsUp,
+  accent: "#1877F2",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `Facebook · ${c.query.trim()}` : "Facebook mentions",
+  capabilities: { requiresEnv: ["XAI_API_KEY"] },
+};

--- a/lib/columns/plugins/facebook/server.ts
+++ b/lib/columns/plugins/facebook/server.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+// Facebook's Graph API has no public mention search and aggressively blocks
+// anonymous scraping, so we piggyback on Grok's web_search with a
+// site:facebook.com filter — no extra env beyond XAI_API_KEY.
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { grokFacebookSearch } from "@/lib/integrations/xai";
+import { meta, type FacebookConfig, type FacebookMeta } from "./plugin";
+
+const fetch: ServerFetcher<FacebookConfig, FacebookMeta> = async (config) => {
+  const items = (await grokFacebookSearch(config.query)) as FeedItem<FacebookMeta>[];
+  return { items };
+};
+
+export const server = defineColumnServer<FacebookConfig, FacebookMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/github-search/client.tsx
+++ b/lib/columns/plugins/github-search/client.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import {
+  CircleDot,
+  FileCode2,
+  GitBranch,
+  GitCommit,
+  GitMerge,
+  GitPullRequest,
+  MessageSquareText,
+  Star,
+} from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type GHSearchConfig, type GHSearchMeta } from "./plugin";
+
+function compact(n: number): string {
+  if (Math.abs(n) < 1000) return String(n);
+  if (Math.abs(n) < 1_000_000)
+    return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+function ConfigForm({ value, onChange }: ConfigFormProps<GHSearchConfig>) {
+  const isUrl = /^https?:\/\//i.test(value.query.trim());
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Scope</Label>
+        <Select
+          value={value.scope}
+          onValueChange={(v) =>
+            onChange({ ...value, scope: v as GHSearchConfig["scope"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="repositories">Repositories</SelectItem>
+            <SelectItem value="issues">Issues / PRs</SelectItem>
+            <SelectItem value="code">Code</SelectItem>
+            <SelectItem value="commits">Commits</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghs-q">Keyword or URL</Label>
+        <Input
+          id="ghs-q"
+          placeholder='"yourdomain.com", "your-product", or any GitHub query'
+          value={value.query}
+          onChange={(e) => onChange({ ...value, query: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          {isUrl
+            ? "URL will be auto-quoted for an exact match."
+            : "Quote phrases for exact match. Full GitHub search syntax (org:, repo:, language:, path:, is:open, ...) is supported."}
+        </p>
+      </div>
+
+      {value.scope === "code" && (
+        <p className="rounded-md border border-border bg-surface/40 px-3 py-2 text-[11.5px] text-muted-foreground">
+          Code search requires{" "}
+          <code className="rounded bg-foreground/[0.06] px-1 py-px text-foreground/90">
+            GITHUB_TOKEN
+          </code>{" "}
+          in your env. Other scopes work without one.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ScopeBadge({ m }: { m: GHSearchMeta }) {
+  if (m.scope === "issues") {
+    const state = m.state ?? "open";
+    const Icon =
+      m.isPr ? (state === "closed" ? GitMerge : GitPullRequest) : CircleDot;
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{
+          backgroundColor:
+            state === "closed"
+              ? "rgba(192, 168, 221, 0.32)"
+              : "rgba(223, 168, 143, 0.28)",
+        }}
+      >
+        <Icon className="size-3" />
+        {m.isPr ? "PR" : "issue"}
+      </span>
+    );
+  }
+  if (m.scope === "code") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(159, 187, 224, 0.32)" }}
+      >
+        <FileCode2 className="size-3" />
+        code
+      </span>
+    );
+  }
+  if (m.scope === "commits") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(159, 201, 162, 0.28)" }}
+      >
+        <GitCommit className="size-3" />
+        commit
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+      style={{ backgroundColor: "rgba(159, 187, 224, 0.32)" }}
+    >
+      <GitBranch className="size-3" />
+      repo
+    </span>
+  );
+}
+
+function MetaRow({ m }: { m: GHSearchMeta }) {
+  if (m.scope === "repositories") {
+    const stars = m.stars ?? 0;
+    const forks = m.forks ?? 0;
+    return (
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <Star className="size-3.5" />
+          <span className="tabular-nums">{compact(stars)}</span>
+        </span>
+        <span className="flex items-center gap-1">
+          <GitBranch className="size-3.5" />
+          <span className="tabular-nums">{compact(forks)}</span>
+        </span>
+        {m.language && (
+          <span className="truncate text-foreground/70">{m.language}</span>
+        )}
+      </div>
+    );
+  }
+  if (m.scope === "issues") {
+    const comments = m.comments ?? 0;
+    return (
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        {m.number !== undefined && (
+          <span className="tabular-nums text-foreground/70">#{m.number}</span>
+        )}
+        <span className="flex items-center gap-1">
+          <MessageSquareText className="size-3.5" />
+          <span className="tabular-nums">{compact(comments)}</span>
+        </span>
+        {m.repo && (
+          <span className="truncate text-foreground/70">{m.repo}</span>
+        )}
+      </div>
+    );
+  }
+  if (m.scope === "commits" && m.sha) {
+    return (
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="font-mono text-foreground/70">
+          {m.sha.slice(0, 7)}
+        </span>
+        {m.repo && (
+          <span className="truncate text-foreground/70">{m.repo}</span>
+        )}
+      </div>
+    );
+  }
+  return null;
+}
+
+function ItemRenderer({ item }: ItemRendererProps<GHSearchMeta>) {
+  const m = item.meta ?? ({ scope: "repositories" } as GHSearchMeta);
+  const [title, ...rest] = item.content.split("\n\n");
+  const snippet = rest.join("\n\n").trim();
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <ScopeBadge m={m} />
+        <span className="truncate text-foreground/80">
+          {item.author.handle ?? item.author.name}
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {title}
+      </h3>
+      {snippet && (
+        <p
+          className={`mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words ${
+            m.scope === "code" ? "font-mono whitespace-pre" : "whitespace-pre-line"
+          }`}
+        >
+          {snippet}
+        </p>
+      )}
+      <MetaRow m={m} />
+    </a>
+  );
+}
+
+export const column = defineColumnUI<GHSearchConfig, GHSearchMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-search/plugin.ts
+++ b/lib/columns/plugins/github-search/plugin.ts
@@ -1,0 +1,62 @@
+// Separate from the `github` plugin: that one is feed-style (trending /
+// releases / issue search). This one is mention-monitoring — free-form
+// keyword/URL search across repos, issues, code, and commits with one
+// switchable scope. Different config form, different renderer concerns.
+
+import { z } from "zod";
+import { SearchCode } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  scope: z
+    .enum(["repositories", "issues", "code", "commits"])
+    .default("issues"),
+  query: z.string().default(""),
+});
+
+export type GHSearchConfig = z.infer<typeof schema>;
+
+export interface GHSearchMeta {
+  scope: "repositories" | "issues" | "code" | "commits";
+  repo?: string;
+  stars?: number;
+  forks?: number;
+  language?: string;
+  number?: number;
+  state?: string;
+  comments?: number;
+  isPr?: boolean;
+  path?: string;
+  sha?: string;
+}
+
+const SCOPE_LABEL: Record<GHSearchConfig["scope"], string> = {
+  repositories: "Repos",
+  issues: "Issues / PRs",
+  code: "Code",
+  commits: "Commits",
+};
+
+export const meta: PluginMeta<GHSearchConfig, GHSearchMeta> = {
+  id: "github-search",
+  label: "GitHub search",
+  description:
+    "Watch GitHub for mentions of a keyword or URL across repos, issues, code, or commits.",
+  icon: SearchCode,
+  accent: "#1f2328",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const label = SCOPE_LABEL[c.scope];
+    const q = c.query.trim();
+    return q ? `GH ${label} · ${q}` : `GitHub · ${label}`;
+  },
+  capabilities: {
+    paginated: true,
+    // GITHUB_TOKEN is genuinely optional — fetcher upgrades automatically when
+    // it's set — so it's not in requiresEnv (which renders as "Requires:" in UI).
+    rateLimitHint:
+      "60 req/hr without GITHUB_TOKEN, 5000 with. Code search requires the token.",
+  },
+};

--- a/lib/columns/plugins/github-search/server.ts
+++ b/lib/columns/plugins/github-search/server.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { searchGitHub } from "@/lib/integrations/github";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type GHSearchConfig, type GHSearchMeta } from "./plugin";
+
+const fetch: ServerFetcher<GHSearchConfig, GHSearchMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 1 : 1;
+  const items = (await searchGitHub(
+    config.scope,
+    config.query,
+    PAGE_SIZE,
+    page,
+  )) as FeedItem<GHSearchMeta>[];
+  return {
+    items,
+    nextCursor: items.length === PAGE_SIZE ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<GHSearchConfig, GHSearchMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/hacker-news-search/client.tsx
+++ b/lib/columns/plugins/hacker-news-search/client.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { ArrowBigUp, MessageSquareText, MessageCircle } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type HNSearchConfig, type HNSearchMeta } from "./plugin";
+
+function compact(n: number): string {
+  if (Math.abs(n) < 1000) return String(n);
+  if (Math.abs(n) < 1_000_000)
+    return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+function ConfigForm({ value, onChange }: ConfigFormProps<HNSearchConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="hns-q">Keyword or URL</Label>
+        <Input
+          id="hns-q"
+          placeholder="anthropic.com, claude code, https://..."
+          value={value.query}
+          onChange={(e) => onChange({ ...value, query: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          URLs are matched against the story link; everything else searches
+          full text.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Scope</Label>
+        <Select
+          value={value.scope}
+          onValueChange={(v) =>
+            onChange({ ...value, scope: v as HNSearchConfig["scope"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Stories &amp; comments</SelectItem>
+            <SelectItem value="stories">Stories only</SelectItem>
+            <SelectItem value="comments">Comments only</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Sort</Label>
+        <Select
+          value={value.sort}
+          onValueChange={(v) =>
+            onChange({ ...value, sort: v as HNSearchConfig["sort"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="date">Newest first</SelectItem>
+            <SelectItem value="relevance">Most relevant</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<HNSearchMeta>) {
+  const m = item.meta;
+  const kind = m?.kind ?? "story";
+  const points = m?.points ?? 0;
+  const comments = m?.comments ?? 0;
+  const commentsUrl = m?.commentsUrl ?? item.url;
+
+  const isComment = kind === "comment";
+  const headline = isComment
+    ? (m?.storyTitle ?? "(comment)")
+    : item.content.split("\n\n")[0];
+  const body = isComment
+    ? item.content
+    : item.content.split("\n\n").slice(1).join("\n\n").trim();
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(255, 102, 0, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[9px] font-bold leading-none text-white"
+            style={{ backgroundColor: "#ff6600" }}
+          >
+            Y
+          </span>
+          {isComment ? "HN comment" : "HN story"}
+        </span>
+        <span className="text-muted-foreground/80">
+          by{" "}
+          <span className="text-foreground/90">
+            {item.author.handle ?? item.author.name}
+          </span>
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+        >
+          {isComment ? `Re: ${headline}` : headline}
+        </h3>
+      </a>
+      {body && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {body}
+        </p>
+      )}
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        {isComment ? (
+          <a
+            href={commentsUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-1 transition-colors hover:text-foreground"
+          >
+            <MessageCircle className="size-3.5" />
+            <span>View thread</span>
+          </a>
+        ) : (
+          <>
+            <span className="flex items-center gap-1">
+              <ArrowBigUp className="size-4" />
+              <span className="tabular-nums">{compact(points)}</span>
+            </span>
+            <a
+              href={commentsUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1 transition-colors hover:text-foreground"
+            >
+              <MessageSquareText className="size-3.5" />
+              <span className="tabular-nums">{compact(comments)}</span>
+            </a>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<HNSearchConfig, HNSearchMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/hacker-news-search/plugin.ts
+++ b/lib/columns/plugins/hacker-news-search/plugin.ts
@@ -1,0 +1,39 @@
+// Dedicated mention monitor for HN — separate from the existing hacker-news
+// plugin so URL detection, comment scope, and date sort don't bloat that
+// plugin's ConfigForm (which serves the front-page/Ask/Show/keyword UX).
+
+import { z } from "zod";
+import { Eye } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+  scope: z.enum(["all", "stories", "comments"]).default("all"),
+  sort: z.enum(["relevance", "date"]).default("date"),
+});
+
+export type HNSearchConfig = z.infer<typeof schema>;
+
+export interface HNSearchMeta {
+  points: number;
+  comments: number;
+  commentsUrl: string;
+  externalUrl?: string;
+  kind: "story" | "comment";
+  storyTitle?: string;
+}
+
+export const meta: PluginMeta<HNSearchConfig, HNSearchMeta> = {
+  id: "hacker-news-search",
+  label: "HN Mentions",
+  description:
+    "Watch Hacker News for keyword or URL mentions across stories and comments.",
+  icon: Eye,
+  accent: "#ff6600",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `HN watch · ${c.query.trim()}` : "HN watch",
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/hacker-news-search/server.ts
+++ b/lib/columns/plugins/hacker-news-search/server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { searchHackerNewsByUrlOrKeyword } from "@/lib/integrations/hackernews";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type HNSearchConfig, type HNSearchMeta } from "./plugin";
+
+const fetch: ServerFetcher<HNSearchConfig, HNSearchMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await searchHackerNewsByUrlOrKeyword(config.query, {
+    scope: config.scope,
+    sort: config.sort,
+    limit: PAGE_SIZE,
+    page,
+  });
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<HNSearchConfig, HNSearchMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -15,6 +15,7 @@ import { meta as reddit } from "./reddit/plugin";
 import { meta as hackerNews } from "./hacker-news/plugin";
 import { meta as hackerNewsSearch } from "./hacker-news-search/plugin";
 import { meta as github } from "./github/plugin";
+import { meta as githubSearch } from "./github-search/plugin";
 import { meta as rss } from "./rss/plugin";
 import { meta as googleNews } from "./google-news/plugin";
 import { meta as mentions } from "./mentions/plugin";
@@ -34,6 +35,7 @@ export const PLUGIN_METAS = [
   hackerNews,
   hackerNewsSearch,
   github,
+  githubSearch,
   rss,
   googleNews,
   mentions,

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -20,6 +20,7 @@ import { meta as rss } from "./rss/plugin";
 import { meta as googleNews } from "./google-news/plugin";
 import { meta as mentions } from "./mentions/plugin";
 import { meta as farcaster } from "./farcaster/plugin";
+import { meta as facebook } from "./facebook/plugin";
 import { meta as youtube } from "./youtube/plugin";
 import { meta as newsnow } from "./newsnow/plugin";
 
@@ -40,6 +41,7 @@ export const PLUGIN_METAS = [
   googleNews,
   mentions,
   farcaster,
+  facebook,
   youtube,
   newsnow,
 ];

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -13,6 +13,7 @@ import { meta as webSearch } from "./web-search/plugin";
 import { meta as newsSearch } from "./news-search/plugin";
 import { meta as reddit } from "./reddit/plugin";
 import { meta as hackerNews } from "./hacker-news/plugin";
+import { meta as hackerNewsSearch } from "./hacker-news-search/plugin";
 import { meta as github } from "./github/plugin";
 import { meta as rss } from "./rss/plugin";
 import { meta as googleNews } from "./google-news/plugin";
@@ -31,6 +32,7 @@ export const PLUGIN_METAS = [
   newsSearch,
   reddit,
   hackerNews,
+  hackerNewsSearch,
   github,
   rss,
   googleNews,

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -23,6 +23,7 @@ import { column as reddit } from "@/lib/columns/plugins/reddit/client";
 import { column as hackerNews } from "@/lib/columns/plugins/hacker-news/client";
 import { column as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/client";
 import { column as github } from "@/lib/columns/plugins/github/client";
+import { column as githubSearch } from "@/lib/columns/plugins/github-search/client";
 import { column as rss } from "@/lib/columns/plugins/rss/client";
 import { column as googleNews } from "@/lib/columns/plugins/google-news/client";
 import { column as mentions } from "@/lib/columns/plugins/mentions/client";
@@ -45,6 +46,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "hacker-news": hackerNews,
   "hacker-news-search": hackerNewsSearch,
   github,
+  "github-search": githubSearch,
   rss,
   "google-news": googleNews,
   mentions,

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -28,6 +28,7 @@ import { column as rss } from "@/lib/columns/plugins/rss/client";
 import { column as googleNews } from "@/lib/columns/plugins/google-news/client";
 import { column as mentions } from "@/lib/columns/plugins/mentions/client";
 import { column as farcaster } from "@/lib/columns/plugins/farcaster/client";
+import { column as facebook } from "@/lib/columns/plugins/facebook/client";
 import { column as youtube } from "@/lib/columns/plugins/youtube/client";
 import { column as newsnow } from "@/lib/columns/plugins/newsnow/client";
 
@@ -51,6 +52,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "google-news": googleNews,
   mentions,
   farcaster,
+  facebook,
   youtube,
   newsnow,
 };

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -21,6 +21,7 @@ import { column as webSearch } from "@/lib/columns/plugins/web-search/client";
 import { column as newsSearch } from "@/lib/columns/plugins/news-search/client";
 import { column as reddit } from "@/lib/columns/plugins/reddit/client";
 import { column as hackerNews } from "@/lib/columns/plugins/hacker-news/client";
+import { column as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/client";
 import { column as github } from "@/lib/columns/plugins/github/client";
 import { column as rss } from "@/lib/columns/plugins/rss/client";
 import { column as googleNews } from "@/lib/columns/plugins/google-news/client";
@@ -42,6 +43,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "news-search": newsSearch,
   reddit,
   "hacker-news": hackerNews,
+  "hacker-news-search": hackerNewsSearch,
   github,
   rss,
   "google-news": googleNews,

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -19,6 +19,7 @@ import { server as reddit } from "@/lib/columns/plugins/reddit/server";
 import { server as hackerNews } from "@/lib/columns/plugins/hacker-news/server";
 import { server as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/server";
 import { server as github } from "@/lib/columns/plugins/github/server";
+import { server as githubSearch } from "@/lib/columns/plugins/github-search/server";
 import { server as rss } from "@/lib/columns/plugins/rss/server";
 import { server as googleNews } from "@/lib/columns/plugins/google-news/server";
 import { server as mentions } from "@/lib/columns/plugins/mentions/server";
@@ -38,6 +39,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "hacker-news": hackerNews,
   "hacker-news-search": hackerNewsSearch,
   github,
+  "github-search": githubSearch,
   rss,
   "google-news": googleNews,
   mentions,

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -24,6 +24,7 @@ import { server as rss } from "@/lib/columns/plugins/rss/server";
 import { server as googleNews } from "@/lib/columns/plugins/google-news/server";
 import { server as mentions } from "@/lib/columns/plugins/mentions/server";
 import { server as farcaster } from "@/lib/columns/plugins/farcaster/server";
+import { server as facebook } from "@/lib/columns/plugins/facebook/server";
 import { server as youtube } from "@/lib/columns/plugins/youtube/server";
 import { server as newsnow } from "@/lib/columns/plugins/newsnow/server";
 
@@ -44,6 +45,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "google-news": googleNews,
   mentions,
   farcaster,
+  facebook,
   youtube,
   newsnow,
 };

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -17,6 +17,7 @@ import { server as webSearch } from "@/lib/columns/plugins/web-search/server";
 import { server as newsSearch } from "@/lib/columns/plugins/news-search/server";
 import { server as reddit } from "@/lib/columns/plugins/reddit/server";
 import { server as hackerNews } from "@/lib/columns/plugins/hacker-news/server";
+import { server as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/server";
 import { server as github } from "@/lib/columns/plugins/github/server";
 import { server as rss } from "@/lib/columns/plugins/rss/server";
 import { server as googleNews } from "@/lib/columns/plugins/google-news/server";
@@ -35,6 +36,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "news-search": newsSearch,
   reddit,
   "hacker-news": hackerNews,
+  "hacker-news-search": hackerNewsSearch,
   github,
   rss,
   "google-news": googleNews,

--- a/lib/integrations/github.ts
+++ b/lib/integrations/github.ts
@@ -4,6 +4,8 @@ const API = "https://api.github.com";
 
 export type GHMode = "trending" | "releases" | "issues";
 
+export type GHSearchScope = "repositories" | "issues" | "code" | "commits";
+
 interface GHRepo {
   id: number;
   full_name: string;
@@ -242,5 +244,264 @@ export async function fetchGitHub(
         : "week") as "day" | "week" | "month";
       return fetchTrending(config.language ?? "", period, limit, page);
     }
+  }
+}
+
+// ---- Free-form search across scopes (used by github-search plugin) ---------
+
+interface GHCodeResult {
+  sha: string;
+  name: string;
+  path: string;
+  html_url: string;
+  repository: {
+    full_name: string;
+    pushed_at?: string;
+    owner?: { login: string; avatar_url?: string };
+  };
+  text_matches?: Array<{ fragment?: string }>;
+}
+
+interface GHCommitResult {
+  sha: string;
+  html_url: string;
+  commit: {
+    message: string;
+    author?: { name?: string; email?: string; date?: string };
+  };
+  author?: { login: string; avatar_url?: string } | null;
+  repository: { full_name: string };
+}
+
+function buildQuery(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+  // GitHub indexes URLs in code/issues but tokenizes on punctuation, so a
+  // bare URL becomes many separate matches. Quote it for an exact match —
+  // unless the user already wrapped it themselves.
+  if (/^https?:\/\//i.test(trimmed) && !/^".*"$/.test(trimmed)) {
+    return `"${trimmed}"`;
+  }
+  return trimmed;
+}
+
+async function searchRepos(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  const params = new URLSearchParams({
+    q: query,
+    sort: "updated",
+    order: "desc",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const json = await ghFetch<GHSearchResponse<GHRepo>>(
+    `${API}/search/repositories?${params}`,
+  );
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((r) => {
+    const owner = r.owner?.login ?? r.full_name.split("/")[0] ?? "github";
+    return {
+      id: `ghs-repo-${r.id}`,
+      author: {
+        name: owner,
+        handle: owner,
+        avatarUrl:
+          r.owner?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(owner)}`,
+      },
+      content: r.description
+        ? `${r.full_name}\n\n${r.description}`
+        : r.full_name,
+      url: r.html_url,
+      createdAt: r.pushed_at ?? r.created_at,
+      meta: {
+        scope: "repositories" as const,
+        repo: r.full_name,
+        stars: r.stargazers_count,
+        forks: r.forks_count,
+        language: r.language ?? undefined,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+async function searchIssuesScope(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  const params = new URLSearchParams({
+    q: query,
+    sort: "updated",
+    order: "desc",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const json = await ghFetch<GHSearchResponse<GHIssue>>(
+    `${API}/search/issues?${params}`,
+  );
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((i) => {
+    const user = i.user?.login ?? "anonymous";
+    const isPr = !!i.pull_request;
+    const repo = i.repository_url.replace(`${API}/repos/`, "");
+    const body = (i.body ?? "").trim();
+    const trimmed =
+      body.length > 400 ? `${body.slice(0, 400).trimEnd()}…` : body;
+    return {
+      id: `ghs-iss-${i.id}`,
+      author: {
+        name: user,
+        handle: user,
+        avatarUrl:
+          i.user?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(user)}`,
+      },
+      content: trimmed ? `${i.title}\n\n${trimmed}` : i.title,
+      url: i.html_url,
+      createdAt: i.updated_at ?? i.created_at,
+      meta: {
+        scope: "issues" as const,
+        repo,
+        number: i.number,
+        state: i.state,
+        comments: i.comments,
+        isPr,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+async function searchCode(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error(
+      "GitHub code search requires a token. Set GITHUB_TOKEN in your env (read-only public scope is enough).",
+    );
+  }
+  const params = new URLSearchParams({
+    q: query,
+    per_page: String(limit),
+    page: String(page),
+  });
+  const res = await fetch(`${API}/search/code?${params}`, {
+    headers: {
+      ...(headers() as Record<string, string>),
+      // text-match returns a `fragment` snippet around each hit
+      accept: "application/vnd.github.text-match+json",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as GHSearchResponse<GHCodeResult>;
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((c) => {
+    const owner =
+      c.repository.owner?.login ??
+      c.repository.full_name.split("/")[0] ??
+      "github";
+    const fragment = (c.text_matches?.[0]?.fragment ?? "").trim();
+    const snippet =
+      fragment.length > 400
+        ? `${fragment.slice(0, 400).trimEnd()}…`
+        : fragment;
+    const title = `${c.repository.full_name} · ${c.path}`;
+    return {
+      id: `ghs-code-${c.repository.full_name}-${c.sha}-${c.path}`,
+      author: {
+        name: owner,
+        handle: owner,
+        avatarUrl:
+          c.repository.owner?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(owner)}`,
+      },
+      content: snippet ? `${title}\n\n${snippet}` : title,
+      url: c.html_url,
+      createdAt: c.repository.pushed_at ?? new Date().toISOString(),
+      meta: {
+        scope: "code" as const,
+        repo: c.repository.full_name,
+        path: c.path,
+        sha: c.sha,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+async function searchCommits(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  const params = new URLSearchParams({
+    q: query,
+    sort: "author-date",
+    order: "desc",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const json = await ghFetch<GHSearchResponse<GHCommitResult>>(
+    `${API}/search/commits?${params}`,
+  );
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((c) => {
+    const handle =
+      c.author?.login ?? c.commit.author?.name ?? "unknown";
+    const message = (c.commit.message ?? "").trim();
+    const [firstLine, ...rest] = message.split("\n");
+    const restJoined = rest.join("\n").trim();
+    const trimmed =
+      restJoined.length > 400
+        ? `${restJoined.slice(0, 400).trimEnd()}…`
+        : restJoined;
+    return {
+      id: `ghs-commit-${c.sha}`,
+      author: {
+        name: handle,
+        handle,
+        avatarUrl:
+          c.author?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(handle)}`,
+      },
+      content: trimmed ? `${firstLine}\n\n${trimmed}` : firstLine,
+      url: c.html_url,
+      createdAt: c.commit.author?.date ?? new Date().toISOString(),
+      meta: {
+        scope: "commits" as const,
+        repo: c.repository.full_name,
+        sha: c.sha,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+export async function searchGitHub(
+  scope: GHSearchScope,
+  rawQuery: string,
+  limit = 12,
+  page = 1,
+): Promise<FeedItem[]> {
+  const query = buildQuery(rawQuery);
+  if (!query) {
+    throw new Error("Query is required for GitHub search.");
+  }
+  switch (scope) {
+    case "repositories":
+      return searchRepos(query, limit, page);
+    case "issues":
+      return searchIssuesScope(query, limit, page);
+    case "code":
+      return searchCode(query, limit, page);
+    case "commits":
+      return searchCommits(query, limit, page);
   }
 }

--- a/lib/integrations/hackernews.ts
+++ b/lib/integrations/hackernews.ts
@@ -18,6 +18,8 @@ interface AlgoliaHit {
   created_at?: string;
   created_at_i?: number;
   story_text?: string;
+  comment_text?: string;
+  story_id?: number;
   _tags?: string[];
 }
 
@@ -126,4 +128,147 @@ export async function fetchHackerNews(
 ): Promise<FeedItem[]> {
   const { items } = await fetchHackerNewsPage(mode, query, limit, 0);
   return items;
+}
+
+// ---- Mentions search ------------------------------------------------------
+
+export type HNSearchScope = "all" | "stories" | "comments";
+export type HNSearchSort = "relevance" | "date";
+
+export interface HNSearchHitMeta {
+  points: number;
+  comments: number;
+  commentsUrl: string;
+  externalUrl?: string;
+  kind: "story" | "comment";
+  storyTitle?: string;
+}
+
+function looksLikeUrl(s: string): boolean {
+  const t = s.trim();
+  if (!t) return false;
+  if (/^https?:\/\//i.test(t)) return true;
+  if (/^www\./i.test(t)) return true;
+  // bare domain or domain+path: at least one dot, recognizable TLD-ish suffix.
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)+(\/[^\s]*)?$/i.test(t);
+}
+
+function normalizeUrlForSearch(s: string): string {
+  return s
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/\/+$/, "");
+}
+
+function decodeSnippet(s: string | undefined): string {
+  return (
+    s
+      ?.replace(/<[^>]+>/g, "")
+      .replace(/&#x27;/g, "'")
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, "&")
+      .trim() ?? ""
+  );
+}
+
+function isCommentHit(h: AlgoliaHit): boolean {
+  if (Array.isArray(h._tags) && h._tags.includes("comment")) return true;
+  return typeof h.comment_text === "string" && h.comment_text.length > 0;
+}
+
+function mapSearchHit(h: AlgoliaHit): FeedItem<HNSearchHitMeta> {
+  const comment = isCommentHit(h);
+  const storyTitle = h.story_title ?? h.title ?? "(untitled)";
+  const externalUrl = h.url ?? h.story_url;
+  const itemUrl = `https://news.ycombinator.com/item?id=${h.objectID}`;
+  const author = h.author ?? "anonymous";
+  const createdMs =
+    typeof h.created_at_i === "number"
+      ? h.created_at_i * 1000
+      : h.created_at
+        ? Date.parse(h.created_at)
+        : Date.now();
+
+  const snippet = decodeSnippet(comment ? h.comment_text : h.story_text);
+  const content = comment
+    ? snippet || `Comment on “${storyTitle}”`
+    : snippet
+      ? `${storyTitle}\n\n${snippet}`
+      : storyTitle;
+
+  return {
+    id: h.objectID,
+    author: {
+      name: author,
+      handle: author,
+      avatarUrl: `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(author)}`,
+    },
+    content,
+    url: comment ? itemUrl : (externalUrl ?? itemUrl),
+    createdAt: new Date(createdMs).toISOString(),
+    meta: {
+      points: h.points ?? 0,
+      comments: h.num_comments ?? 0,
+      commentsUrl: itemUrl,
+      externalUrl: externalUrl ?? undefined,
+      kind: comment ? "comment" : "story",
+      storyTitle: comment ? storyTitle : undefined,
+    },
+  };
+}
+
+export async function searchHackerNewsByUrlOrKeyword(
+  input: string,
+  opts: {
+    scope: HNSearchScope;
+    sort: HNSearchSort;
+    limit: number;
+    page: number;
+  },
+): Promise<{ items: FeedItem<HNSearchHitMeta>[]; hasMore: boolean }> {
+  const { scope, sort, limit, page } = opts;
+  const trimmed = input.trim();
+  if (!trimmed) return { items: [], hasMore: false };
+
+  const params = new URLSearchParams({
+    hitsPerPage: String(limit),
+    page: String(page),
+  });
+
+  const isUrl = looksLikeUrl(trimmed);
+  if (isUrl) {
+    params.set("query", normalizeUrlForSearch(trimmed));
+    // Algolia attribute scoping — only match against the indexed URL field
+    // so domain queries don't get diluted by title/comment matches.
+    params.set("restrictSearchableAttributes", "url");
+  } else {
+    params.set("query", trimmed);
+  }
+
+  switch (scope) {
+    case "stories":
+      params.set("tags", "story");
+      break;
+    case "comments":
+      params.set("tags", "comment");
+      break;
+    case "all":
+      params.set("tags", "(story,comment)");
+      break;
+  }
+
+  const path = sort === "date" ? "search_by_date" : "search";
+  const res = await fetch(`${ALGOLIA}/${path}?${params}`, {
+    headers: { accept: "application/json" },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`HN ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  const json = (await res.json()) as AlgoliaResponse;
+  const hits = json.hits ?? [];
+  const totalPages = typeof json.nbPages === "number" ? json.nbPages : 1;
+  const hasMore = page + 1 < totalPages && hits.length === limit;
+  return { items: hits.slice(0, limit).map(mapSearchHit), hasMore };
 }

--- a/lib/integrations/xai.ts
+++ b/lib/integrations/xai.ts
@@ -309,3 +309,17 @@ export async function grokNewsSearch(query: string, limit = 6): Promise<FeedItem
     .filter((i): i is FeedItem => i !== null)
     .slice(0, limit);
 }
+
+export async function grokFacebookSearch(query: string, limit = 6): Promise<FeedItem[]> {
+  const q = query.trim();
+  const scoped = q ? `site:facebook.com ${q}` : "site:facebook.com";
+  const prompt = `Search the web for the ${limit} most recent public Facebook posts or pages matching: ${JSON.stringify(
+    scoped,
+  )}. Restrict results to facebook.com URLs (posts, page wall items, public group posts). Sort newest first. For each, set "source" to the page or profile name (not the domain), and "title" to a short snippet from the post. Return ONLY a JSON array (no prose, no code fences) matching this shape: ${WEB_ITEM_SHAPE}.`;
+  const items = await callGrok({ prompt, tools: [{ type: "web_search" }] });
+  return items
+    .map((g) => toWebFeedItem(g, "web"))
+    .filter((i): i is FeedItem => i !== null)
+    .filter((i) => /(^|\.)facebook\.com\//i.test(i.url ?? ""))
+    .slice(0, limit);
+}


### PR DESCRIPTION
## Summary
- New `facebook` column type that surfaces public Facebook posts/pages mentioning a keyword or URL.
- Backed by Grok `web_search` with a `site:facebook.com` filter — no extra credential beyond `XAI_API_KEY` (the same one `web-search` and `news-search` already use). Graph API has no public mention search and anonymous scraping is aggressively blocked, so this was the easiest no-extra-key path.
- Three plugin files + 3 registration lines (manifest / registry / server-registry); `npm run build` passes the parity check and TypeScript.

## Test plan
- [ ] Add the column from the picker — capability note should mention `XAI_API_KEY`.
- [ ] Run a query (keyword e.g. "claude code" and a URL e.g. `anthropic.com`) and confirm results are facebook.com URLs rendered via `LinkItem` with the blue Facebook badge.
- [ ] Empty query → column renders without throwing; results may be sparse but should not error.
- [ ] Without `XAI_API_KEY` set, the API route returns a clear error.

## Notes
- lucide-react v1.11.0 in this repo has no `Facebook` icon, so the plugin uses `ThumbsUp` (the iconic FB-like glyph). Easy swap to `Share2` / `Users2` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)