### PR TITLE
Add github-watchers column for latest stargazers and forks

### DIFF
--- a/lib/columns/plugins/github-watchers/client.tsx
+++ b/lib/columns/plugins/github-watchers/client.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { GitFork, Star } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type GHWatchersConfig, type GHWatchersMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<GHWatchersConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghw-repo">Repository</Label>
+        <Input
+          id="ghw-repo"
+          placeholder="vercel/next.js"
+          value={value.repo}
+          onChange={(e) => onChange({ ...value, repo: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          <code>owner/repo</code> or full GitHub URL.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Show</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as GHWatchersConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="both">Stars &amp; forks</SelectItem>
+            <SelectItem value="stars">Stars only</SelectItem>
+            <SelectItem value="forks">Forks only</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function KindBadge({ kind }: { kind: GHWatchersMeta["kind"] }) {
+  if (kind === "star") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(245, 166, 35, 0.22)" }}
+      >
+        <Star className="size-3" />
+        Starred
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+      style={{ backgroundColor: "rgba(159, 187, 224, 0.32)" }}
+    >
+      <GitFork className="size-3" />
+      Forked
+    </span>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<GHWatchersMeta>) {
+  const m = item.meta;
+  const handle = item.author.handle ?? item.author.name;
+  const repo = m?.repo ?? "";
+  const repoUrl = repo ? `https://github.com/${repo}` : undefined;
+
+  return (
+    <article className="border-b border-border px-3.5 py-3">
+      <div className="flex items-start gap-2.5">
+        {item.author.avatarUrl && (
+          <a
+            href={item.url}
+            target="_blank"
+            rel="noreferrer"
+            className="shrink-0"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={item.author.avatarUrl}
+              alt={handle}
+              className="size-8 rounded-full ring-1 ring-black/5"
+              loading="lazy"
+            />
+          </a>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+            {m && <KindBadge kind={m.kind} />}
+            <a
+              href={item.url}
+              target="_blank"
+              rel="noreferrer"
+              className="truncate font-medium text-foreground/90 hover:text-[color:var(--brand-hover)]"
+            >
+              {handle}
+            </a>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums">
+              <RelativeTime date={item.createdAt} addSuffix />
+            </span>
+          </div>
+          {repo && (
+            <p className="mt-1 text-[13.5px] text-foreground break-words">
+              {m?.kind === "fork" && m.forkUrl ? (
+                <>
+                  forked{" "}
+                  <a
+                    href={repoUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-medium hover:text-[color:var(--brand-hover)]"
+                  >
+                    {repo}
+                  </a>{" "}
+                  →{" "}
+                  <a
+                    href={m.forkUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-foreground/80 hover:text-[color:var(--brand-hover)]"
+                  >
+                    {m.forkUrl.replace(/^https?:\/\/github\.com\//, "")}
+                  </a>
+                </>
+              ) : (
+                <>
+                  starred{" "}
+                  <a
+                    href={repoUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-medium hover:text-[color:var(--brand-hover)]"
+                  >
+                    {repo}
+                  </a>
+                </>
+              )}
+            </p>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export const column = defineColumnUI<GHWatchersConfig, GHWatchersMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-watchers/plugin.ts
+++ b/lib/columns/plugins/github-watchers/plugin.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { Star } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+import type { GHWatcherItemMeta } from "@/lib/integrations/github";
+
+export const schema = z.object({
+  repo: z.string().default(""),
+  mode: z.enum(["stars", "forks", "both"]).default("both"),
+});
+
+export type GHWatchersConfig = z.infer<typeof schema>;
+
+export type GHWatchersMeta = GHWatcherItemMeta;
+
+const MODE_LABEL: Record<GHWatchersConfig["mode"], string> = {
+  stars: "Stars",
+  forks: "Forks",
+  both: "Stars & forks",
+};
+
+export const meta: PluginMeta<GHWatchersConfig, GHWatchersMeta> = {
+  id: "github-watchers",
+  label: "GitHub watchers",
+  description: "Latest stargazers and forks for a GitHub repo.",
+  icon: Star,
+  accent: "#f5a623",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const r = c.repo.trim();
+    return r ? `${MODE_LABEL[c.mode]} · ${r}` : `GitHub · ${MODE_LABEL[c.mode]}`;
+  },
+  capabilities: {
+    paginated: true,
+    rateLimitHint:
+      "60 req/hr without GITHUB_TOKEN, 5000 with. Token also unlocks GraphQL for newest-first stargazers.",
+  },
+};

--- a/lib/columns/plugins/github-watchers/server.ts
+++ b/lib/columns/plugins/github-watchers/server.ts
@@ -1,0 +1,54 @@
+import "server-only";
+
+// GraphQL when GITHUB_TOKEN is present (clean STARRED_AT DESC); REST + Link
+// header walk for newest-first stargazers when keyless. Forks are REST sort=newest.
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { fetchForks, fetchStargazers } from "@/lib/integrations/github";
+import type { GHWatcherItem, GHWatcherItemMeta } from "@/lib/integrations/github";
+import { meta, type GHWatchersConfig } from "./plugin";
+
+const fetch: ServerFetcher<GHWatchersConfig, GHWatcherItemMeta> = async (
+  config,
+  cursor,
+) => {
+  const repo = config.repo.trim();
+  if (!repo) throw new Error("Repository is required (owner/repo).");
+
+  if (config.mode === "stars") {
+    return fetchStargazers(repo, PAGE_SIZE, cursor);
+  }
+  if (config.mode === "forks") {
+    return fetchForks(repo, PAGE_SIZE, cursor);
+  }
+
+  // "both" — fan out, interleave by event time newest-first. No pagination:
+  // stargazer + fork timelines diverge, so a single cursor can't represent
+  // both fairly without duplicates or skips.
+  const [stars, forks] = await Promise.allSettled([
+    fetchStargazers(repo, PAGE_SIZE, undefined),
+    fetchForks(repo, PAGE_SIZE, undefined),
+  ]);
+  const errors: string[] = [];
+  const items: GHWatcherItem[] = [];
+  if (stars.status === "fulfilled") items.push(...stars.value.items);
+  else errors.push(stars.reason instanceof Error ? stars.reason.message : String(stars.reason));
+  if (forks.status === "fulfilled") items.push(...forks.value.items);
+  else errors.push(forks.reason instanceof Error ? forks.reason.message : String(forks.reason));
+
+  if (items.length === 0 && errors.length > 0) {
+    throw new Error(errors.join("\n"));
+  }
+
+  items.sort((a, b) => +new Date(b.createdAt) - +new Date(a.createdAt));
+  return { items };
+};
+
+export const server = defineColumnServer<GHWatchersConfig, GHWatcherItemMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -14,6 +14,7 @@ import { meta as newsSearch } from "./news-search/plugin";
 import { meta as reddit } from "./reddit/plugin";
 import { meta as hackerNews } from "./hacker-news/plugin";
 import { meta as github } from "./github/plugin";
+import { meta as githubWatchers } from "./github-watchers/plugin";
 import { meta as rss } from "./rss/plugin";
 import { meta as googleNews } from "./google-news/plugin";
 import { meta as mentions } from "./mentions/plugin";
@@ -32,6 +33,7 @@ export const PLUGIN_METAS = [
   reddit,
   hackerNews,
   github,
+  githubWatchers,
   rss,
   googleNews,
   mentions,

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -22,6 +22,7 @@ import { column as newsSearch } from "@/lib/columns/plugins/news-search/client";
 import { column as reddit } from "@/lib/columns/plugins/reddit/client";
 import { column as hackerNews } from "@/lib/columns/plugins/hacker-news/client";
 import { column as github } from "@/lib/columns/plugins/github/client";
+import { column as githubWatchers } from "@/lib/columns/plugins/github-watchers/client";
 import { column as rss } from "@/lib/columns/plugins/rss/client";
 import { column as googleNews } from "@/lib/columns/plugins/google-news/client";
 import { column as mentions } from "@/lib/columns/plugins/mentions/client";
@@ -43,6 +44,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   reddit,
   "hacker-news": hackerNews,
   github,
+  "github-watchers": githubWatchers,
   rss,
   "google-news": googleNews,
   mentions,

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -18,6 +18,7 @@ import { server as newsSearch } from "@/lib/columns/plugins/news-search/server";
 import { server as reddit } from "@/lib/columns/plugins/reddit/server";
 import { server as hackerNews } from "@/lib/columns/plugins/hacker-news/server";
 import { server as github } from "@/lib/columns/plugins/github/server";
+import { server as githubWatchers } from "@/lib/columns/plugins/github-watchers/server";
 import { server as rss } from "@/lib/columns/plugins/rss/server";
 import { server as googleNews } from "@/lib/columns/plugins/google-news/server";
 import { server as mentions } from "@/lib/columns/plugins/mentions/server";
@@ -36,6 +37,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   reddit,
   "hacker-news": hackerNews,
   github,
+  "github-watchers": githubWatchers,
   rss,
   "google-news": googleNews,
   mentions,

--- a/lib/integrations/github.ts
+++ b/lib/integrations/github.ts
@@ -244,3 +244,286 @@ export async function fetchGitHub(
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// Stargazers + forks (used by the github-watchers plugin)
+// ---------------------------------------------------------------------------
+
+export interface GHWatcherItemMeta {
+  kind: "star" | "fork";
+  repo: string;
+  forkUrl?: string;
+  starredAt?: string;
+  forkedAt?: string;
+}
+
+export type GHWatcherItem = FeedItem<GHWatcherItemMeta>;
+
+export interface GHWatcherPage {
+  items: GHWatcherItem[];
+  nextCursor?: string;
+}
+
+export function normalizeGitHubRepo(input: string): string {
+  const clean = input
+    .trim()
+    .replace(/^https?:\/\//, "")
+    .replace(/^github\.com\//, "")
+    .replace(/\/+$/, "");
+  if (!/^[\w.-]+\/[\w.-]+$/.test(clean)) {
+    throw new Error(
+      `Invalid repo "${input}". Use owner/repo (e.g. vercel/next.js).`,
+    );
+  }
+  return clean;
+}
+
+function parseLastPage(linkHeader: string | null): number | undefined {
+  if (!linkHeader) return undefined;
+  // Link: <...&page=42>; rel="last", <...&page=2>; rel="next"
+  for (const part of linkHeader.split(",")) {
+    const m = /<([^>]+)>;\s*rel="last"/.exec(part.trim());
+    if (m) {
+      try {
+        const u = new URL(m[1]);
+        const p = u.searchParams.get("page");
+        if (p) return Number(p);
+      } catch {
+        // ignore
+      }
+    }
+  }
+  return undefined;
+}
+
+interface GHStargazerEdgeREST {
+  starred_at: string;
+  user: { login: string; avatar_url?: string; html_url?: string };
+}
+
+async function ghFetchStargazersPageREST(
+  fullRepo: string,
+  page: number,
+  perPage: number,
+): Promise<{ items: GHWatcherItem[]; lastPage?: number }> {
+  const params = new URLSearchParams({
+    per_page: String(perPage),
+    page: String(page),
+  });
+  const url = `${API}/repos/${fullRepo}/stargazers?${params}`;
+  const res = await fetch(url, {
+    headers: {
+      ...headers(),
+      // star+json is required to receive `starred_at` timestamps.
+      accept: "application/vnd.github.star+json",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const lastPage = parseLastPage(res.headers.get("link"));
+  const json = (await res.json()) as GHStargazerEdgeREST[];
+  const items = json.map((edge) => {
+    const u = edge.user;
+    return {
+      id: `gh-star-${fullRepo}-${u.login}`,
+      author: {
+        name: u.login,
+        handle: u.login,
+        avatarUrl:
+          u.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(u.login)}`,
+      },
+      content: `${u.login} starred ${fullRepo}`,
+      url: u.html_url ?? `https://github.com/${u.login}`,
+      createdAt: edge.starred_at,
+      meta: {
+        kind: "star",
+        repo: fullRepo,
+        starredAt: edge.starred_at,
+      },
+    } satisfies GHWatcherItem;
+  });
+  return { items, lastPage };
+}
+
+interface GHGraphQLStargazersResponse {
+  data?: {
+    repository: {
+      stargazers: {
+        pageInfo: { endCursor: string | null; hasNextPage: boolean };
+        edges: Array<{
+          starredAt: string;
+          node: { login: string; avatarUrl?: string; url?: string };
+        }>;
+      } | null;
+    } | null;
+  };
+  errors?: Array<{ message: string }>;
+}
+
+async function fetchStargazersGraphQL(
+  fullRepo: string,
+  limit: number,
+  cursor?: string,
+): Promise<GHWatcherPage> {
+  const [owner, name] = fullRepo.split("/");
+  const query = `
+    query($owner:String!, $name:String!, $first:Int!, $after:String) {
+      repository(owner:$owner, name:$name) {
+        stargazers(first:$first, after:$after, orderBy:{field:STARRED_AT, direction:DESC}) {
+          pageInfo { endCursor hasNextPage }
+          edges {
+            starredAt
+            node { login avatarUrl url }
+          }
+        }
+      }
+    }
+  `;
+  const res = await fetch(`${API}/graphql`, {
+    method: "POST",
+    headers: { ...headers(), "content-type": "application/json" },
+    body: JSON.stringify({
+      query,
+      variables: { owner, name, first: limit, after: cursor ?? null },
+    }),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub GraphQL ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as GHGraphQLStargazersResponse;
+  if (json.errors?.length) {
+    throw new Error(json.errors.map((e) => e.message).join("; "));
+  }
+  const sg = json.data?.repository?.stargazers;
+  if (!sg) throw new Error(`Repository ${fullRepo} not found.`);
+  const items = sg.edges.map((edge) => {
+    const u = edge.node;
+    return {
+      id: `gh-star-${fullRepo}-${u.login}`,
+      author: {
+        name: u.login,
+        handle: u.login,
+        avatarUrl:
+          u.avatarUrl ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(u.login)}`,
+      },
+      content: `${u.login} starred ${fullRepo}`,
+      url: u.url ?? `https://github.com/${u.login}`,
+      createdAt: edge.starredAt,
+      meta: {
+        kind: "star",
+        repo: fullRepo,
+        starredAt: edge.starredAt,
+      },
+    } satisfies GHWatcherItem;
+  });
+  return {
+    items,
+    nextCursor:
+      sg.pageInfo.hasNextPage && sg.pageInfo.endCursor
+        ? `gql:${sg.pageInfo.endCursor}`
+        : undefined,
+  };
+}
+
+async function fetchStargazersREST(
+  fullRepo: string,
+  limit: number,
+  cursor?: string,
+): Promise<GHWatcherPage> {
+  // REST sorts oldest-first. To surface newest-first we must walk the Link
+  // header to find the last page, then page backwards from there.
+  let pageToFetch: number;
+  if (cursor) {
+    pageToFetch = Number(cursor);
+    if (!Number.isFinite(pageToFetch) || pageToFetch < 1) {
+      return { items: [] };
+    }
+  } else {
+    const probe = await ghFetchStargazersPageREST(fullRepo, 1, limit);
+    pageToFetch = probe.lastPage ?? 1;
+  }
+  const { items } = await ghFetchStargazersPageREST(
+    fullRepo,
+    pageToFetch,
+    limit,
+  );
+  items.reverse();
+  return {
+    items,
+    nextCursor: pageToFetch > 1 ? String(pageToFetch - 1) : undefined,
+  };
+}
+
+export async function fetchStargazers(
+  repo: string,
+  limit = 12,
+  cursor?: string,
+): Promise<GHWatcherPage> {
+  const fullRepo = normalizeGitHubRepo(repo);
+  if (process.env.GITHUB_TOKEN) {
+    return fetchStargazersGraphQL(
+      fullRepo,
+      limit,
+      cursor?.startsWith("gql:") ? cursor.slice(4) : undefined,
+    );
+  }
+  return fetchStargazersREST(fullRepo, limit, cursor);
+}
+
+interface GHForkREST {
+  id: number;
+  full_name: string;
+  html_url: string;
+  created_at: string;
+  owner?: { login: string; avatar_url?: string; html_url?: string };
+}
+
+export async function fetchForks(
+  repo: string,
+  limit = 12,
+  cursor?: string,
+): Promise<GHWatcherPage> {
+  const fullRepo = normalizeGitHubRepo(repo);
+  const page = cursor ? Number(cursor) || 1 : 1;
+  const params = new URLSearchParams({
+    sort: "newest",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const forks = await ghFetch<GHForkREST[]>(
+    `${API}/repos/${fullRepo}/forks?${params}`,
+  );
+  const items: GHWatcherItem[] = forks.map((f) => {
+    const owner = f.owner?.login ?? f.full_name.split("/")[0] ?? "github";
+    return {
+      id: `gh-fork-${f.id}`,
+      author: {
+        name: owner,
+        handle: owner,
+        avatarUrl:
+          f.owner?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(owner)}`,
+      },
+      content: `${owner} forked ${fullRepo}`,
+      url: f.owner?.html_url ?? `https://github.com/${owner}`,
+      createdAt: f.created_at,
+      meta: {
+        kind: "fork",
+        repo: fullRepo,
+        forkUrl: f.html_url,
+        forkedAt: f.created_at,
+      },
+    };
+  });
+  return {
+    items,
+    nextCursor: items.length === limit ? String(page + 1) : undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- New `github-watchers` column type: latest stargazers and forks for any GitHub repo, with a `stars` / `forks` / `both` mode toggle.
- Uses GitHub GraphQL with `STARRED_AT DESC` when `GITHUB_TOKEN` is set; falls back to REST + `Link` header walk for newest-first stargazers when keyless. Forks use REST `?sort=newest`.
- `both` mode fans out via `Promise.allSettled` and interleaves by event time newest-first (no cursor — divergent timelines).
- Keyless out of the box (60 req/hr); upgrades to 5000/hr + GraphQL when `GITHUB_TOKEN` is set.

## Files
- `lib/columns/plugins/github-watchers/{plugin,server,client}.tsx` — full plugin contract.
- `lib/integrations/github.ts` — adds `normalizeGitHubRepo`, `fetchStargazers`, `fetchForks`.
- `manifest.ts`, `registry.ts`, `server-registry.ts` — registration.

## Test plan
- [x] `npm run build` clean (TypeScript + parity check pass).
- [x] `npx eslint` clean on changed files.
- [ ] Add the column with `vercel/next.js` and `mode = both`, confirm interleaved stars + forks.
- [ ] Toggle `mode = stars` and click Load more — verify newest-first ordering and pagination, both keyless and with `GITHUB_TOKEN`.
- [ ] Toggle `mode = forks` and click Load more — verify newest-first.
- [ ] Try a repo with no forks / few stars and a private/missing repo — verify error surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)