### PR TITLE
Add github-backlinks column type

### DIFF
--- a/lib/columns/plugins/github-backlinks/client.tsx
+++ b/lib/columns/plugins/github-backlinks/client.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import {
+  meta,
+  type BacklinksConfig,
+  type BacklinkSource,
+  type BacklinksItemMeta,
+} from "./plugin";
+
+const SOURCE_LABEL: Record<BacklinkSource, string> = {
+  hn: "HN",
+  reddit: "Reddit",
+  "google-news": "Google",
+  "bing-news": "Bing",
+  github: "GitHub",
+  web: "Web",
+};
+
+const SOURCE_BG: Record<BacklinkSource, string> = {
+  hn: "rgba(255, 102, 0, 0.18)",
+  reddit: "rgba(245, 78, 0, 0.18)",
+  "google-news": "rgba(159, 201, 162, 0.32)",
+  "bing-news": "rgba(159, 187, 224, 0.32)",
+  github: "rgba(38, 37, 30, 0.16)",
+  web: "rgba(192, 168, 221, 0.32)",
+};
+
+function ConfigForm({ value, onChange }: ConfigFormProps<BacklinksConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghbl-repo">Repository</Label>
+        <Input
+          id="ghbl-repo"
+          placeholder="vercel/next.js or https://github.com/vercel/next.js"
+          value={value.repo}
+          onChange={(e) => onChange({ ...value, repo: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Watches HN, Reddit, Google News, and Bing News for posts linking to
+          this repo. Dedupes by canonical URL.
+        </p>
+      </div>
+      <label className="flex items-start gap-2 text-sm">
+        <input
+          type="checkbox"
+          className="mt-0.5 size-3.5 accent-foreground"
+          checked={value.includeIssues}
+          onChange={(e) =>
+            onChange({ ...value, includeIssues: e.target.checked })
+          }
+        />
+        <span>
+          <span className="font-medium">Include GitHub issues / PRs</span>
+          <span className="block text-xs text-muted-foreground">
+            Issues and PRs in other repos that reference this repo.
+          </span>
+        </span>
+      </label>
+      <label className="flex items-start gap-2 text-sm">
+        <input
+          type="checkbox"
+          className="mt-0.5 size-3.5 accent-foreground"
+          checked={value.includeWebSearch}
+          onChange={(e) =>
+            onChange({ ...value, includeWebSearch: e.target.checked })
+          }
+        />
+        <span>
+          <span className="font-medium">Include web search</span>
+          <span className="block text-xs text-muted-foreground">
+            Catches blog posts, Substack, etc. via Grok. Requires{" "}
+            <code>XAI_API_KEY</code>.
+          </span>
+        </span>
+      </label>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<BacklinksItemMeta>) {
+  const source = item.meta?.source ?? "web";
+  const sourceLabel = SOURCE_LABEL[source] ?? source;
+  const bg = SOURCE_BG[source] ?? "rgba(0,0,0,0.06)";
+
+  const [title, ...rest] = item.content.split("\n\n");
+  const snippet = rest.join("\n\n").trim();
+  const hostName = (() => {
+    try {
+      return new URL(item.url ?? "").hostname.replace(/^www\./, "");
+    } catch {
+      return "";
+    }
+  })();
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: bg }}
+        >
+          {sourceLabel}
+        </span>
+        {hostName && (
+          <span className="truncate max-w-[200px] text-foreground/80">
+            {hostName}
+          </span>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {title}
+      </h3>
+      {snippet && (
+        <p className="mt-1 line-clamp-2 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {snippet}
+        </p>
+      )}
+    </a>
+  );
+}
+
+export const column = defineColumnUI<BacklinksConfig, BacklinksItemMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-backlinks/plugin.ts
+++ b/lib/columns/plugins/github-backlinks/plugin.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { Link2 } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  repo: z.string().default(""),
+  includeIssues: z.boolean().default(true),
+  includeWebSearch: z.boolean().default(false),
+});
+
+export type BacklinksConfig = z.infer<typeof schema>;
+
+export type BacklinkSource =
+  | "hn"
+  | "reddit"
+  | "google-news"
+  | "bing-news"
+  | "github"
+  | "web";
+
+export interface BacklinksItemMeta {
+  source: BacklinkSource;
+  canonicalUrl: string;
+}
+
+export const meta: PluginMeta<BacklinksConfig, BacklinksItemMeta> = {
+  id: "github-backlinks",
+  label: "GitHub backlinks",
+  description:
+    "Find pages, posts, and issues across the web that link to a GitHub repo.",
+  icon: Link2,
+  accent: "#5e6dc7",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const t = c.repo.trim();
+    return t ? `Backlinks · ${t.replace(/^https?:\/\/github\.com\//i, "")}` : "GitHub backlinks";
+  },
+};

