### PR TITLE
Add wallet-tx column: multi-chain wallet transactions via Blockscout

### DIFF
--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -20,6 +20,7 @@ import { meta as mentions } from "./mentions/plugin";
 import { meta as farcaster } from "./farcaster/plugin";
 import { meta as youtube } from "./youtube/plugin";
 import { meta as newsnow } from "./newsnow/plugin";
+import { meta as walletTx } from "./wallet-tx/plugin";
 
 export const PLUGIN_METAS = [
   grokAsk,
@@ -38,6 +39,7 @@ export const PLUGIN_METAS = [
   farcaster,
   youtube,
   newsnow,
+  walletTx,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/plugins/wallet-tx/client.tsx
+++ b/lib/columns/plugins/wallet-tx/client.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { ArrowDownLeft, ArrowUpRight, Wallet } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type WalletTxConfig, type WalletTxMeta } from "./plugin";
+
+const CHAIN_OPTIONS: { value: WalletTxConfig["chain"]; label: string }[] = [
+  { value: "ethereum", label: "Ethereum" },
+  { value: "base", label: "Base" },
+  { value: "optimism", label: "Optimism" },
+  { value: "arbitrum", label: "Arbitrum" },
+  { value: "polygon", label: "Polygon" },
+  { value: "gnosis", label: "Gnosis" },
+  { value: "scroll", label: "Scroll" },
+  { value: "celo", label: "Celo" },
+  { value: "zksync", label: "zkSync" },
+];
+
+function shortHash(h: string, head = 6, tail = 4): string {
+  if (!h) return "";
+  if (h.length <= head + tail + 1) return h;
+  return `${h.slice(0, head)}…${h.slice(-tail)}`;
+}
+
+function formatUsd(n: number): string {
+  if (n < 0.01) return "<$0.01";
+  if (n < 1000) return `$${n.toFixed(2)}`;
+  if (n < 1_000_000) return `$${(n / 1000).toFixed(n < 10_000 ? 2 : 1)}k`;
+  return `$${(n / 1_000_000).toFixed(2)}M`;
+}
+
+const ADDR_RE = /^0x[a-fA-F0-9]{40}$/;
+
+function ConfigForm({ value, onChange }: ConfigFormProps<WalletTxConfig>) {
+  const trimmed = value.address.trim();
+  const showError = trimmed.length > 0 && !ADDR_RE.test(trimmed);
+
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Chain</Label>
+        <Select
+          value={value.chain}
+          onValueChange={(v) =>
+            onChange({ ...value, chain: v as WalletTxConfig["chain"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {CHAIN_OPTIONS.map((c) => (
+              <SelectItem key={c.value} value={c.value}>
+                {c.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="wallet-tx-addr">Wallet address</Label>
+        <Input
+          id="wallet-tx-addr"
+          placeholder="0x…"
+          value={value.address}
+          onChange={(e) => onChange({ ...value, address: e.target.value })}
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+          aria-invalid={showError || undefined}
+        />
+        <p className="text-xs text-muted-foreground">
+          {showError ? (
+            <span className="text-[color:var(--destructive,#c0392b)]">
+              EVM address must be <code>0x</code>-prefixed and 42 characters.
+            </span>
+          ) : (
+            <>EVM address — 42 characters, starts with <code>0x</code>.</>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<WalletTxMeta>) {
+  const m = item.meta;
+  if (!m) return null;
+  const fromShort = shortHash(m.from);
+  const toShort = m.to ? shortHash(m.to) : "—";
+  const isFailed = m.status === "failed";
+  const isOutgoing =
+    item.author.handle?.toLowerCase() === m.from.toLowerCase();
+  const DirectionIcon = isOutgoing ? ArrowUpRight : ArrowDownLeft;
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(98, 126, 234, 0.18)" }}
+        >
+          <Wallet className="size-3" />
+          {shortHash(m.hash, 6, 4)}
+        </span>
+        {m.method && (
+          <span className="rounded-full bg-foreground/[0.06] px-1.5 py-0.5 text-foreground/80">
+            {m.method}
+          </span>
+        )}
+        {isFailed && (
+          <span
+            className="rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+            style={{ backgroundColor: "rgba(192, 57, 43, 0.18)" }}
+          >
+            failed
+          </span>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+
+      <div className="mt-1.5 flex items-center gap-2 text-[13px] text-foreground">
+        <DirectionIcon
+          className={`size-4 ${isOutgoing ? "text-rose-500" : "text-emerald-500"}`}
+        />
+        <span className="font-mono text-foreground/80">{fromShort}</span>
+        <span className="text-muted-foreground/60">→</span>
+        <span className="font-mono text-foreground/80">{toShort}</span>
+      </div>
+
+      <div className="mt-1.5 flex items-baseline gap-2">
+        <span
+          className={`font-serif text-[16px] leading-tight tabular-nums ${
+            isFailed ? "text-muted-foreground line-through" : "text-foreground"
+          }`}
+          style={{ letterSpacing: "-0.005em" }}
+        >
+          {item.content}
+        </span>
+        {typeof m.valueUsd === "number" && m.valueUsd > 0 && (
+          <span className="text-[11.5px] text-muted-foreground tabular-nums">
+            ≈ {formatUsd(m.valueUsd)}
+          </span>
+        )}
+        <span className="ml-auto text-[11px] text-muted-foreground/70 tabular-nums">
+          #{m.blockNumber.toLocaleString()}
+        </span>
+      </div>
+    </a>
+  );
+}
+
+export const column = defineColumnUI<WalletTxConfig, WalletTxMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/wallet-tx/plugin.ts
+++ b/lib/columns/plugins/wallet-tx/plugin.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { Wallet } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  chain: z
+    .enum([
+      "ethereum",
+      "base",
+      "optimism",
+      "arbitrum",
+      "polygon",
+      "gnosis",
+      "scroll",
+      "celo",
+      "zksync",
+    ])
+    .default("ethereum"),
+  address: z.string().default(""),
+});
+
+export type WalletTxConfig = z.infer<typeof schema>;
+
+export interface WalletTxMeta {
+  chainId: number;
+  hash: string;
+  from: string;
+  to: string;
+  value: string;
+  valueUsd?: number;
+  method?: string;
+  status: "success" | "failed";
+  blockNumber: number;
+  gasUsed?: string;
+}
+
+const CHAIN_LABELS: Record<WalletTxConfig["chain"], string> = {
+  ethereum: "Ethereum",
+  base: "Base",
+  optimism: "Optimism",
+  arbitrum: "Arbitrum",
+  polygon: "Polygon",
+  gnosis: "Gnosis",
+  scroll: "Scroll",
+  celo: "Celo",
+  zksync: "zkSync",
+};
+
+function shortAddr(a: string): string {
+  const trimmed = a.trim();
+  if (!trimmed) return "";
+  if (trimmed.length <= 12) return trimmed;
+  return `${trimmed.slice(0, 6)}…${trimmed.slice(-4)}`;
+}
+
+export const meta: PluginMeta<WalletTxConfig, WalletTxMeta> = {
+  id: "wallet-tx",
+  label: "Wallet · Transactions",
+  description: "Latest on-chain transactions for an EVM wallet address.",
+  icon: Wallet,
+  accent: "#627eea",
+  category: "blockchain",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const label = CHAIN_LABELS[c.chain] ?? c.chain;
+    const addr = shortAddr(c.address);
+    return addr ? `${label} · ${addr}` : `Wallet · ${label}`;
+  },
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/wallet-tx/server.ts
+++ b/lib/columns/plugins/wallet-tx/server.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+// Uses Blockscout REST v2 (keyless multi-chain) — see lib/integrations/blockscout.ts.
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchAddressTransactions } from "@/lib/integrations/blockscout";
+import { meta, type WalletTxConfig, type WalletTxMeta } from "./plugin";
+
+const fetch: ServerFetcher<WalletTxConfig, WalletTxMeta> = async (
+  config,
+  cursor,
+) => {
+  const address = config.address.trim();
+  if (!address) return { items: [] };
+  return fetchAddressTransactions(config.chain, address, cursor);
+};
+
+export const server = defineColumnServer<WalletTxConfig, WalletTxMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -28,6 +28,7 @@ import { column as mentions } from "@/lib/columns/plugins/mentions/client";
 import { column as farcaster } from "@/lib/columns/plugins/farcaster/client";
 import { column as youtube } from "@/lib/columns/plugins/youtube/client";
 import { column as newsnow } from "@/lib/columns/plugins/newsnow/client";
+import { column as walletTx } from "@/lib/columns/plugins/wallet-tx/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -49,6 +50,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   farcaster,
   youtube,
   newsnow,
+  "wallet-tx": walletTx,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -24,6 +24,7 @@ import { server as mentions } from "@/lib/columns/plugins/mentions/server";
 import { server as farcaster } from "@/lib/columns/plugins/farcaster/server";
 import { server as youtube } from "@/lib/columns/plugins/youtube/server";
 import { server as newsnow } from "@/lib/columns/plugins/newsnow/server";
+import { server as walletTx } from "@/lib/columns/plugins/wallet-tx/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "grok-ask": grokAsk,
@@ -42,6 +43,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   farcaster,
   youtube,
   newsnow,
+  "wallet-tx": walletTx,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/blockscout.ts
+++ b/lib/integrations/blockscout.ts
@@ -1,0 +1,304 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// Multi-chain Blockscout REST v2 client. Keyless by default. If
+// `BLOCKSCOUT_API_KEY` is set, it's appended as `?apikey=` to every request
+// (Blockscout's Pro tier accepts the same param across all instances), which
+// raises rate limits without changing call sites.
+
+export const SUPPORTED_CHAINS = [
+  "ethereum",
+  "base",
+  "optimism",
+  "arbitrum",
+  "polygon",
+  "gnosis",
+  "scroll",
+  "celo",
+  "zksync",
+] as const;
+
+export type Chain = (typeof SUPPORTED_CHAINS)[number];
+
+interface ChainInfo {
+  chainId: number;
+  host: string;
+  nativeSymbol: string;
+  label: string;
+}
+
+const CHAINS: Record<Chain, ChainInfo> = {
+  ethereum: { chainId: 1, host: "eth.blockscout.com", nativeSymbol: "ETH", label: "Ethereum" },
+  base: { chainId: 8453, host: "base.blockscout.com", nativeSymbol: "ETH", label: "Base" },
+  optimism: { chainId: 10, host: "optimism.blockscout.com", nativeSymbol: "ETH", label: "Optimism" },
+  arbitrum: { chainId: 42161, host: "arbitrum.blockscout.com", nativeSymbol: "ETH", label: "Arbitrum" },
+  polygon: { chainId: 137, host: "polygon.blockscout.com", nativeSymbol: "POL", label: "Polygon" },
+  gnosis: { chainId: 100, host: "gnosis.blockscout.com", nativeSymbol: "xDAI", label: "Gnosis" },
+  scroll: { chainId: 534352, host: "scroll.blockscout.com", nativeSymbol: "ETH", label: "Scroll" },
+  celo: { chainId: 42220, host: "celo.blockscout.com", nativeSymbol: "CELO", label: "Celo" },
+  zksync: { chainId: 324, host: "zksync.blockscout.com", nativeSymbol: "ETH", label: "zkSync" },
+};
+
+export function getChainInfo(chain: Chain): ChainInfo {
+  return CHAINS[chain];
+}
+
+export function explorerTxUrl(chain: Chain, hash: string): string {
+  return `https://${CHAINS[chain].host}/tx/${hash}`;
+}
+
+export function explorerAddressUrl(chain: Chain, address: string): string {
+  return `https://${CHAINS[chain].host}/address/${address}`;
+}
+
+export interface WalletTxMeta {
+  chainId: number;
+  hash: string;
+  from: string;
+  to: string;
+  value: string;
+  valueUsd?: number;
+  method?: string;
+  status: "success" | "failed";
+  blockNumber: number;
+  gasUsed?: string;
+  [key: string]: unknown;
+}
+
+interface BSAddressRef {
+  hash?: string;
+  name?: string | null;
+  is_contract?: boolean;
+}
+
+interface BSTokenInfo {
+  symbol?: string | null;
+  decimals?: string | null;
+  exchange_rate?: string | null;
+}
+
+interface BSTokenTransfer {
+  from?: BSAddressRef;
+  to?: BSAddressRef;
+  total?: { value?: string | null; decimals?: string | null };
+  token?: BSTokenInfo;
+}
+
+interface BSTransaction {
+  hash: string;
+  from?: BSAddressRef;
+  to?: BSAddressRef | null;
+  value?: string | null;
+  fee?: { value?: string | null } | null;
+  gas_used?: string | null;
+  block_number?: number | null;
+  block?: number | null;
+  status?: string | null;
+  result?: string | null;
+  method?: string | null;
+  timestamp?: string | null;
+  tx_types?: string[];
+  transaction_types?: string[];
+  exchange_rate?: string | null;
+  token_transfers?: BSTokenTransfer[];
+}
+
+interface BSResponse<T> {
+  items?: T[];
+  next_page_params?: Record<string, unknown> | null;
+  message?: string;
+}
+
+const EVM_ADDR_RE = /^0x[a-fA-F0-9]{40}$/;
+
+export function isValidEvmAddress(addr: string): boolean {
+  return EVM_ADDR_RE.test(addr.trim());
+}
+
+function buildUrl(
+  chain: Chain,
+  path: string,
+  params?: Record<string, string>,
+): string {
+  const url = new URL(`https://${CHAINS[chain].host}/api/v2${path}`);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  }
+  const key = process.env.BLOCKSCOUT_API_KEY;
+  if (key) url.searchParams.set("apikey", key);
+  return url.toString();
+}
+
+export function encodeCursor(next: Record<string, unknown> | null | undefined): string | undefined {
+  if (!next || Object.keys(next).length === 0) return undefined;
+  const json = JSON.stringify(next);
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+export function decodeCursor(cursor?: string): Record<string, string> | undefined {
+  if (!cursor) return undefined;
+  try {
+    const json = Buffer.from(cursor, "base64url").toString("utf8");
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (v === null || v === undefined) continue;
+      out[k] = String(v);
+    }
+    return out;
+  } catch {
+    return undefined;
+  }
+}
+
+function formatUnits(raw: string, decimals: number): string {
+  const negative = raw.startsWith("-");
+  const digits = (negative ? raw.slice(1) : raw).replace(/^0+/, "") || "0";
+  if (decimals === 0) return (negative ? "-" : "") + digits;
+  const padded = digits.padStart(decimals + 1, "0");
+  const whole = padded.slice(0, padded.length - decimals);
+  const frac = padded.slice(padded.length - decimals).replace(/0+$/, "");
+  const sign = negative ? "-" : "";
+  return frac ? `${sign}${whole}.${frac}` : `${sign}${whole}`;
+}
+
+function trimDecimals(value: string, maxFrac = 6): string {
+  const [whole, frac] = value.split(".");
+  if (!frac) return whole;
+  const trimmed = frac.slice(0, maxFrac).replace(/0+$/, "");
+  return trimmed ? `${whole}.${trimmed}` : whole;
+}
+
+function pickValueDisplay(
+  tx: BSTransaction,
+  nativeSymbol: string,
+): { display: string; symbol: string; rawWei: string; rate?: number } {
+  const valueWei = tx.value && tx.value !== "0" ? tx.value : null;
+  if (valueWei) {
+    const human = formatUnits(valueWei, 18);
+    const rate = parseFloatOrUndef(tx.exchange_rate);
+    return {
+      display: trimDecimals(human, 6),
+      symbol: nativeSymbol,
+      rawWei: valueWei,
+      rate,
+    };
+  }
+
+  const transfer = tx.token_transfers?.[0];
+  if (transfer?.total?.value && transfer.token) {
+    const decimals = Number(transfer.total.decimals ?? transfer.token.decimals ?? "18") || 0;
+    const symbol = transfer.token.symbol ?? "TOKEN";
+    const display = trimDecimals(formatUnits(transfer.total.value, decimals), 6);
+    const rate = parseFloatOrUndef(transfer.token.exchange_rate);
+    return { display, symbol, rawWei: transfer.total.value, rate };
+  }
+
+  return { display: "0", symbol: nativeSymbol, rawWei: "0" };
+}
+
+function parseFloatOrUndef(s?: string | null): number | undefined {
+  if (!s) return undefined;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function statusFrom(tx: BSTransaction): "success" | "failed" {
+  const s = (tx.status ?? tx.result ?? "").toString().toLowerCase();
+  if (s === "ok" || s === "success") return "success";
+  if (s === "error" || s === "failed" || s === "fail") return "failed";
+  return "success";
+}
+
+export async function fetchAddressTransactions(
+  chain: Chain,
+  address: string,
+  cursor?: string,
+): Promise<{ items: FeedItem<WalletTxMeta>[]; nextCursor?: string }> {
+  if (!isValidEvmAddress(address)) {
+    throw new Error(
+      `Invalid address "${address}". Expected a 0x-prefixed 42-character EVM address.`,
+    );
+  }
+  const info = CHAINS[chain];
+  const params = decodeCursor(cursor);
+  const url = buildUrl(chain, `/addresses/${address}/transactions`, params);
+
+  const res = await fetch(url, {
+    headers: { accept: "application/json", "user-agent": "minitor/0.1" },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Blockscout ${info.host} ${res.status}: ${body.slice(0, 200)}`);
+  }
+
+  const json = (await res.json()) as BSResponse<BSTransaction>;
+  if (json.message && !json.items) {
+    throw new Error(`Blockscout ${info.host}: ${json.message}`);
+  }
+
+  const items = (json.items ?? []).map((tx): FeedItem<WalletTxMeta> => {
+    const value = pickValueDisplay(tx, info.nativeSymbol);
+    const valueNum = Number(value.display);
+    const valueUsd =
+      value.rate !== undefined && Number.isFinite(valueNum) && valueNum > 0
+        ? valueNum * value.rate
+        : undefined;
+    const status = statusFrom(tx);
+    const blockNumber = tx.block_number ?? tx.block ?? 0;
+    const fromAddr = tx.from?.hash ?? "";
+    const toAddr = tx.to?.hash ?? "";
+    const methodRaw = tx.method?.trim() || undefined;
+    const method = methodRaw ?? inferMethodLabel(tx, address, fromAddr);
+
+    return {
+      id: `${info.chainId}-${tx.hash}`,
+      author: {
+        name: shortAddress(fromAddr || address),
+        handle: fromAddr || address,
+        avatarUrl: `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(fromAddr || address)}`,
+      },
+      content: `${value.display} ${value.symbol}`,
+      url: explorerTxUrl(chain, tx.hash),
+      createdAt: tx.timestamp ?? new Date().toISOString(),
+      meta: {
+        chainId: info.chainId,
+        hash: tx.hash,
+        from: fromAddr,
+        to: toAddr,
+        value: `${value.display} ${value.symbol}`,
+        valueUsd,
+        method,
+        status,
+        blockNumber,
+        gasUsed: tx.gas_used ?? undefined,
+      },
+    };
+  });
+
+  return {
+    items,
+    nextCursor: encodeCursor(json.next_page_params ?? undefined),
+  };
+}
+
+function shortAddress(addr: string): string {
+  if (!addr) return "unknown";
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function inferMethodLabel(
+  tx: BSTransaction,
+  watched: string,
+  from: string,
+): string | undefined {
+  const types = tx.tx_types ?? tx.transaction_types ?? [];
+  if (types.includes("token_transfer")) return "Token transfer";
+  if (types.includes("coin_transfer")) {
+    return from.toLowerCase() === watched.toLowerCase() ? "Send" : "Receive";
+  }
+  if (types.includes("contract_call")) return "Contract call";
+  if (types.includes("contract_creation")) return "Contract creation";
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- New `wallet-tx` column type that monitors the latest on-chain transactions for an EVM wallet address.
- Keyless multi-chain Blockscout REST v2 client at `lib/integrations/blockscout.ts` (ethereum, base, optimism, arbitrum, polygon, gnosis, scroll, celo, zksync).
- Cursor encodes Blockscout's `next_page_params` as base64url-JSON; `BLOCKSCOUT_API_KEY` is picked up transparently for the upgrade path.
- Plugin at `lib/columns/plugins/wallet-tx/` with chain `Select` + 0x/42-char-validated address input, and an item renderer showing short hash, from→to, value (+ USD estimate), method, success/failed badge, block number, and a relative timestamp linking out to the matching Blockscout explorer.
- Registered in `manifest.ts`, `registry.ts`, and `server-registry.ts` (parity check passes).

## Test plan
- [x] `npm run build` — TypeScript + parity check pass
- [ ] Smoke test: add a wallet-tx column for vitalik.eth's address on Ethereum, verify items + Load more
- [ ] Smoke test: switch chain to Base / Polygon, verify chain-specific symbol + explorer links
- [ ] Verify failed-tx and token-transfer items render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)