### PR TITLE
Add github-prs column type for per-repo pull requests

### DIFF
--- a/lib/columns/plugins/github-prs/client.tsx
+++ b/lib/columns/plugins/github-prs/client.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import {
+  GitMerge,
+  GitPullRequest,
+  GitPullRequestClosed,
+  GitPullRequestDraft,
+  MessageSquareText,
+} from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type GHPRConfig, type GHPRMeta } from "./plugin";
+
+function compact(n: number): string {
+  if (Math.abs(n) < 1000) return String(n);
+  if (Math.abs(n) < 1_000_000)
+    return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+function ConfigForm({ value, onChange }: ConfigFormProps<GHPRConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghpr-repo">Repository</Label>
+        <Input
+          id="ghpr-repo"
+          placeholder="vercel/next.js"
+          value={value.repo}
+          onChange={(e) => onChange({ ...value, repo: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Use the <code>owner/repo</code> form.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>State</Label>
+        <Select
+          value={value.state}
+          onValueChange={(v) =>
+            onChange({ ...value, state: v as GHPRConfig["state"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="open">Open</SelectItem>
+            <SelectItem value="closed">Closed</SelectItem>
+            <SelectItem value="all">All</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Sort</Label>
+        <Select
+          value={value.sort}
+          onValueChange={(v) =>
+            onChange({ ...value, sort: v as GHPRConfig["sort"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="updated">Recently updated</SelectItem>
+            <SelectItem value="created">Recently created</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function StateBadge({ meta: m }: { meta: GHPRMeta }) {
+  if (m.isDraft) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(160, 160, 160, 0.32)" }}
+      >
+        <GitPullRequestDraft className="size-3" />
+        draft
+      </span>
+    );
+  }
+  if (m.state === "merged") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(159, 201, 162, 0.32)" }}
+      >
+        <GitMerge className="size-3" />
+        merged
+      </span>
+    );
+  }
+  if (m.state === "closed") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(214, 138, 138, 0.32)" }}
+      >
+        <GitPullRequestClosed className="size-3" />
+        closed
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+      style={{ backgroundColor: "rgba(159, 201, 162, 0.28)" }}
+    >
+      <GitPullRequest className="size-3" />
+      open
+    </span>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<GHPRMeta>) {
+  const m = item.meta;
+  const [title, ...rest] = item.content.split("\n\n");
+  const snippet = rest.join("\n\n").trim();
+  const handle = item.author.handle ?? item.author.name;
+  const avatarUrl = item.author.avatarUrl;
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        {m && <StateBadge meta={m} />}
+        {avatarUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={avatarUrl}
+            alt=""
+            className="size-4 rounded-full"
+            loading="lazy"
+          />
+        )}
+        <span className="truncate text-foreground/80">{handle}</span>
+        {m && (
+          <span className="tabular-nums text-foreground/70">#{m.number}</span>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {title}
+      </h3>
+      {snippet && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words whitespace-pre-line">
+          {snippet}
+        </p>
+      )}
+      {m && (
+        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11.5px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <MessageSquareText className="size-3.5" />
+            <span className="tabular-nums">{compact(m.commentsCount)}</span>
+          </span>
+          {(m.additions !== undefined || m.deletions !== undefined) && (
+            <span className="flex items-center gap-2 tabular-nums">
+              {m.additions !== undefined && (
+                <span className="text-emerald-700 dark:text-emerald-400">
+                  +{compact(m.additions)}
+                </span>
+              )}
+              {m.deletions !== undefined && (
+                <span className="text-rose-700 dark:text-rose-400">
+                  −{compact(m.deletions)}
+                </span>
+              )}
+            </span>
+          )}
+          <span className="truncate text-foreground/60">
+            {m.headBranch} → {m.baseBranch}
+          </span>
+        </div>
+      )}
+    </a>
+  );
+}
+
+export const column = defineColumnUI<GHPRConfig, GHPRMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-prs/plugin.ts
+++ b/lib/columns/plugins/github-prs/plugin.ts
@@ -1,0 +1,54 @@
+// Dedicated plugin (rather than a "prs" mode in github/) — that plugin already
+// has 4 modes and a per-repo PR feed wants different fields and a focused form.
+
+import { z } from "zod";
+import { GitPullRequest } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  repo: z.string().default(""),
+  state: z.enum(["open", "closed", "all"]).default("open"),
+  sort: z.enum(["created", "updated"]).default("updated"),
+});
+
+export type GHPRConfig = z.infer<typeof schema>;
+
+export interface GHPRMeta {
+  number: number;
+  state: "open" | "closed" | "merged";
+  isDraft: boolean;
+  additions?: number;
+  deletions?: number;
+  changedFiles?: number;
+  baseBranch: string;
+  headBranch: string;
+  commentsCount: number;
+  repo: string;
+  mergedAt?: string;
+}
+
+const STATE_LABEL: Record<GHPRConfig["state"], string> = {
+  open: "open",
+  closed: "closed",
+  all: "all",
+};
+
+export const meta: PluginMeta<GHPRConfig, GHPRMeta> = {
+  id: "github-prs",
+  label: "GitHub PRs",
+  description: "Latest pull requests on a specific GitHub repository.",
+  icon: GitPullRequest,
+  accent: "#26251e",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const repo = c.repo.trim();
+    if (!repo) return "GitHub · PRs";
+    return `PRs · ${repo}${c.state === "open" ? "" : ` (${STATE_LABEL[c.state]})`}`;
+  },
+  capabilities: {
+    paginated: true,
+    rateLimitHint: "60 req/hr without GITHUB_TOKEN, 5000 with",
+  },
+};

--- a/lib/columns/plugins/github-prs/server.ts
+++ b/lib/columns/plugins/github-prs/server.ts
@@ -1,0 +1,27 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchPullRequests } from "@/lib/integrations/github";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type GHPRConfig, type GHPRMeta } from "./plugin";
+
+const fetch: ServerFetcher<GHPRConfig, GHPRMeta> = async (config, cursor) => {
+  const page = cursor ? Number(cursor) || 1 : 1;
+  const items = (await fetchPullRequests(
+    config.repo,
+    config.state,
+    config.sort,
+    PAGE_SIZE,
+    page,
+  )) as FeedItem<GHPRMeta>[];
+  return {
+    items,
+    nextCursor: items.length === PAGE_SIZE ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<GHPRConfig, GHPRMeta>({ meta, fetch });

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -14,6 +14,7 @@ import { meta as newsSearch } from "./news-search/plugin";
 import { meta as reddit } from "./reddit/plugin";
 import { meta as hackerNews } from "./hacker-news/plugin";
 import { meta as github } from "./github/plugin";
+import { meta as githubPrs } from "./github-prs/plugin";
 import { meta as rss } from "./rss/plugin";
 import { meta as googleNews } from "./google-news/plugin";
 import { meta as mentions } from "./mentions/plugin";
@@ -32,6 +33,7 @@ export const PLUGIN_METAS = [
   reddit,
   hackerNews,
   github,
+  githubPrs,
   rss,
   googleNews,
   mentions,

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -22,6 +22,7 @@ import { column as newsSearch } from "@/lib/columns/plugins/news-search/client";
 import { column as reddit } from "@/lib/columns/plugins/reddit/client";
 import { column as hackerNews } from "@/lib/columns/plugins/hacker-news/client";
 import { column as github } from "@/lib/columns/plugins/github/client";
+import { column as githubPrs } from "@/lib/columns/plugins/github-prs/client";
 import { column as rss } from "@/lib/columns/plugins/rss/client";
 import { column as googleNews } from "@/lib/columns/plugins/google-news/client";
 import { column as mentions } from "@/lib/columns/plugins/mentions/client";
@@ -43,6 +44,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   reddit,
   "hacker-news": hackerNews,
   github,
+  "github-prs": githubPrs,
   rss,
   "google-news": googleNews,
   mentions,

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -18,6 +18,7 @@ import { server as newsSearch } from "@/lib/columns/plugins/news-search/server";
 import { server as reddit } from "@/lib/columns/plugins/reddit/server";
 import { server as hackerNews } from "@/lib/columns/plugins/hacker-news/server";
 import { server as github } from "@/lib/columns/plugins/github/server";
+import { server as githubPrs } from "@/lib/columns/plugins/github-prs/server";
 import { server as rss } from "@/lib/columns/plugins/rss/server";
 import { server as googleNews } from "@/lib/columns/plugins/google-news/server";
 import { server as mentions } from "@/lib/columns/plugins/mentions/server";
@@ -36,6 +37,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   reddit,
   "hacker-news": hackerNews,
   github,
+  "github-prs": githubPrs,
   rss,
   "google-news": googleNews,
   mentions,

--- a/lib/integrations/github.ts
+++ b/lib/integrations/github.ts
@@ -52,6 +52,27 @@ interface GHSearchResponse<T> {
   total_count?: number;
 }
 
+interface GHPullRequest {
+  id: number;
+  number: number;
+  title: string;
+  body: string | null;
+  html_url: string;
+  state: "open" | "closed";
+  draft: boolean;
+  created_at: string;
+  updated_at: string;
+  merged_at: string | null;
+  closed_at: string | null;
+  comments?: number;
+  additions?: number;
+  deletions?: number;
+  changed_files?: number;
+  base: { ref: string };
+  head: { ref: string };
+  user?: { login: string; avatar_url?: string } | null;
+}
+
 function headers(): HeadersInit {
   const h: Record<string, string> = {
     accept: "application/vnd.github+json",
@@ -221,6 +242,82 @@ async function fetchIssues(
         comments: i.comments,
       },
     } satisfies FeedItem;
+  });
+}
+
+export interface GHPRItemMeta {
+  number: number;
+  state: "open" | "closed" | "merged";
+  isDraft: boolean;
+  additions?: number;
+  deletions?: number;
+  changedFiles?: number;
+  baseBranch: string;
+  headBranch: string;
+  commentsCount: number;
+  repo: string;
+  mergedAt?: string;
+}
+
+export async function fetchPullRequests(
+  repo: string,
+  state: "open" | "closed" | "all",
+  sort: "created" | "updated",
+  limit: number,
+  page = 1,
+): Promise<FeedItem<GHPRItemMeta>[]> {
+  const clean = repo.trim().replace(/^https?:\/\/github\.com\//, "");
+  if (!/^[\w.-]+\/[\w.-]+$/.test(clean)) {
+    throw new Error(`Invalid repo "${repo}". Use owner/repo (e.g. vercel/next.js).`);
+  }
+  const params = new URLSearchParams({
+    state,
+    sort,
+    direction: "desc",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const prs = await ghFetch<GHPullRequest[]>(
+    `${API}/repos/${clean}/pulls?${params}`,
+  );
+  return prs.slice(0, limit).map((p) => {
+    const user = p.user?.login ?? "anonymous";
+    const merged = p.state === "closed" && !!p.merged_at;
+    const display: GHPRItemMeta["state"] = merged
+      ? "merged"
+      : p.state === "closed"
+        ? "closed"
+        : "open";
+    const body = (p.body ?? "").trim();
+    const trimmed =
+      body.length > 400 ? `${body.slice(0, 400).trimEnd()}…` : body;
+    const sortField = sort === "created" ? p.created_at : p.updated_at;
+    return {
+      id: `pr-${p.id}`,
+      author: {
+        name: user,
+        handle: user,
+        avatarUrl:
+          p.user?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(user)}`,
+      },
+      content: trimmed ? `${p.title}\n\n${trimmed}` : p.title,
+      url: p.html_url,
+      createdAt: sortField,
+      meta: {
+        number: p.number,
+        state: display,
+        isDraft: p.draft,
+        additions: p.additions,
+        deletions: p.deletions,
+        changedFiles: p.changed_files,
+        baseBranch: p.base.ref,
+        headBranch: p.head.ref,
+        commentsCount: p.comments ?? 0,
+        repo: clean,
+        mergedAt: p.merged_at ?? undefined,
+      },
+    } satisfies FeedItem<GHPRItemMeta>;
   });
 }
 


### PR DESCRIPTION
## Summary
- New `github-prs` column plugin watches latest pull requests on a single repo with state (open/closed/all) and sort (created/updated) filters
- Renderer shows state badge (open/merged/closed/draft with appropriate colors), author, #number, branch flow, and +additions/−deletions when GitHub provides them
- Extends `lib/integrations/github.ts` with `fetchPullRequests`; distinguishes merged from closed via `merged_at`. `GITHUB_TOKEN` is optional and upgrades the rate limit (60→5000/hr) when set

## Test plan
- [ ] Add a `github-prs` column for a real repo (e.g. `vercel/next.js`), verify open/closed/all state filters and created/updated sort
- [ ] Confirm merged PRs render with the green merge badge, closed-but-not-merged with the red badge, drafts with grey
- [ ] Click "Load more" and verify page-based pagination
- [ ] Without `GITHUB_TOKEN`, confirm the column still loads (keyless path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)