--- a/lib/columns/plugins/github-backlinks/server.ts
+++ b/lib/columns/plugins/github-backlinks/server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchBacklinks } from "@/lib/integrations/github-backlinks";
+import {
+  meta,
+  type BacklinksConfig,
+  type BacklinksItemMeta,
+} from "./plugin";
+
+// Fan-out across HN (URL-indexed), Reddit search, Google News, Bing News,
+// optionally GitHub issue search and Grok web search; dedup on canonical URL.
+const fetch: ServerFetcher<BacklinksConfig, BacklinksItemMeta> = async (
+  config,
+) => {
+  const items = (await fetchBacklinks({
+    repo: config.repo,
+    includeIssues: config.includeIssues,
+    includeWebSearch: config.includeWebSearch,
+  })) as FeedItem<BacklinksItemMeta>[];
+  return { items };
+};
+
+export const server = defineColumnServer<BacklinksConfig, BacklinksItemMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -14,6 +14,7 @@ import { meta as newsSearch } from "./news-search/plugin";
 import { meta as reddit } from "./reddit/plugin";
 import { meta as hackerNews } from "./hacker-news/plugin";
 import { meta as github } from "./github/plugin";
+import { meta as githubBacklinks } from "./github-backlinks/plugin";
 import { meta as rss } from "./rss/plugin";
 import { meta as googleNews } from "./google-news/plugin";
 import { meta as mentions } from "./mentions/plugin";
@@ -32,6 +33,7 @@ export const PLUGIN_METAS = [
   reddit,
   hackerNews,
   github,
+  githubBacklinks,
   rss,
   googleNews,
   mentions,

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -22,6 +22,7 @@ import { column as newsSearch } from "@/lib/columns/plugins/news-search/client";
 import { column as reddit } from "@/lib/columns/plugins/reddit/client";
 import { column as hackerNews } from "@/lib/columns/plugins/hacker-news/client";
 import { column as github } from "@/lib/columns/plugins/github/client";
+import { column as githubBacklinks } from "@/lib/columns/plugins/github-backlinks/client";
 import { column as rss } from "@/lib/columns/plugins/rss/client";
 import { column as googleNews } from "@/lib/columns/plugins/google-news/client";
 import { column as mentions } from "@/lib/columns/plugins/mentions/client";
@@ -43,6 +44,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   reddit,
   "hacker-news": hackerNews,
   github,
+  "github-backlinks": githubBacklinks,
   rss,
   "google-news": googleNews,
   mentions,

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -18,6 +18,7 @@ import { server as newsSearch } from "@/lib/columns/plugins/news-search/server";
 import { server as reddit } from "@/lib/columns/plugins/reddit/server";
 import { server as hackerNews } from "@/lib/columns/plugins/hacker-news/server";
 import { server as github } from "@/lib/columns/plugins/github/server";
+import { server as githubBacklinks } from "@/lib/columns/plugins/github-backlinks/server";
 import { server as rss } from "@/lib/columns/plugins/rss/server";
 import { server as googleNews } from "@/lib/columns/plugins/google-news/server";
 import { server as mentions } from "@/lib/columns/plugins/mentions/server";
@@ -36,6 +37,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   reddit,
   "hacker-news": hackerNews,
   github,
+  "github-backlinks": githubBacklinks,
   rss,
   "google-news": googleNews,
   mentions,

--- a/lib/integrations/github-backlinks.ts
+++ b/lib/integrations/github-backlinks.ts
@@ -1,0 +1,174 @@
+import type { FeedItem } from "@/lib/columns/types";
+import { fetchGitHub } from "@/lib/integrations/github";
+import { fetchHackerNews } from "@/lib/integrations/hackernews";
+import { searchReddit } from "@/lib/integrations/reddit";
+import { fetchFeed, googleNewsUrl } from "@/lib/integrations/rss";
+import { grokWebSearch } from "@/lib/integrations/xai";
+
+export type BacklinkSource =
+  | "hn"
+  | "reddit"
+  | "google-news"
+  | "bing-news"
+  | "github"
+  | "web";
+
+export interface BacklinksConfig {
+  repo: string;
+  includeIssues?: boolean;
+  includeWebSearch?: boolean;
+  limitPerSource?: number;
+}
+
+export interface NormalizedRepo {
+  ownerRepo: string;
+  canonicalUrl: string;
+}
+
+export function normalizeRepo(input: string): NormalizedRepo {
+  const trimmed = input.trim();
+  if (!trimmed) throw new Error("Repo is required (owner/repo or full URL).");
+  const stripped = trimmed
+    .replace(/^https?:\/\//i, "")
+    .replace(/^github\.com\//i, "")
+    .replace(/\.git$/i, "")
+    .replace(/\/+$/, "");
+  if (!/^[\w.-]+\/[\w.-]+$/.test(stripped)) {
+    throw new Error(
+      `Invalid repo "${input}". Use owner/repo (e.g. vercel/next.js) or https://github.com/owner/repo.`,
+    );
+  }
+  return {
+    ownerRepo: stripped,
+    canonicalUrl: `https://github.com/${stripped}`,
+  };
+}
+
+const TRACKING_PARAMS = new Set([
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "fbclid",
+  "gclid",
+  "mc_cid",
+  "mc_eid",
+  "ref",
+]);
+
+function canonicalize(url: string): string {
+  try {
+    const u = new URL(url);
+    u.hostname = u.hostname.toLowerCase().replace(/^www\./, "");
+    for (const p of [...u.searchParams.keys()]) {
+      if (TRACKING_PARAMS.has(p.toLowerCase())) u.searchParams.delete(p);
+    }
+    u.hash = "";
+    let s = u.toString();
+    if (s.endsWith("/")) s = s.slice(0, -1);
+    return s;
+  } catch {
+    return url;
+  }
+}
+
+function tag(
+  items: FeedItem[],
+  source: BacklinkSource,
+  canonicalUrl: string,
+): FeedItem[] {
+  return items.map((it) => ({
+    ...it,
+    id: `${source}-${it.id}`,
+    meta: { ...(it.meta ?? {}), source, canonicalUrl },
+  }));
+}
+
+export async function fetchBacklinks(
+  config: BacklinksConfig,
+): Promise<FeedItem[]> {
+  const { ownerRepo, canonicalUrl } = normalizeRepo(config.repo);
+  const limit = config.limitPerSource ?? 8;
+
+  const tasks: Promise<FeedItem[]>[] = [];
+
+  // Algolia indexes HN submissions by URL — full URL query matches against the url field.
+  tasks.push(
+    fetchHackerNews("query", canonicalUrl, limit).then((items) =>
+      tag(items, "hn", canonicalUrl),
+    ),
+  );
+
+  // Reddit search — returns posts whose body or link URL matches.
+  tasks.push(
+    searchReddit(canonicalUrl, limit).then((items) =>
+      tag(items, "reddit", canonicalUrl),
+    ),
+  );
+
+  // Google News + Bing News scoped to canonical URL OR owner/repo phrase.
+  const newsQuery = `"${canonicalUrl}" OR "${ownerRepo}"`;
+  tasks.push(
+    fetchFeed(googleNewsUrl(newsQuery), limit).then((items) =>
+      tag(items, "google-news", canonicalUrl),
+    ),
+  );
+  const bingUrl = `https://www.bing.com/news/search?q=${encodeURIComponent(
+    newsQuery,
+  )}&format=rss`;
+  tasks.push(
+    fetchFeed(bingUrl, limit).then((items) =>
+      tag(items, "bing-news", canonicalUrl),
+    ),
+  );
+
+  // GitHub issues/PRs across the rest of GitHub that mention this repo URL.
+  // -repo:owner/name strips out the repo's own self-references.
+  if (config.includeIssues ?? true) {
+    const ghQuery = `${canonicalUrl} -repo:${ownerRepo}`;
+    tasks.push(
+      fetchGitHub("issues", { query: ghQuery }, limit).then((items) =>
+        tag(items, "github", canonicalUrl),
+      ),
+    );
+  }
+
+  // Optional Grok web search — only when XAI_API_KEY is set and user opts in.
+  if (config.includeWebSearch) {
+    tasks.push(
+      grokWebSearch(`pages linking to "${canonicalUrl}"`, limit).then(
+        (items) => tag(items, "web", canonicalUrl),
+      ),
+    );
+  }
+
+  const settled = await Promise.allSettled(tasks);
+  const errors: string[] = [];
+  const all: FeedItem[] = [];
+  for (const r of settled) {
+    if (r.status === "fulfilled") {
+      all.push(...r.value);
+    } else {
+      errors.push(
+        r.reason instanceof Error ? r.reason.message : String(r.reason),
+      );
+    }
+  }
+
+  if (all.length === 0 && errors.length > 0) {
+    throw new Error(`All sources failed:\n${errors.join("\n")}`);
+  }
+
+  const seen = new Set<string>();
+  const deduped: FeedItem[] = [];
+  for (const it of all) {
+    const key = canonicalize(it.url ?? it.id);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(it);
+  }
+
+  deduped.sort((a, b) => +new Date(b.createdAt) - +new Date(a.createdAt));
+  return deduped.slice(0, limit * 2);
+}


### PR DESCRIPTION
## Summary
- New \`github-backlinks\` column watches the rest of the internet for links pointing to a given GitHub repo
- Fans out to HN (Algolia URL search), Reddit search, Google News, Bing News, optional GitHub issue/PR search (\`-repo:owner/name\` to drop self-references), and optional Grok \`web_search\` (gated on \`XAI_API_KEY\`)
- Dedups by canonical URL; works keyless out of the box

## Test plan
- [ ] \`npm run build\` succeeds (parity check passes)
- [ ] Add column with repo \`vercel/next.js\` — verify mixed sources show up with badges
- [ ] Add column with full URL \`https://github.com/vercel/next.js\` — same canonical results
- [ ] Toggle "Include GitHub issues / PRs" off — github-source items disappear
- [ ] Toggle "Include web search" on with no \`XAI_API_KEY\` — column still loads from other sources (web fan-out fails silently via \`Promise.allSettled\`)
- [ ] Invalid repo input surfaces a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)