### PR TITLE
Merge 15 column plugins (consolidates #4–#18)

### DIFF
--- a/lib/columns/plugins/app-reviews/client.tsx
+++ b/lib/columns/plugins/app-reviews/client.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { Star } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import {
+  meta,
+  type AppReviewsConfig,
+  type AppReviewsItemMeta,
+} from "./plugin";
+
+const PLATFORM_LABEL: Record<AppReviewsItemMeta["platform"], string> = {
+  "app-store": "App Store",
+  "google-play": "Google Play",
+};
+
+const PLATFORM_BG: Record<AppReviewsItemMeta["platform"], string> = {
+  "app-store": "rgba(0, 122, 255, 0.18)",
+  "google-play": "rgba(52, 168, 83, 0.18)",
+};
+
+function ConfigForm({ value, onChange }: ConfigFormProps<AppReviewsConfig>) {
+  const showAppleHint = value.platform !== "google-play";
+  const showPlayHint = value.platform !== "app-store";
+
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Platform</Label>
+        <Select
+          value={value.platform}
+          onValueChange={(v) =>
+            onChange({ ...value, platform: v as AppReviewsConfig["platform"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="app-store">App Store (iOS)</SelectItem>
+            <SelectItem value="google-play">Google Play (Android)</SelectItem>
+            <SelectItem value="both">Both (interleaved)</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="app-reviews-id">App ID</Label>
+        <Input
+          id="app-reviews-id"
+          placeholder={
+            value.platform === "google-play"
+              ? "com.spotify.music"
+              : "284882215"
+          }
+          value={value.appId}
+          onChange={(e) => onChange({ ...value, appId: e.target.value })}
+        />
+        <div className="text-xs text-muted-foreground space-y-0.5">
+          {showAppleHint && (
+            <p>
+              <span className="font-medium text-foreground">App Store:</span>{" "}
+              numeric ID from the URL —{" "}
+              <code>apps.apple.com/.../id</code>
+              <code className="text-foreground">284882215</code>.
+            </p>
+          )}
+          {showPlayHint && (
+            <p>
+              <span className="font-medium text-foreground">Google Play:</span>{" "}
+              package ID from the URL —{" "}
+              <code>play.google.com/store/apps/details?id=</code>
+              <code className="text-foreground">com.spotify.music</code>.
+            </p>
+          )}
+          {value.platform === "both" && (
+            <p className="pt-1">
+              For <span className="font-medium">Both</span>, enter the same
+              app&apos;s ID in whichever store you opened first — the platform
+              the ID matches will be queried, the other skipped.
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="app-reviews-country">Country</Label>
+        <Input
+          id="app-reviews-country"
+          placeholder="us"
+          maxLength={2}
+          value={value.country}
+          onChange={(e) =>
+            onChange({ ...value, country: e.target.value.toLowerCase() })
+          }
+        />
+        <p className="text-xs text-muted-foreground">
+          Two-letter country code. Defaults to <code>us</code>.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function Stars({ rating }: { rating: number }) {
+  const clamped = Math.max(0, Math.min(5, Math.round(rating)));
+  return (
+    <span className="inline-flex items-center gap-0.5" aria-label={`${clamped} of 5 stars`}>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Star
+          key={i}
+          className={`size-3.5 ${i < clamped ? "fill-amber-400 text-amber-400" : "text-muted-foreground/40"}`}
+          strokeWidth={1.5}
+        />
+      ))}
+    </span>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<AppReviewsItemMeta>) {
+  const m = item.meta;
+  const platform = m?.platform ?? "app-store";
+  const platformLabel = PLATFORM_LABEL[platform];
+  const bg = PLATFORM_BG[platform];
+  const rating = m?.rating ?? 0;
+  const version = m?.version;
+  const title = m?.title;
+  const reviewer = item.author.name || "Anonymous";
+
+  // Body content — strip the optional title prefix added by the integration.
+  const body = title && item.content.startsWith(`${title}\n\n`)
+    ? item.content.slice(title.length + 2)
+    : item.content;
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: bg }}
+        >
+          {platformLabel}
+        </span>
+        <Stars rating={rating} />
+        <span className="text-foreground/90">{reviewer}</span>
+        {version && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums">v{version}</span>
+          </>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      {title && (
+        <h3
+          className="mt-1 font-serif text-[15px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+          style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+        >
+          {title}
+        </h3>
+      )}
+      {body && (
+        <p className="mt-1 text-[13px] leading-snug text-foreground/85 break-words whitespace-pre-line">
+          {body}
+        </p>
+      )}
+    </a>
+  );
+}
+
+export const column = defineColumnUI<AppReviewsConfig, AppReviewsItemMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/app-reviews/plugin.ts
+++ b/lib/columns/plugins/app-reviews/plugin.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { Star } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  platform: z.enum(["app-store", "google-play", "both"]).default("app-store"),
+  appId: z.string().default(""),
+  country: z.string().default("us"),
+});
+
+export type AppReviewsConfig = z.infer<typeof schema>;
+
+export interface AppReviewsItemMeta {
+  rating: number;
+  version?: string;
+  country: string;
+  platform: "app-store" | "google-play";
+  title?: string;
+  thumbsUp?: number;
+}
+
+export const meta: PluginMeta<AppReviewsConfig, AppReviewsItemMeta> = {
+  id: "app-reviews",
+  label: "App reviews",
+  description: "Latest App Store and/or Google Play reviews for an app.",
+  icon: Star,
+  accent: "#f5a623",
+  category: "other",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const id = c.appId.trim();
+    if (!id) return "App reviews";
+    const label =
+      c.platform === "app-store"
+        ? "App Store"
+        : c.platform === "google-play"
+          ? "Google Play"
+          : "Reviews";
+    return `${label} · ${id}`;
+  },
+  capabilities: {
+    rateLimitHint:
+      "App Store uses Apple's public RSS; Google Play uses the public store endpoint. No keys required.",
+  },
+};

--- a/lib/columns/plugins/app-reviews/server.ts
+++ b/lib/columns/plugins/app-reviews/server.ts
@@ -1,0 +1,82 @@
+import "server-only";
+
+// Keyless by default — Apple's iTunes RSS for App Store, public batchexecute scrape for Google Play. Env-gated upgrade paths live behind `fetchReviews()`.
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchReviews } from "@/lib/integrations/app-reviews";
+import {
+  meta,
+  type AppReviewsConfig,
+  type AppReviewsItemMeta,
+} from "./plugin";
+
+const fetch: ServerFetcher<AppReviewsConfig, AppReviewsItemMeta> = async (
+  config,
+) => {
+  const appId = config.appId.trim();
+  if (!appId) throw new Error("App ID is required.");
+  const country = (config.country.trim() || "us").toLowerCase();
+
+  if (config.platform !== "both") {
+    const items = (await fetchReviews(
+      config.platform,
+      appId,
+      country,
+    )) as FeedItem<AppReviewsItemMeta>[];
+    items.sort((a, b) => +new Date(b.createdAt) - +new Date(a.createdAt));
+    return { items };
+  }
+
+  // "both" — fan out to both stores, dedupe by id, sort newest first.
+  const isNumeric = /^\d+$/.test(appId);
+  const tasks: Promise<FeedItem<AppReviewsItemMeta>[]>[] = [];
+  if (isNumeric) {
+    tasks.push(
+      fetchReviews("app-store", appId, country) as Promise<
+        FeedItem<AppReviewsItemMeta>[]
+      >,
+    );
+  }
+  if (!isNumeric || appId.includes(".")) {
+    tasks.push(
+      fetchReviews("google-play", appId, country) as Promise<
+        FeedItem<AppReviewsItemMeta>[]
+      >,
+    );
+  }
+  if (tasks.length === 0) {
+    throw new Error(
+      'For "both", provide a numeric App Store ID or a Play package ID like com.example.app.',
+    );
+  }
+
+  const settled = await Promise.allSettled(tasks);
+  const errors: string[] = [];
+  const all: FeedItem<AppReviewsItemMeta>[] = [];
+  for (const r of settled) {
+    if (r.status === "fulfilled") all.push(...r.value);
+    else errors.push(r.reason instanceof Error ? r.reason.message : String(r.reason));
+  }
+  if (all.length === 0 && errors.length > 0) {
+    throw new Error(`All sources failed:\n${errors.join("\n")}`);
+  }
+
+  const seen = new Set<string>();
+  const deduped: FeedItem<AppReviewsItemMeta>[] = [];
+  for (const it of all) {
+    if (seen.has(it.id)) continue;
+    seen.add(it.id);
+    deduped.push(it);
+  }
+  deduped.sort((a, b) => +new Date(b.createdAt) - +new Date(a.createdAt));
+  return { items: deduped };
+};
+
+export const server = defineColumnServer<AppReviewsConfig, AppReviewsItemMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/facebook/client.tsx
+++ b/lib/columns/plugins/facebook/client.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LinkItem } from "@/lib/columns/shared/link-renderer";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type FacebookConfig, type FacebookMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<FacebookConfig>) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="fb-q">Keyword or URL</Label>
+      <Input
+        id="fb-q"
+        placeholder="anthropic.com, claude code, https://..."
+        value={value.query}
+        onChange={(e) => onChange({ query: e.target.value })}
+      />
+      <p className="text-xs text-muted-foreground">
+        Searches public facebook.com posts and pages for mentions. URLs and
+        keywords both work.
+      </p>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<FacebookMeta>) {
+  return (
+    <LinkItem
+      item={item}
+      badgeLabel="Facebook"
+      badgeClass="bg-[#1877F2]/15 text-foreground ring-1 ring-black/5"
+    />
+  );
+}
+
+export const column = defineColumnUI<FacebookConfig, FacebookMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/facebook/plugin.ts
+++ b/lib/columns/plugins/facebook/plugin.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { ThumbsUp } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+});
+
+export type FacebookConfig = z.infer<typeof schema>;
+
+export interface FacebookMeta {
+  source: string;
+  kind: "web" | "news";
+}
+
+export const meta: PluginMeta<FacebookConfig, FacebookMeta> = {
+  id: "facebook",
+  label: "Facebook mentions",
+  description:
+    "Watch public Facebook posts and pages for mentions of a keyword or URL.",
+  icon: ThumbsUp,
+  accent: "#1877F2",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `Facebook · ${c.query.trim()}` : "Facebook mentions",
+  capabilities: { requiresEnv: ["XAI_API_KEY"] },
+};

--- a/lib/columns/plugins/facebook/server.ts
+++ b/lib/columns/plugins/facebook/server.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+// Facebook's Graph API has no public mention search and aggressively blocks
+// anonymous scraping, so we piggyback on Grok's web_search with a
+// site:facebook.com filter — no extra env beyond XAI_API_KEY.
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { grokFacebookSearch } from "@/lib/integrations/xai";
+import { meta, type FacebookConfig, type FacebookMeta } from "./plugin";
+
+const fetch: ServerFetcher<FacebookConfig, FacebookMeta> = async (config) => {
+  const items = (await grokFacebookSearch(config.query)) as FeedItem<FacebookMeta>[];
+  return { items };
+};
+
+export const server = defineColumnServer<FacebookConfig, FacebookMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/github-backlinks/client.tsx
+++ b/lib/columns/plugins/github-backlinks/client.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import {
+  meta,
+  type BacklinksConfig,
+  type BacklinkSource,
+  type BacklinksItemMeta,
+} from "./plugin";
+
+const SOURCE_LABEL: Record<BacklinkSource, string> = {
+  hn: "HN",
+  reddit: "Reddit",
+  "google-news": "Google",
+  "bing-news": "Bing",
+  github: "GitHub",
+  web: "Web",
+};
+
+const SOURCE_BG: Record<BacklinkSource, string> = {
+  hn: "rgba(255, 102, 0, 0.18)",
+  reddit: "rgba(245, 78, 0, 0.18)",
+  "google-news": "rgba(159, 201, 162, 0.32)",
+  "bing-news": "rgba(159, 187, 224, 0.32)",
+  github: "rgba(38, 37, 30, 0.16)",
+  web: "rgba(192, 168, 221, 0.32)",
+};
+
+function ConfigForm({ value, onChange }: ConfigFormProps<BacklinksConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghbl-repo">Repository</Label>
+        <Input
+          id="ghbl-repo"
+          placeholder="vercel/next.js or https://github.com/vercel/next.js"
+          value={value.repo}
+          onChange={(e) => onChange({ ...value, repo: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Watches HN, Reddit, Google News, and Bing News for posts linking to
+          this repo. Dedupes by canonical URL.
+        </p>
+      </div>
+      <label className="flex items-start gap-2 text-sm">
+        <input
+          type="checkbox"
+          className="mt-0.5 size-3.5 accent-foreground"
+          checked={value.includeIssues}
+          onChange={(e) =>
+            onChange({ ...value, includeIssues: e.target.checked })
+          }
+        />
+        <span>
+          <span className="font-medium">Include GitHub issues / PRs</span>
+          <span className="block text-xs text-muted-foreground">
+            Issues and PRs in other repos that reference this repo.
+          </span>
+        </span>
+      </label>
+      <label className="flex items-start gap-2 text-sm">
+        <input
+          type="checkbox"
+          className="mt-0.5 size-3.5 accent-foreground"
+          checked={value.includeWebSearch}
+          onChange={(e) =>
+            onChange({ ...value, includeWebSearch: e.target.checked })
+          }
+        />
+        <span>
+          <span className="font-medium">Include web search</span>
+          <span className="block text-xs text-muted-foreground">
+            Catches blog posts, Substack, etc. via Grok. Requires{" "}
+            <code>XAI_API_KEY</code>.
+          </span>
+        </span>
+      </label>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<BacklinksItemMeta>) {
+  const source = item.meta?.source ?? "web";
+  const sourceLabel = SOURCE_LABEL[source] ?? source;
+  const bg = SOURCE_BG[source] ?? "rgba(0,0,0,0.06)";
+
+  const [title, ...rest] = item.content.split("\n\n");
+  const snippet = rest.join("\n\n").trim();
+  const hostName = (() => {
+    try {
+      return new URL(item.url ?? "").hostname.replace(/^www\./, "");
+    } catch {
+      return "";
+    }
+  })();
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: bg }}
+        >
+          {sourceLabel}
+        </span>
+        {hostName && (
+          <span className="truncate max-w-[200px] text-foreground/80">
+            {hostName}
+          </span>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {title}
+      </h3>
+      {snippet && (
+        <p className="mt-1 line-clamp-2 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {snippet}
+        </p>
+      )}
+    </a>
+  );
+}
+
+export const column = defineColumnUI<BacklinksConfig, BacklinksItemMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-backlinks/plugin.ts
+++ b/lib/columns/plugins/github-backlinks/plugin.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { Link2 } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  repo: z.string().default(""),
+  includeIssues: z.boolean().default(true),
+  includeWebSearch: z.boolean().default(false),
+});
+
+export type BacklinksConfig = z.infer<typeof schema>;
+
+export type BacklinkSource =
+  | "hn"
+  | "reddit"
+  | "google-news"
+  | "bing-news"
+  | "github"
+  | "web";
+
+export interface BacklinksItemMeta {
+  source: BacklinkSource;
+  canonicalUrl: string;
+}
+
+export const meta: PluginMeta<BacklinksConfig, BacklinksItemMeta> = {
+  id: "github-backlinks",
+  label: "GitHub backlinks",
+  description:
+    "Find pages, posts, and issues across the web that link to a GitHub repo.",
+  icon: Link2,
+  accent: "#5e6dc7",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const t = c.repo.trim();
+    return t ? `Backlinks · ${t.replace(/^https?:\/\/github\.com\//i, "")}` : "GitHub backlinks";
+  },
+};

--- a/lib/columns/plugins/github-backlinks/server.ts
+++ b/lib/columns/plugins/github-backlinks/server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchBacklinks } from "@/lib/integrations/github-backlinks";
+import {
+  meta,
+  type BacklinksConfig,
+  type BacklinksItemMeta,
+} from "./plugin";
+
+// Fan-out across HN (URL-indexed), Reddit search, Google News, Bing News,
+// optionally GitHub issue search and Grok web search; dedup on canonical URL.
+const fetch: ServerFetcher<BacklinksConfig, BacklinksItemMeta> = async (
+  config,
+) => {
+  const items = (await fetchBacklinks({
+    repo: config.repo,
+    includeIssues: config.includeIssues,
+    includeWebSearch: config.includeWebSearch,
+  })) as FeedItem<BacklinksItemMeta>[];
+  return { items };
+};
+
+export const server = defineColumnServer<BacklinksConfig, BacklinksItemMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/github-prs/client.tsx
+++ b/lib/columns/plugins/github-prs/client.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import {
+  GitMerge,
+  GitPullRequest,
+  GitPullRequestClosed,
+  GitPullRequestDraft,
+  MessageSquareText,
+} from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type GHPRConfig, type GHPRMeta } from "./plugin";
+
+function compact(n: number): string {
+  if (Math.abs(n) < 1000) return String(n);
+  if (Math.abs(n) < 1_000_000)
+    return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+function ConfigForm({ value, onChange }: ConfigFormProps<GHPRConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghpr-repo">Repository</Label>
+        <Input
+          id="ghpr-repo"
+          placeholder="vercel/next.js"
+          value={value.repo}
+          onChange={(e) => onChange({ ...value, repo: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Use the <code>owner/repo</code> form.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>State</Label>
+        <Select
+          value={value.state}
+          onValueChange={(v) =>
+            onChange({ ...value, state: v as GHPRConfig["state"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="open">Open</SelectItem>
+            <SelectItem value="closed">Closed</SelectItem>
+            <SelectItem value="all">All</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Sort</Label>
+        <Select
+          value={value.sort}
+          onValueChange={(v) =>
+            onChange({ ...value, sort: v as GHPRConfig["sort"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="updated">Recently updated</SelectItem>
+            <SelectItem value="created">Recently created</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function StateBadge({ meta: m }: { meta: GHPRMeta }) {
+  if (m.isDraft) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(160, 160, 160, 0.32)" }}
+      >
+        <GitPullRequestDraft className="size-3" />
+        draft
+      </span>
+    );
+  }
+  if (m.state === "merged") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(159, 201, 162, 0.32)" }}
+      >
+        <GitMerge className="size-3" />
+        merged
+      </span>
+    );
+  }
+  if (m.state === "closed") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(214, 138, 138, 0.32)" }}
+      >
+        <GitPullRequestClosed className="size-3" />
+        closed
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+      style={{ backgroundColor: "rgba(159, 201, 162, 0.28)" }}
+    >
+      <GitPullRequest className="size-3" />
+      open
+    </span>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<GHPRMeta>) {
+  const m = item.meta;
+  const [title, ...rest] = item.content.split("\n\n");
+  const snippet = rest.join("\n\n").trim();
+  const handle = item.author.handle ?? item.author.name;
+  const avatarUrl = item.author.avatarUrl;
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        {m && <StateBadge meta={m} />}
+        {avatarUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={avatarUrl}
+            alt=""
+            className="size-4 rounded-full"
+            loading="lazy"
+          />
+        )}
+        <span className="truncate text-foreground/80">{handle}</span>
+        {m && (
+          <span className="tabular-nums text-foreground/70">#{m.number}</span>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {title}
+      </h3>
+      {snippet && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words whitespace-pre-line">
+          {snippet}
+        </p>
+      )}
+      {m && (
+        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11.5px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <MessageSquareText className="size-3.5" />
+            <span className="tabular-nums">{compact(m.commentsCount)}</span>
+          </span>
+          {(m.additions !== undefined || m.deletions !== undefined) && (
+            <span className="flex items-center gap-2 tabular-nums">
+              {m.additions !== undefined && (
+                <span className="text-emerald-700 dark:text-emerald-400">
+                  +{compact(m.additions)}
+                </span>
+              )}
+              {m.deletions !== undefined && (
+                <span className="text-rose-700 dark:text-rose-400">
+                  −{compact(m.deletions)}
+                </span>
+              )}
+            </span>
+          )}
+          <span className="truncate text-foreground/60">
+            {m.headBranch} → {m.baseBranch}
+          </span>
+        </div>
+      )}
+    </a>
+  );
+}
+
+export const column = defineColumnUI<GHPRConfig, GHPRMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-prs/plugin.ts
+++ b/lib/columns/plugins/github-prs/plugin.ts
@@ -1,0 +1,54 @@
+// Dedicated plugin (rather than a "prs" mode in github/) — that plugin already
+// has 4 modes and a per-repo PR feed wants different fields and a focused form.
+
+import { z } from "zod";
+import { GitPullRequest } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  repo: z.string().default(""),
+  state: z.enum(["open", "closed", "all"]).default("open"),
+  sort: z.enum(["created", "updated"]).default("updated"),
+});
+
+export type GHPRConfig = z.infer<typeof schema>;
+
+export interface GHPRMeta {
+  number: number;
+  state: "open" | "closed" | "merged";
+  isDraft: boolean;
+  additions?: number;
+  deletions?: number;
+  changedFiles?: number;
+  baseBranch: string;
+  headBranch: string;
+  commentsCount: number;
+  repo: string;
+  mergedAt?: string;
+}
+
+const STATE_LABEL: Record<GHPRConfig["state"], string> = {
+  open: "open",
+  closed: "closed",
+  all: "all",
+};
+
+export const meta: PluginMeta<GHPRConfig, GHPRMeta> = {
+  id: "github-prs",
+  label: "GitHub PRs",
+  description: "Latest pull requests on a specific GitHub repository.",
+  icon: GitPullRequest,
+  accent: "#26251e",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const repo = c.repo.trim();
+    if (!repo) return "GitHub · PRs";
+    return `PRs · ${repo}${c.state === "open" ? "" : ` (${STATE_LABEL[c.state]})`}`;
+  },
+  capabilities: {
+    paginated: true,
+    rateLimitHint: "60 req/hr without GITHUB_TOKEN, 5000 with",
+  },
+};

--- a/lib/columns/plugins/github-prs/server.ts
+++ b/lib/columns/plugins/github-prs/server.ts
@@ -1,0 +1,27 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchPullRequests } from "@/lib/integrations/github";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type GHPRConfig, type GHPRMeta } from "./plugin";
+
+const fetch: ServerFetcher<GHPRConfig, GHPRMeta> = async (config, cursor) => {
+  const page = cursor ? Number(cursor) || 1 : 1;
+  const items = (await fetchPullRequests(
+    config.repo,
+    config.state,
+    config.sort,
+    PAGE_SIZE,
+    page,
+  )) as FeedItem<GHPRMeta>[];
+  return {
+    items,
+    nextCursor: items.length === PAGE_SIZE ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<GHPRConfig, GHPRMeta>({ meta, fetch });

--- a/lib/columns/plugins/github-search/client.tsx
+++ b/lib/columns/plugins/github-search/client.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import {
+  CircleDot,
+  FileCode2,
+  GitBranch,
+  GitCommit,
+  GitMerge,
+  GitPullRequest,
+  MessageSquareText,
+  Star,
+} from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type GHSearchConfig, type GHSearchMeta } from "./plugin";
+
+function compact(n: number): string {
+  if (Math.abs(n) < 1000) return String(n);
+  if (Math.abs(n) < 1_000_000)
+    return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+function ConfigForm({ value, onChange }: ConfigFormProps<GHSearchConfig>) {
+  const isUrl = /^https?:\/\//i.test(value.query.trim());
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Scope</Label>
+        <Select
+          value={value.scope}
+          onValueChange={(v) =>
+            onChange({ ...value, scope: v as GHSearchConfig["scope"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="repositories">Repositories</SelectItem>
+            <SelectItem value="issues">Issues / PRs</SelectItem>
+            <SelectItem value="code">Code</SelectItem>
+            <SelectItem value="commits">Commits</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghs-q">Keyword or URL</Label>
+        <Input
+          id="ghs-q"
+          placeholder='"yourdomain.com", "your-product", or any GitHub query'
+          value={value.query}
+          onChange={(e) => onChange({ ...value, query: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          {isUrl
+            ? "URL will be auto-quoted for an exact match."
+            : "Quote phrases for exact match. Full GitHub search syntax (org:, repo:, language:, path:, is:open, ...) is supported."}
+        </p>
+      </div>
+
+      {value.scope === "code" && (
+        <p className="rounded-md border border-border bg-surface/40 px-3 py-2 text-[11.5px] text-muted-foreground">
+          Code search requires{" "}
+          <code className="rounded bg-foreground/[0.06] px-1 py-px text-foreground/90">
+            GITHUB_TOKEN
+          </code>{" "}
+          in your env. Other scopes work without one.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ScopeBadge({ m }: { m: GHSearchMeta }) {
+  if (m.scope === "issues") {
+    const state = m.state ?? "open";
+    const Icon =
+      m.isPr ? (state === "closed" ? GitMerge : GitPullRequest) : CircleDot;
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{
+          backgroundColor:
+            state === "closed"
+              ? "rgba(192, 168, 221, 0.32)"
+              : "rgba(223, 168, 143, 0.28)",
+        }}
+      >
+        <Icon className="size-3" />
+        {m.isPr ? "PR" : "issue"}
+      </span>
+    );
+  }
+  if (m.scope === "code") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(159, 187, 224, 0.32)" }}
+      >
+        <FileCode2 className="size-3" />
+        code
+      </span>
+    );
+  }
+  if (m.scope === "commits") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(159, 201, 162, 0.28)" }}
+      >
+        <GitCommit className="size-3" />
+        commit
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+      style={{ backgroundColor: "rgba(159, 187, 224, 0.32)" }}
+    >
+      <GitBranch className="size-3" />
+      repo
+    </span>
+  );
+}
+
+function MetaRow({ m }: { m: GHSearchMeta }) {
+  if (m.scope === "repositories") {
+    const stars = m.stars ?? 0;
+    const forks = m.forks ?? 0;
+    return (
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <Star className="size-3.5" />
+          <span className="tabular-nums">{compact(stars)}</span>
+        </span>
+        <span className="flex items-center gap-1">
+          <GitBranch className="size-3.5" />
+          <span className="tabular-nums">{compact(forks)}</span>
+        </span>
+        {m.language && (
+          <span className="truncate text-foreground/70">{m.language}</span>
+        )}
+      </div>
+    );
+  }
+  if (m.scope === "issues") {
+    const comments = m.comments ?? 0;
+    return (
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        {m.number !== undefined && (
+          <span className="tabular-nums text-foreground/70">#{m.number}</span>
+        )}
+        <span className="flex items-center gap-1">
+          <MessageSquareText className="size-3.5" />
+          <span className="tabular-nums">{compact(comments)}</span>
+        </span>
+        {m.repo && (
+          <span className="truncate text-foreground/70">{m.repo}</span>
+        )}
+      </div>
+    );
+  }
+  if (m.scope === "commits" && m.sha) {
+    return (
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="font-mono text-foreground/70">
+          {m.sha.slice(0, 7)}
+        </span>
+        {m.repo && (
+          <span className="truncate text-foreground/70">{m.repo}</span>
+        )}
+      </div>
+    );
+  }
+  return null;
+}
+
+function ItemRenderer({ item }: ItemRendererProps<GHSearchMeta>) {
+  const m = item.meta ?? ({ scope: "repositories" } as GHSearchMeta);
+  const [title, ...rest] = item.content.split("\n\n");
+  const snippet = rest.join("\n\n").trim();
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <ScopeBadge m={m} />
+        <span className="truncate text-foreground/80">
+          {item.author.handle ?? item.author.name}
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {title}
+      </h3>
+      {snippet && (
+        <p
+          className={`mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words ${
+            m.scope === "code" ? "font-mono whitespace-pre" : "whitespace-pre-line"
+          }`}
+        >
+          {snippet}
+        </p>
+      )}
+      <MetaRow m={m} />
+    </a>
+  );
+}
+
+export const column = defineColumnUI<GHSearchConfig, GHSearchMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-search/plugin.ts
+++ b/lib/columns/plugins/github-search/plugin.ts
@@ -1,0 +1,62 @@
+// Separate from the `github` plugin: that one is feed-style (trending /
+// releases / issue search). This one is mention-monitoring — free-form
+// keyword/URL search across repos, issues, code, and commits with one
+// switchable scope. Different config form, different renderer concerns.
+
+import { z } from "zod";
+import { SearchCode } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  scope: z
+    .enum(["repositories", "issues", "code", "commits"])
+    .default("issues"),
+  query: z.string().default(""),
+});
+
+export type GHSearchConfig = z.infer<typeof schema>;
+
+export interface GHSearchMeta {
+  scope: "repositories" | "issues" | "code" | "commits";
+  repo?: string;
+  stars?: number;
+  forks?: number;
+  language?: string;
+  number?: number;
+  state?: string;
+  comments?: number;
+  isPr?: boolean;
+  path?: string;
+  sha?: string;
+}
+
+const SCOPE_LABEL: Record<GHSearchConfig["scope"], string> = {
+  repositories: "Repos",
+  issues: "Issues / PRs",
+  code: "Code",
+  commits: "Commits",
+};
+
+export const meta: PluginMeta<GHSearchConfig, GHSearchMeta> = {
+  id: "github-search",
+  label: "GitHub search",
+  description:
+    "Watch GitHub for mentions of a keyword or URL across repos, issues, code, or commits.",
+  icon: SearchCode,
+  accent: "#1f2328",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const label = SCOPE_LABEL[c.scope];
+    const q = c.query.trim();
+    return q ? `GH ${label} · ${q}` : `GitHub · ${label}`;
+  },
+  capabilities: {
+    paginated: true,
+    // GITHUB_TOKEN is genuinely optional — fetcher upgrades automatically when
+    // it's set — so it's not in requiresEnv (which renders as "Requires:" in UI).
+    rateLimitHint:
+      "60 req/hr without GITHUB_TOKEN, 5000 with. Code search requires the token.",
+  },
+};

--- a/lib/columns/plugins/github-search/server.ts
+++ b/lib/columns/plugins/github-search/server.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { searchGitHub } from "@/lib/integrations/github";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type GHSearchConfig, type GHSearchMeta } from "./plugin";
+
+const fetch: ServerFetcher<GHSearchConfig, GHSearchMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 1 : 1;
+  const items = (await searchGitHub(
+    config.scope,
+    config.query,
+    PAGE_SIZE,
+    page,
+  )) as FeedItem<GHSearchMeta>[];
+  return {
+    items,
+    nextCursor: items.length === PAGE_SIZE ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<GHSearchConfig, GHSearchMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/github-watchers/client.tsx
+++ b/lib/columns/plugins/github-watchers/client.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { GitFork, Star } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type GHWatchersConfig, type GHWatchersMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<GHWatchersConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghw-repo">Repository</Label>
+        <Input
+          id="ghw-repo"
+          placeholder="vercel/next.js"
+          value={value.repo}
+          onChange={(e) => onChange({ ...value, repo: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          <code>owner/repo</code> or full GitHub URL.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Show</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as GHWatchersConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="both">Stars &amp; forks</SelectItem>
+            <SelectItem value="stars">Stars only</SelectItem>
+            <SelectItem value="forks">Forks only</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function KindBadge({ kind }: { kind: GHWatchersMeta["kind"] }) {
+  if (kind === "star") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+        style={{ backgroundColor: "rgba(245, 166, 35, 0.22)" }}
+      >
+        <Star className="size-3" />
+        Starred
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+      style={{ backgroundColor: "rgba(159, 187, 224, 0.32)" }}
+    >
+      <GitFork className="size-3" />
+      Forked
+    </span>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<GHWatchersMeta>) {
+  const m = item.meta;
+  const handle = item.author.handle ?? item.author.name;
+  const repo = m?.repo ?? "";
+  const repoUrl = repo ? `https://github.com/${repo}` : undefined;
+
+  return (
+    <article className="border-b border-border px-3.5 py-3">
+      <div className="flex items-start gap-2.5">
+        {item.author.avatarUrl && (
+          <a
+            href={item.url}
+            target="_blank"
+            rel="noreferrer"
+            className="shrink-0"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={item.author.avatarUrl}
+              alt={handle}
+              className="size-8 rounded-full ring-1 ring-black/5"
+              loading="lazy"
+            />
+          </a>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+            {m && <KindBadge kind={m.kind} />}
+            <a
+              href={item.url}
+              target="_blank"
+              rel="noreferrer"
+              className="truncate font-medium text-foreground/90 hover:text-[color:var(--brand-hover)]"
+            >
+              {handle}
+            </a>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums">
+              <RelativeTime date={item.createdAt} addSuffix />
+            </span>
+          </div>
+          {repo && (
+            <p className="mt-1 text-[13.5px] text-foreground break-words">
+              {m?.kind === "fork" && m.forkUrl ? (
+                <>
+                  forked{" "}
+                  <a
+                    href={repoUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-medium hover:text-[color:var(--brand-hover)]"
+                  >
+                    {repo}
+                  </a>{" "}
+                  →{" "}
+                  <a
+                    href={m.forkUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-foreground/80 hover:text-[color:var(--brand-hover)]"
+                  >
+                    {m.forkUrl.replace(/^https?:\/\/github\.com\//, "")}
+                  </a>
+                </>
+              ) : (
+                <>
+                  starred{" "}
+                  <a
+                    href={repoUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-medium hover:text-[color:var(--brand-hover)]"
+                  >
+                    {repo}
+                  </a>
+                </>
+              )}
+            </p>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export const column = defineColumnUI<GHWatchersConfig, GHWatchersMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-watchers/plugin.ts
+++ b/lib/columns/plugins/github-watchers/plugin.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { Star } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+import type { GHWatcherItemMeta } from "@/lib/integrations/github";
+
+export const schema = z.object({
+  repo: z.string().default(""),
+  mode: z.enum(["stars", "forks", "both"]).default("both"),
+});
+
+export type GHWatchersConfig = z.infer<typeof schema>;
+
+export type GHWatchersMeta = GHWatcherItemMeta;
+
+const MODE_LABEL: Record<GHWatchersConfig["mode"], string> = {
+  stars: "Stars",
+  forks: "Forks",
+  both: "Stars & forks",
+};
+
+export const meta: PluginMeta<GHWatchersConfig, GHWatchersMeta> = {
+  id: "github-watchers",
+  label: "GitHub watchers",
+  description: "Latest stargazers and forks for a GitHub repo.",
+  icon: Star,
+  accent: "#f5a623",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const r = c.repo.trim();
+    return r ? `${MODE_LABEL[c.mode]} · ${r}` : `GitHub · ${MODE_LABEL[c.mode]}`;
+  },
+  capabilities: {
+    paginated: true,
+    rateLimitHint:
+      "60 req/hr without GITHUB_TOKEN, 5000 with. Token also unlocks GraphQL for newest-first stargazers.",
+  },
+};

--- a/lib/columns/plugins/github-watchers/server.ts
+++ b/lib/columns/plugins/github-watchers/server.ts
@@ -1,0 +1,54 @@
+import "server-only";
+
+// GraphQL when GITHUB_TOKEN is present (clean STARRED_AT DESC); REST + Link
+// header walk for newest-first stargazers when keyless. Forks are REST sort=newest.
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { fetchForks, fetchStargazers } from "@/lib/integrations/github";
+import type { GHWatcherItem, GHWatcherItemMeta } from "@/lib/integrations/github";
+import { meta, type GHWatchersConfig } from "./plugin";
+
+const fetch: ServerFetcher<GHWatchersConfig, GHWatcherItemMeta> = async (
+  config,
+  cursor,
+) => {
+  const repo = config.repo.trim();
+  if (!repo) throw new Error("Repository is required (owner/repo).");
+
+  if (config.mode === "stars") {
+    return fetchStargazers(repo, PAGE_SIZE, cursor);
+  }
+  if (config.mode === "forks") {
+    return fetchForks(repo, PAGE_SIZE, cursor);
+  }
+
+  // "both" — fan out, interleave by event time newest-first. No pagination:
+  // stargazer + fork timelines diverge, so a single cursor can't represent
+  // both fairly without duplicates or skips.
+  const [stars, forks] = await Promise.allSettled([
+    fetchStargazers(repo, PAGE_SIZE, undefined),
+    fetchForks(repo, PAGE_SIZE, undefined),
+  ]);
+  const errors: string[] = [];
+  const items: GHWatcherItem[] = [];
+  if (stars.status === "fulfilled") items.push(...stars.value.items);
+  else errors.push(stars.reason instanceof Error ? stars.reason.message : String(stars.reason));
+  if (forks.status === "fulfilled") items.push(...forks.value.items);
+  else errors.push(forks.reason instanceof Error ? forks.reason.message : String(forks.reason));
+
+  if (items.length === 0 && errors.length > 0) {
+    throw new Error(errors.join("\n"));
+  }
+
+  items.sort((a, b) => +new Date(b.createdAt) - +new Date(a.createdAt));
+  return { items };
+};
+
+export const server = defineColumnServer<GHWatchersConfig, GHWatcherItemMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/hacker-news-search/client.tsx
+++ b/lib/columns/plugins/hacker-news-search/client.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { ArrowBigUp, MessageSquareText, MessageCircle } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type HNSearchConfig, type HNSearchMeta } from "./plugin";
+
+function compact(n: number): string {
+  if (Math.abs(n) < 1000) return String(n);
+  if (Math.abs(n) < 1_000_000)
+    return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+function ConfigForm({ value, onChange }: ConfigFormProps<HNSearchConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="hns-q">Keyword or URL</Label>
+        <Input
+          id="hns-q"
+          placeholder="anthropic.com, claude code, https://..."
+          value={value.query}
+          onChange={(e) => onChange({ ...value, query: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          URLs are matched against the story link; everything else searches
+          full text.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Scope</Label>
+        <Select
+          value={value.scope}
+          onValueChange={(v) =>
+            onChange({ ...value, scope: v as HNSearchConfig["scope"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Stories &amp; comments</SelectItem>
+            <SelectItem value="stories">Stories only</SelectItem>
+            <SelectItem value="comments">Comments only</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Sort</Label>
+        <Select
+          value={value.sort}
+          onValueChange={(v) =>
+            onChange({ ...value, sort: v as HNSearchConfig["sort"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="date">Newest first</SelectItem>
+            <SelectItem value="relevance">Most relevant</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<HNSearchMeta>) {
+  const m = item.meta;
+  const kind = m?.kind ?? "story";
+  const points = m?.points ?? 0;
+  const comments = m?.comments ?? 0;
+  const commentsUrl = m?.commentsUrl ?? item.url;
+
+  const isComment = kind === "comment";
+  const headline = isComment
+    ? (m?.storyTitle ?? "(comment)")
+    : item.content.split("\n\n")[0];
+  const body = isComment
+    ? item.content
+    : item.content.split("\n\n").slice(1).join("\n\n").trim();
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(255, 102, 0, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[9px] font-bold leading-none text-white"
+            style={{ backgroundColor: "#ff6600" }}
+          >
+            Y
+          </span>
+          {isComment ? "HN comment" : "HN story"}
+        </span>
+        <span className="text-muted-foreground/80">
+          by{" "}
+          <span className="text-foreground/90">
+            {item.author.handle ?? item.author.name}
+          </span>
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+        >
+          {isComment ? `Re: ${headline}` : headline}
+        </h3>
+      </a>
+      {body && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {body}
+        </p>
+      )}
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        {isComment ? (
+          <a
+            href={commentsUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-1 transition-colors hover:text-foreground"
+          >
+            <MessageCircle className="size-3.5" />
+            <span>View thread</span>
+          </a>
+        ) : (
+          <>
+            <span className="flex items-center gap-1">
+              <ArrowBigUp className="size-4" />
+              <span className="tabular-nums">{compact(points)}</span>
+            </span>
+            <a
+              href={commentsUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1 transition-colors hover:text-foreground"
+            >
+              <MessageSquareText className="size-3.5" />
+              <span className="tabular-nums">{compact(comments)}</span>
+            </a>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<HNSearchConfig, HNSearchMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/hacker-news-search/plugin.ts
+++ b/lib/columns/plugins/hacker-news-search/plugin.ts
@@ -1,0 +1,39 @@
+// Dedicated mention monitor for HN — separate from the existing hacker-news
+// plugin so URL detection, comment scope, and date sort don't bloat that
+// plugin's ConfigForm (which serves the front-page/Ask/Show/keyword UX).
+
+import { z } from "zod";
+import { Eye } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+  scope: z.enum(["all", "stories", "comments"]).default("all"),
+  sort: z.enum(["relevance", "date"]).default("date"),
+});
+
+export type HNSearchConfig = z.infer<typeof schema>;
+
+export interface HNSearchMeta {
+  points: number;
+  comments: number;
+  commentsUrl: string;
+  externalUrl?: string;
+  kind: "story" | "comment";
+  storyTitle?: string;
+}
+
+export const meta: PluginMeta<HNSearchConfig, HNSearchMeta> = {
+  id: "hacker-news-search",
+  label: "HN Mentions",
+  description:
+    "Watch Hacker News for keyword or URL mentions across stories and comments.",
+  icon: Eye,
+  accent: "#ff6600",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `HN watch · ${c.query.trim()}` : "HN watch",
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/hacker-news-search/server.ts
+++ b/lib/columns/plugins/hacker-news-search/server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { searchHackerNewsByUrlOrKeyword } from "@/lib/integrations/hackernews";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type HNSearchConfig, type HNSearchMeta } from "./plugin";
+
+const fetch: ServerFetcher<HNSearchConfig, HNSearchMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await searchHackerNewsByUrlOrKeyword(config.query, {
+    scope: config.scope,
+    sort: config.sort,
+    limit: PAGE_SIZE,
+    page,
+  });
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<HNSearchConfig, HNSearchMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/instagram/client.tsx
+++ b/lib/columns/plugins/instagram/client.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LinkItem } from "@/lib/columns/shared/link-renderer";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type InstagramConfig, type InstagramMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<InstagramConfig>) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="ig-q">Keyword or URL</Label>
+      <Input
+        id="ig-q"
+        placeholder='claude code  ·  https://example.com'
+        value={value.query}
+        onChange={(e) => onChange({ query: e.target.value })}
+      />
+      <p className="text-xs text-muted-foreground">
+        Surfaces public Instagram posts (via web search) that mention your
+        keyword, hashtag, or URL.
+      </p>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<InstagramMeta>) {
+  return (
+    <LinkItem
+      item={item}
+      badgeLabel="Instagram"
+      badgeClass="bg-[#e1306c]/20 text-foreground ring-1 ring-black/5"
+    />
+  );
+}
+
+export const column = defineColumnUI<InstagramConfig, InstagramMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/instagram/plugin.ts
+++ b/lib/columns/plugins/instagram/plugin.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+// `Instagram` brand icon was dropped from lucide-react v1.x; `Aperture` is
+// the camera-lens substitute used by other dashboards.
+import { Aperture } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+});
+
+export type InstagramConfig = z.infer<typeof schema>;
+
+export interface InstagramMeta {
+  source: string;
+  kind: "web" | "news";
+}
+
+export const meta: PluginMeta<InstagramConfig, InstagramMeta> = {
+  id: "instagram",
+  label: "Instagram",
+  description: "Public Instagram posts mentioning a keyword or URL.",
+  icon: Aperture,
+  accent: "#e1306c",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `Instagram · ${c.query.trim()}` : "Instagram",
+  capabilities: {
+    requiresEnv: ["XAI_API_KEY"],
+    rateLimitHint:
+      "Indexed via web search — only public posts already crawled by search engines are returned.",
+  },
+};

--- a/lib/columns/plugins/instagram/server.ts
+++ b/lib/columns/plugins/instagram/server.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+// Backend choice: Grok web_search with site:instagram.com — IG's Graph API
+// has no public hashtag/keyword search, so web search is the easiest path.
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchInstagram } from "@/lib/integrations/instagram";
+import { meta, type InstagramConfig, type InstagramMeta } from "./plugin";
+
+const fetch: ServerFetcher<InstagramConfig, InstagramMeta> = async (config) => {
+  const items = (await fetchInstagram(config.query)) as FeedItem<InstagramMeta>[];
+  return { items };
+};
+
+export const server = defineColumnServer<InstagramConfig, InstagramMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/linkedin/client.tsx
+++ b/lib/columns/plugins/linkedin/client.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LinkItem } from "@/lib/columns/shared/link-renderer";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type LinkedinConfig, type LinkedinMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<LinkedinConfig>) {
+  const isUrl = /^https?:\/\//i.test(value.query.trim());
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="li-q">Keyword or URL</Label>
+      <Input
+        id="li-q"
+        placeholder='"anthropic", https://yourdomain.com'
+        value={value.query}
+        onChange={(e) => onChange({ query: e.target.value })}
+      />
+      <p className="text-xs text-muted-foreground">
+        {isUrl
+          ? "URL is matched as an exact phrase against LinkedIn posts."
+          : "Searches public LinkedIn posts for keyword mentions."}
+      </p>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<LinkedinMeta>) {
+  return (
+    <LinkItem
+      item={item}
+      badgeLabel="LinkedIn"
+      badgeClass="bg-[#0a66c2]/15 text-foreground ring-1 ring-black/5"
+    />
+  );
+}
+
+export const column = defineColumnUI<LinkedinConfig, LinkedinMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/linkedin/plugin.ts
+++ b/lib/columns/plugins/linkedin/plugin.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { Briefcase } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+});
+
+export type LinkedinConfig = z.infer<typeof schema>;
+
+export interface LinkedinMeta {
+  source: string;
+  isLinkedin: true;
+}
+
+export const meta: PluginMeta<LinkedinConfig, LinkedinMeta> = {
+  id: "linkedin",
+  label: "LinkedIn mentions",
+  description: "Watch LinkedIn posts mentioning a keyword or URL.",
+  icon: Briefcase,
+  accent: "#0a66c2",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `LinkedIn · ${c.query.trim()}` : "LinkedIn mentions",
+  capabilities: { requiresEnv: ["XAI_API_KEY"] },
+};

--- a/lib/columns/plugins/linkedin/server.ts
+++ b/lib/columns/plugins/linkedin/server.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+// Approach: xAI Grok web_search with a site:linkedin.com/posts filter — the
+// official LinkedIn API is closed for public search, so we mirror the web-search
+// plugin's pattern via lib/integrations/linkedin.ts.
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { searchLinkedinPosts } from "@/lib/integrations/linkedin";
+import { meta, type LinkedinConfig, type LinkedinMeta } from "./plugin";
+
+const fetch: ServerFetcher<LinkedinConfig, LinkedinMeta> = async (config) => {
+  const items = (await searchLinkedinPosts(config.query)) as FeedItem<LinkedinMeta>[];
+  return { items };
+};
+
+export const server = defineColumnServer<LinkedinConfig, LinkedinMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -20,6 +20,21 @@ import { meta as mentions } from "./mentions/plugin";
 import { meta as farcaster } from "./farcaster/plugin";
 import { meta as youtube } from "./youtube/plugin";
 import { meta as newsnow } from "./newsnow/plugin";
+import { meta as instagram } from "./instagram/plugin";
+import { meta as rednote } from "./rednote/plugin";
+import { meta as hackerNewsSearch } from "./hacker-news-search/plugin";
+import { meta as githubSearch } from "./github-search/plugin";
+import { meta as tiktok } from "./tiktok/plugin";
+import { meta as weiboSearch } from "./weibo-search/plugin";
+import { meta as substack } from "./substack/plugin";
+import { meta as linkedin } from "./linkedin/plugin";
+import { meta as facebook } from "./facebook/plugin";
+import { meta as githubBacklinks } from "./github-backlinks/plugin";
+import { meta as walletTx } from "./wallet-tx/plugin";
+import { meta as githubPrs } from "./github-prs/plugin";
+import { meta as telegramSearch } from "./telegram-search/plugin";
+import { meta as appReviews } from "./app-reviews/plugin";
+import { meta as githubWatchers } from "./github-watchers/plugin";
 
 export const PLUGIN_METAS = [
   grokAsk,
@@ -38,6 +53,21 @@ export const PLUGIN_METAS = [
   farcaster,
   youtube,
   newsnow,
+  instagram,
+  rednote,
+  hackerNewsSearch,
+  githubSearch,
+  tiktok,
+  weiboSearch,
+  substack,
+  linkedin,
+  facebook,
+  githubBacklinks,
+  walletTx,
+  githubPrs,
+  telegramSearch,
+  appReviews,
+  githubWatchers,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/plugins/rednote/client.tsx
+++ b/lib/columns/plugins/rednote/client.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LinkItem } from "@/lib/columns/shared/link-renderer";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type RednoteConfig, type RednoteMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<RednoteConfig>) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="rednote-q">Keyword or URL</Label>
+      <Input
+        id="rednote-q"
+        placeholder="brand name, hashtag, or xiaohongshu.com URL"
+        value={value.query}
+        onChange={(e) => onChange({ query: e.target.value })}
+      />
+      <p className="text-xs text-muted-foreground">
+        Searches Xiaohongshu (小红书) via Grok web search. Coverage is
+        best-effort — xhs blocks anonymous scraping, so only pages indexed by
+        public crawlers and shared xhslink.com URLs surface.
+      </p>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<RednoteMeta>) {
+  return (
+    <LinkItem
+      item={item}
+      badgeLabel="Rednote"
+      badgeClass="bg-[#ff2442]/15 text-foreground ring-1 ring-black/5"
+    />
+  );
+}
+
+export const column = defineColumnUI<RednoteConfig, RednoteMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/rednote/plugin.ts
+++ b/lib/columns/plugins/rednote/plugin.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { BookHeart } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+});
+
+export type RednoteConfig = z.infer<typeof schema>;
+
+export interface RednoteMeta {
+  source: string;
+  kind: "rednote";
+}
+
+export const meta: PluginMeta<RednoteConfig, RednoteMeta> = {
+  id: "rednote",
+  label: "Rednote · Mentions",
+  description: "Latest Xiaohongshu (小红书) posts mentioning a keyword or URL.",
+  icon: BookHeart,
+  accent: "#ff2442",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `Rednote · ${c.query.trim()}` : "Rednote · Mentions",
+  capabilities: {
+    requiresEnv: ["XAI_API_KEY"],
+    rateLimitHint:
+      "Xiaohongshu has no public API. Results come from Grok web search scoped to xhs domains; coverage depends on what crawlers can index.",
+  },
+};

--- a/lib/columns/plugins/rednote/server.ts
+++ b/lib/columns/plugins/rednote/server.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+// Path: site:xiaohongshu.com web search via Grok (no public xhs API). Swap to
+// a paid scraper later by editing lib/integrations/rednote.ts only.
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchRednoteMentions } from "@/lib/integrations/rednote";
+import { meta, type RednoteConfig, type RednoteMeta } from "./plugin";
+
+const fetch: ServerFetcher<RednoteConfig, RednoteMeta> = async (config) => {
+  const items = (await fetchRednoteMentions(
+    config.query,
+  )) as FeedItem<RednoteMeta>[];
+  return { items };
+};
+
+export const server = defineColumnServer<RednoteConfig, RednoteMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/substack/client.tsx
+++ b/lib/columns/plugins/substack/client.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { LinkItem } from "@/lib/columns/shared/link-renderer";
+import { meta, type SubstackConfig, type SubstackMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<SubstackConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="sub-handles">Publications</Label>
+        <Textarea
+          id="sub-handles"
+          placeholder={"mattyglesias\nslowboring\nstratechery.com"}
+          value={value.handles}
+          onChange={(e) => onChange({ ...value, handles: e.target.value })}
+          rows={3}
+        />
+        <p className="text-xs text-muted-foreground">
+          One per line, or comma-separated. Use the handle (
+          <code>mattyglesias</code>) or full URL (
+          <code>slowboring.substack.com</code>). Substack has no global search,
+          so we fetch each publication&apos;s RSS and filter locally.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="sub-q">Keyword or URL (optional)</Label>
+        <Input
+          id="sub-q"
+          placeholder='"AI agents", anthropic.com, https://...'
+          value={value.query}
+          onChange={(e) => onChange({ ...value, query: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Leave blank to see every recent post. URLs are matched against the
+          post link; everything else searches title and summary.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<SubstackMeta>) {
+  return (
+    <LinkItem
+      item={item}
+      badgeLabel="Substack"
+      badgeClass="bg-[color:var(--chart-1)]/40 text-foreground ring-1 ring-black/5"
+    />
+  );
+}
+
+export const column = defineColumnUI<SubstackConfig, SubstackMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/substack/plugin.ts
+++ b/lib/columns/plugins/substack/plugin.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { BookOpen } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  handles: z.string().default(""),
+  query: z.string().default(""),
+});
+
+export type SubstackConfig = z.infer<typeof schema>;
+
+export interface SubstackMeta {
+  publication: string;
+  feedTitle?: string;
+  source: string;
+}
+
+export const meta: PluginMeta<SubstackConfig, SubstackMeta> = {
+  id: "substack",
+  label: "Substack",
+  description:
+    "Watch Substack publications for posts mentioning a keyword or URL.",
+  icon: BookOpen,
+  accent: "#ff6719",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const q = c.query.trim();
+    if (q) return `Substack · ${q}`;
+    const first = c.handles.split(/[\s,]+/).find((s) => s.trim());
+    return first ? `Substack · ${first.trim()}` : "Substack";
+  },
+  capabilities: {
+    rateLimitHint:
+      "One RSS fetch per publication. Substack has no global search API; results are filtered in-memory across the handles you supply.",
+  },
+};

--- a/lib/columns/plugins/substack/server.ts
+++ b/lib/columns/plugins/substack/server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+// Per-publication RSS via lib/integrations/rss.ts. Substack's discover/search
+// API (substack.com/api/v1/post/search) returns empty results without auth, so
+// the user picks one or more handles and we filter their feeds in-memory.
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import {
+  parseHandles,
+  searchSubstackPublications,
+} from "@/lib/integrations/substack";
+import { meta, type SubstackConfig, type SubstackMeta } from "./plugin";
+
+const fetch: ServerFetcher<SubstackConfig, SubstackMeta> = async (config) => {
+  const handles = parseHandles(config.handles);
+  if (handles.length === 0) return { items: [] };
+  const items = (await searchSubstackPublications(
+    handles,
+    config.query,
+  )) as FeedItem<SubstackMeta>[];
+  return { items };
+};
+
+export const server = defineColumnServer<SubstackConfig, SubstackMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/telegram-search/client.tsx
+++ b/lib/columns/plugins/telegram-search/client.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Eye, Send } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type TGSearchConfig, type TGSearchMeta } from "./plugin";
+
+function compact(n: number): string {
+  if (Math.abs(n) < 1000) return String(n);
+  if (Math.abs(n) < 1_000_000)
+    return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+function ConfigForm({ value, onChange }: ConfigFormProps<TGSearchConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="tg-channels">Channels</Label>
+        <Input
+          id="tg-channels"
+          placeholder="durov, telegram, @anothername"
+          value={value.channels}
+          onChange={(e) => onChange({ ...value, channels: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Public channel handles — comma- or space-separated. <code>@</code> and{" "}
+          <code>t.me/</code> prefixes are stripped.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="tg-q">Keyword or URL</Label>
+        <Input
+          id="tg-q"
+          placeholder="anthropic.com, claude code, https://..."
+          value={value.query}
+          onChange={(e) => onChange({ ...value, query: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Leave empty to see every recent post from these channels.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Match mode</Label>
+        <Select
+          value={value.matchMode}
+          onValueChange={(v) =>
+            onChange({ ...value, matchMode: v as TGSearchConfig["matchMode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="keyword">Keyword (auto-detects URLs)</SelectItem>
+            <SelectItem value="url">URL / domain only</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<TGSearchMeta>) {
+  const m = item.meta;
+  const channel = m?.channel ?? item.author.handle ?? "";
+  const channelTitle = m?.channelTitle ?? item.author.name;
+  const views = m?.views;
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(34, 158, 217, 0.18)" }}
+        >
+          <Send className="size-3 text-[#229ED9]" />
+          @{channel}
+        </span>
+        {channelTitle && channelTitle !== channel && (
+          <span className="truncate text-foreground/80">{channelTitle}</span>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <p className="mt-1 line-clamp-6 text-[13.5px] leading-snug text-foreground whitespace-pre-line break-words">
+        {item.content}
+      </p>
+      {typeof views === "number" && views > 0 && (
+        <div className="mt-2 flex items-center gap-1 text-[11.5px] text-muted-foreground">
+          <Eye className="size-3.5" />
+          <span className="tabular-nums">{compact(views)}</span>
+        </div>
+      )}
+    </a>
+  );
+}
+
+export const column = defineColumnUI<TGSearchConfig, TGSearchMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/telegram-search/plugin.ts
+++ b/lib/columns/plugins/telegram-search/plugin.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { Send } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  channels: z.string().default(""),
+  query: z.string().default(""),
+  matchMode: z.enum(["keyword", "url"]).default("keyword"),
+});
+
+export type TGSearchConfig = z.infer<typeof schema>;
+
+export interface TGSearchMeta {
+  channel: string;
+  channelTitle?: string;
+  postId: string;
+  views?: number;
+}
+
+export const meta: PluginMeta<TGSearchConfig, TGSearchMeta> = {
+  id: "telegram-search",
+  label: "Telegram mentions",
+  description:
+    "Watch public Telegram channels for keyword or URL mentions in their recent posts.",
+  icon: Send,
+  accent: "#229ED9",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const q = c.query.trim();
+    return q ? `Telegram · ${q}` : "Telegram mentions";
+  },
+  capabilities: {
+    rateLimitHint:
+      "Scrapes public t.me/s/<channel> previews — recent posts only, no auth required.",
+  },
+};

--- a/lib/columns/plugins/telegram-search/server.ts
+++ b/lib/columns/plugins/telegram-search/server.ts
@@ -1,0 +1,28 @@
+import "server-only";
+
+// Scrapes the server-rendered t.me/s/<channel> preview pages — no API key, no
+// MTProto. Bot tokens can't read arbitrary channels, so this is the only path
+// that works without per-channel admin access.
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchTelegramChannelMentions } from "@/lib/integrations/telegram";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type TGSearchConfig, type TGSearchMeta } from "./plugin";
+
+const fetch: ServerFetcher<TGSearchConfig, TGSearchMeta> = async (config) => {
+  const items = await fetchTelegramChannelMentions({
+    channels: config.channels,
+    query: config.query,
+    matchMode: config.matchMode,
+    limit: PAGE_SIZE,
+  });
+  return { items };
+};
+
+export const server = defineColumnServer<TGSearchConfig, TGSearchMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/tiktok/client.tsx
+++ b/lib/columns/plugins/tiktok/client.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { LinkItem } from "@/lib/columns/shared/link-renderer";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type TikTokConfig, type TikTokMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<TikTokConfig>) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="tt-q">Keyword or URL</Label>
+      <Input
+        id="tt-q"
+        placeholder='"claude code", anthropic.com, https://...'
+        value={value.query}
+        onChange={(e) => onChange({ query: e.target.value })}
+      />
+      <p className="text-xs text-muted-foreground">
+        Searches TikTok via Grok web search (<code>site:tiktok.com</code>).
+        Requires <code>XAI_API_KEY</code>.
+      </p>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<TikTokMeta>) {
+  return (
+    <LinkItem
+      item={item}
+      badgeLabel="TikTok"
+      badgeClass="bg-[#fe2c55]/15 text-foreground ring-1 ring-black/5"
+    />
+  );
+}
+
+export const column = defineColumnUI<TikTokConfig, TikTokMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/tiktok/plugin.ts
+++ b/lib/columns/plugins/tiktok/plugin.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { Music2 } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+});
+
+export type TikTokConfig = z.infer<typeof schema>;
+
+export interface TikTokMeta {
+  source: "tiktok";
+  username?: string;
+  videoId?: string;
+}
+
+export const meta: PluginMeta<TikTokConfig, TikTokMeta> = {
+  id: "tiktok",
+  label: "TikTok",
+  description: "Watch TikTok for videos mentioning a keyword or URL.",
+  icon: Music2,
+  accent: "#fe2c55",
+  category: "video",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `TikTok · ${c.query.trim()}` : "TikTok",
+  capabilities: { requiresEnv: ["XAI_API_KEY"] },
+};

--- a/lib/columns/plugins/tiktok/server.ts
+++ b/lib/columns/plugins/tiktok/server.ts
@@ -1,0 +1,25 @@
+import "server-only";
+
+// TikTok has no public mention-search API; we use Grok web_search with a
+// `site:tiktok.com` filter (option 1 from the plugin design notes).
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { searchTikTok } from "@/lib/integrations/tiktok";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type TikTokConfig, type TikTokMeta } from "./plugin";
+
+const fetch: ServerFetcher<TikTokConfig, TikTokMeta> = async (config) => {
+  const items = (await searchTikTok(
+    config.query,
+    PAGE_SIZE,
+  )) as FeedItem<TikTokMeta>[];
+  return { items };
+};
+
+export const server = defineColumnServer<TikTokConfig, TikTokMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/wallet-tx/client.tsx
+++ b/lib/columns/plugins/wallet-tx/client.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { ArrowDownLeft, ArrowUpRight, Wallet } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type WalletTxConfig, type WalletTxMeta } from "./plugin";
+
+const CHAIN_OPTIONS: { value: WalletTxConfig["chain"]; label: string }[] = [
+  { value: "ethereum", label: "Ethereum" },
+  { value: "base", label: "Base" },
+  { value: "optimism", label: "Optimism" },
+  { value: "arbitrum", label: "Arbitrum" },
+  { value: "polygon", label: "Polygon" },
+  { value: "gnosis", label: "Gnosis" },
+  { value: "scroll", label: "Scroll" },
+  { value: "celo", label: "Celo" },
+  { value: "zksync", label: "zkSync" },
+];
+
+function shortHash(h: string, head = 6, tail = 4): string {
+  if (!h) return "";
+  if (h.length <= head + tail + 1) return h;
+  return `${h.slice(0, head)}…${h.slice(-tail)}`;
+}
+
+function formatUsd(n: number): string {
+  if (n < 0.01) return "<$0.01";
+  if (n < 1000) return `$${n.toFixed(2)}`;
+  if (n < 1_000_000) return `$${(n / 1000).toFixed(n < 10_000 ? 2 : 1)}k`;
+  return `$${(n / 1_000_000).toFixed(2)}M`;
+}
+
+const ADDR_RE = /^0x[a-fA-F0-9]{40}$/;
+
+function ConfigForm({ value, onChange }: ConfigFormProps<WalletTxConfig>) {
+  const trimmed = value.address.trim();
+  const showError = trimmed.length > 0 && !ADDR_RE.test(trimmed);
+
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Chain</Label>
+        <Select
+          value={value.chain}
+          onValueChange={(v) =>
+            onChange({ ...value, chain: v as WalletTxConfig["chain"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {CHAIN_OPTIONS.map((c) => (
+              <SelectItem key={c.value} value={c.value}>
+                {c.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="wallet-tx-addr">Wallet address</Label>
+        <Input
+          id="wallet-tx-addr"
+          placeholder="0x…"
+          value={value.address}
+          onChange={(e) => onChange({ ...value, address: e.target.value })}
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+          aria-invalid={showError || undefined}
+        />
+        <p className="text-xs text-muted-foreground">
+          {showError ? (
+            <span className="text-[color:var(--destructive,#c0392b)]">
+              EVM address must be <code>0x</code>-prefixed and 42 characters.
+            </span>
+          ) : (
+            <>EVM address — 42 characters, starts with <code>0x</code>.</>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<WalletTxMeta>) {
+  const m = item.meta;
+  if (!m) return null;
+  const fromShort = shortHash(m.from);
+  const toShort = m.to ? shortHash(m.to) : "—";
+  const isFailed = m.status === "failed";
+  const isOutgoing =
+    item.author.handle?.toLowerCase() === m.from.toLowerCase();
+  const DirectionIcon = isOutgoing ? ArrowUpRight : ArrowDownLeft;
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(98, 126, 234, 0.18)" }}
+        >
+          <Wallet className="size-3" />
+          {shortHash(m.hash, 6, 4)}
+        </span>
+        {m.method && (
+          <span className="rounded-full bg-foreground/[0.06] px-1.5 py-0.5 text-foreground/80">
+            {m.method}
+          </span>
+        )}
+        {isFailed && (
+          <span
+            className="rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+            style={{ backgroundColor: "rgba(192, 57, 43, 0.18)" }}
+          >
+            failed
+          </span>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+
+      <div className="mt-1.5 flex items-center gap-2 text-[13px] text-foreground">
+        <DirectionIcon
+          className={`size-4 ${isOutgoing ? "text-rose-500" : "text-emerald-500"}`}
+        />
+        <span className="font-mono text-foreground/80">{fromShort}</span>
+        <span className="text-muted-foreground/60">→</span>
+        <span className="font-mono text-foreground/80">{toShort}</span>
+      </div>
+
+      <div className="mt-1.5 flex items-baseline gap-2">
+        <span
+          className={`font-serif text-[16px] leading-tight tabular-nums ${
+            isFailed ? "text-muted-foreground line-through" : "text-foreground"
+          }`}
+          style={{ letterSpacing: "-0.005em" }}
+        >
+          {item.content}
+        </span>
+        {typeof m.valueUsd === "number" && m.valueUsd > 0 && (
+          <span className="text-[11.5px] text-muted-foreground tabular-nums">
+            ≈ {formatUsd(m.valueUsd)}
+          </span>
+        )}
+        <span className="ml-auto text-[11px] text-muted-foreground/70 tabular-nums">
+          #{m.blockNumber.toLocaleString()}
+        </span>
+      </div>
+    </a>
+  );
+}
+
+export const column = defineColumnUI<WalletTxConfig, WalletTxMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/wallet-tx/plugin.ts
+++ b/lib/columns/plugins/wallet-tx/plugin.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { Wallet } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  chain: z
+    .enum([
+      "ethereum",
+      "base",
+      "optimism",
+      "arbitrum",
+      "polygon",
+      "gnosis",
+      "scroll",
+      "celo",
+      "zksync",
+    ])
+    .default("ethereum"),
+  address: z.string().default(""),
+});
+
+export type WalletTxConfig = z.infer<typeof schema>;
+
+export interface WalletTxMeta {
+  chainId: number;
+  hash: string;
+  from: string;
+  to: string;
+  value: string;
+  valueUsd?: number;
+  method?: string;
+  status: "success" | "failed";
+  blockNumber: number;
+  gasUsed?: string;
+}
+
+const CHAIN_LABELS: Record<WalletTxConfig["chain"], string> = {
+  ethereum: "Ethereum",
+  base: "Base",
+  optimism: "Optimism",
+  arbitrum: "Arbitrum",
+  polygon: "Polygon",
+  gnosis: "Gnosis",
+  scroll: "Scroll",
+  celo: "Celo",
+  zksync: "zkSync",
+};
+
+function shortAddr(a: string): string {
+  const trimmed = a.trim();
+  if (!trimmed) return "";
+  if (trimmed.length <= 12) return trimmed;
+  return `${trimmed.slice(0, 6)}…${trimmed.slice(-4)}`;
+}
+
+export const meta: PluginMeta<WalletTxConfig, WalletTxMeta> = {
+  id: "wallet-tx",
+  label: "Wallet · Transactions",
+  description: "Latest on-chain transactions for an EVM wallet address.",
+  icon: Wallet,
+  accent: "#627eea",
+  category: "blockchain",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const label = CHAIN_LABELS[c.chain] ?? c.chain;
+    const addr = shortAddr(c.address);
+    return addr ? `${label} · ${addr}` : `Wallet · ${label}`;
+  },
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/wallet-tx/server.ts
+++ b/lib/columns/plugins/wallet-tx/server.ts
@@ -1,0 +1,24 @@
+import "server-only";
+
+// Uses Blockscout REST v2 (keyless multi-chain) — see lib/integrations/blockscout.ts.
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchAddressTransactions } from "@/lib/integrations/blockscout";
+import { meta, type WalletTxConfig, type WalletTxMeta } from "./plugin";
+
+const fetch: ServerFetcher<WalletTxConfig, WalletTxMeta> = async (
+  config,
+  cursor,
+) => {
+  const address = config.address.trim();
+  if (!address) return { items: [] };
+  return fetchAddressTransactions(config.chain, address, cursor);
+};
+
+export const server = defineColumnServer<WalletTxConfig, WalletTxMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/weibo-search/client.tsx
+++ b/lib/columns/plugins/weibo-search/client.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { TweetItem } from "@/lib/columns/shared/tweet-renderer";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+} from "@/lib/columns/types";
+import { meta, type WeiboSearchConfig, type WeiboSearchMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<WeiboSearchConfig>) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor="weibo-q">Keyword or URL</Label>
+      <Input
+        id="weibo-q"
+        placeholder="anthropic, claude, https://example.com..."
+        value={value.query}
+        onChange={(e) => onChange({ query: e.target.value })}
+      />
+      <p className="text-xs text-muted-foreground">
+        Searches Weibo posts (微博) mentioning your query. The mobile search
+        endpoint is keyless but may return empty results from non-CN egress
+        IPs.
+      </p>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<WeiboSearchConfig, WeiboSearchMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer: TweetItem,
+});

--- a/lib/columns/plugins/weibo-search/plugin.ts
+++ b/lib/columns/plugins/weibo-search/plugin.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { MessageSquare } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+import type { WeiboSearchMeta } from "@/lib/integrations/weibo";
+
+export const schema = z.object({
+  query: z.string().default(""),
+});
+
+export type WeiboSearchConfig = z.infer<typeof schema>;
+
+export type { WeiboSearchMeta };
+
+export const meta: PluginMeta<WeiboSearchConfig, WeiboSearchMeta> = {
+  id: "weibo-search",
+  label: "Weibo · Search",
+  description: "Watch Weibo (微博) for posts mentioning a keyword or URL.",
+  icon: MessageSquare,
+  accent: "#e6162d",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.query.trim() ? `微博 · ${c.query.trim()}` : "Weibo · Search",
+  capabilities: {
+    rateLimitHint:
+      "m.weibo.cn is fronted by CN-only infrastructure — requests from non-CN egress IPs may return empty results or rate-limit. Best run from a Chinese region.",
+  },
+};

--- a/lib/columns/plugins/weibo-search/server.ts
+++ b/lib/columns/plugins/weibo-search/server.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+// Keyless path: m.weibo.cn mobile JSON search. Chosen over s.weibo.com HTML
+// scrape (brittle DOM) and Grok web_search (requires XAI_API_KEY).
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { searchWeibo } from "@/lib/integrations/weibo";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type WeiboSearchConfig, type WeiboSearchMeta } from "./plugin";
+
+const fetch: ServerFetcher<WeiboSearchConfig, WeiboSearchMeta> = async (
+  config,
+) => {
+  const items = await searchWeibo(config.query, PAGE_SIZE);
+  return { items };
+};
+
+export const server = defineColumnServer<WeiboSearchConfig, WeiboSearchMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -28,6 +28,21 @@ import { column as mentions } from "@/lib/columns/plugins/mentions/client";
 import { column as farcaster } from "@/lib/columns/plugins/farcaster/client";
 import { column as youtube } from "@/lib/columns/plugins/youtube/client";
 import { column as newsnow } from "@/lib/columns/plugins/newsnow/client";
+import { column as instagram } from "@/lib/columns/plugins/instagram/client";
+import { column as rednote } from "@/lib/columns/plugins/rednote/client";
+import { column as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/client";
+import { column as githubSearch } from "@/lib/columns/plugins/github-search/client";
+import { column as tiktok } from "@/lib/columns/plugins/tiktok/client";
+import { column as weiboSearch } from "@/lib/columns/plugins/weibo-search/client";
+import { column as substack } from "@/lib/columns/plugins/substack/client";
+import { column as linkedin } from "@/lib/columns/plugins/linkedin/client";
+import { column as facebook } from "@/lib/columns/plugins/facebook/client";
+import { column as githubBacklinks } from "@/lib/columns/plugins/github-backlinks/client";
+import { column as walletTx } from "@/lib/columns/plugins/wallet-tx/client";
+import { column as githubPrs } from "@/lib/columns/plugins/github-prs/client";
+import { column as telegramSearch } from "@/lib/columns/plugins/telegram-search/client";
+import { column as appReviews } from "@/lib/columns/plugins/app-reviews/client";
+import { column as githubWatchers } from "@/lib/columns/plugins/github-watchers/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -49,6 +64,21 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   farcaster,
   youtube,
   newsnow,
+  instagram,
+  rednote,
+  "hacker-news-search": hackerNewsSearch,
+  "github-search": githubSearch,
+  tiktok,
+  "weibo-search": weiboSearch,
+  substack,
+  linkedin,
+  facebook,
+  "github-backlinks": githubBacklinks,
+  "wallet-tx": walletTx,
+  "github-prs": githubPrs,
+  "telegram-search": telegramSearch,
+  "app-reviews": appReviews,
+  "github-watchers": githubWatchers,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -24,6 +24,21 @@ import { server as mentions } from "@/lib/columns/plugins/mentions/server";
 import { server as farcaster } from "@/lib/columns/plugins/farcaster/server";
 import { server as youtube } from "@/lib/columns/plugins/youtube/server";
 import { server as newsnow } from "@/lib/columns/plugins/newsnow/server";
+import { server as instagram } from "@/lib/columns/plugins/instagram/server";
+import { server as rednote } from "@/lib/columns/plugins/rednote/server";
+import { server as hackerNewsSearch } from "@/lib/columns/plugins/hacker-news-search/server";
+import { server as githubSearch } from "@/lib/columns/plugins/github-search/server";
+import { server as tiktok } from "@/lib/columns/plugins/tiktok/server";
+import { server as weiboSearch } from "@/lib/columns/plugins/weibo-search/server";
+import { server as substack } from "@/lib/columns/plugins/substack/server";
+import { server as linkedin } from "@/lib/columns/plugins/linkedin/server";
+import { server as facebook } from "@/lib/columns/plugins/facebook/server";
+import { server as githubBacklinks } from "@/lib/columns/plugins/github-backlinks/server";
+import { server as walletTx } from "@/lib/columns/plugins/wallet-tx/server";
+import { server as githubPrs } from "@/lib/columns/plugins/github-prs/server";
+import { server as telegramSearch } from "@/lib/columns/plugins/telegram-search/server";
+import { server as appReviews } from "@/lib/columns/plugins/app-reviews/server";
+import { server as githubWatchers } from "@/lib/columns/plugins/github-watchers/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "grok-ask": grokAsk,
@@ -42,6 +57,21 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   farcaster,
   youtube,
   newsnow,
+  instagram,
+  rednote,
+  "hacker-news-search": hackerNewsSearch,
+  "github-search": githubSearch,
+  tiktok,
+  "weibo-search": weiboSearch,
+  substack,
+  linkedin,
+  facebook,
+  "github-backlinks": githubBacklinks,
+  "wallet-tx": walletTx,
+  "github-prs": githubPrs,
+  "telegram-search": telegramSearch,
+  "app-reviews": appReviews,
+  "github-watchers": githubWatchers,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/app-reviews.ts
+++ b/lib/integrations/app-reviews.ts
@@ -1,0 +1,247 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// Single source of truth for App Store + Google Play review fetching. Two
+// keyless paths today (Apple's iTunes RSS for App Store; the public
+// batchexecute scrape for Google Play). Env-var-gated upgrade paths
+// (APP_STORE_CONNECT_KEY for App Store Connect API, GOOGLE_PLAY_SA_JSON for
+// Google Play Developer Reporting API) can drop in here without changing
+// the plugin contract.
+
+export type AppReviewPlatform = "app-store" | "google-play";
+
+export interface AppReviewMeta {
+  rating: number;
+  version?: string;
+  country: string;
+  platform: AppReviewPlatform;
+  title?: string;
+  thumbsUp?: number;
+}
+
+const UA =
+  "minitor/0.1 (+https://github.com/anthropics/claude-code)";
+
+// ---- App Store (iTunes RSS, keyless) ---------------------------------------
+
+interface AppleEntryField {
+  label?: string;
+  attributes?: Record<string, string>;
+}
+
+interface AppleReviewEntry {
+  id?: AppleEntryField;
+  title?: AppleEntryField;
+  content?: AppleEntryField;
+  updated?: AppleEntryField;
+  author?: { name?: AppleEntryField; uri?: AppleEntryField };
+  link?: AppleEntryField | AppleEntryField[];
+  "im:rating"?: AppleEntryField;
+  "im:version"?: AppleEntryField;
+  "im:voteSum"?: AppleEntryField;
+}
+
+interface AppleFeedResponse {
+  feed?: {
+    entry?: AppleReviewEntry | AppleReviewEntry[];
+  };
+}
+
+function appleReviewLink(
+  entry: AppleReviewEntry,
+  appId: string,
+  country: string,
+): string {
+  const link = Array.isArray(entry.link) ? entry.link[0] : entry.link;
+  const href = link?.attributes?.href;
+  if (href) return href;
+  return `https://apps.apple.com/${country}/app/id${appId}`;
+}
+
+async function fetchAppStoreReviews(
+  appId: string,
+  country: string,
+): Promise<FeedItem<AppReviewMeta>[]> {
+  const url = `https://itunes.apple.com/${encodeURIComponent(country)}/rss/customerreviews/page=1/id=${encodeURIComponent(appId)}/sortby=mostrecent/json`;
+  const res = await fetch(url, {
+    headers: { accept: "application/json", "user-agent": UA },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(
+      `App Store RSS ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const json = (await res.json()) as AppleFeedResponse;
+  const raw = json.feed?.entry;
+  const entries = Array.isArray(raw) ? raw : raw ? [raw] : [];
+
+  return entries
+    .filter((e): e is AppleReviewEntry => Boolean(e?.id?.label))
+    .map((e) => {
+      const id = e.id!.label!;
+      const title = e.title?.label?.trim() ?? "";
+      const body = e.content?.label?.trim() ?? "";
+      const ratingNum = Number(e["im:rating"]?.label ?? "0") || 0;
+      const version = e["im:version"]?.label || undefined;
+      const author = e.author?.name?.label ?? "Anonymous";
+      const updated = e.updated?.label;
+      return {
+        id: `app-store-${id}`,
+        author: { name: author, handle: author },
+        content: title && body ? `${title}\n\n${body}` : body || title,
+        url: appleReviewLink(e, appId, country),
+        createdAt: updated ? new Date(updated).toISOString() : new Date().toISOString(),
+        meta: {
+          rating: ratingNum,
+          version,
+          country,
+          platform: "app-store",
+          title: title || undefined,
+        },
+      } satisfies FeedItem<AppReviewMeta>;
+    });
+}
+
+// ---- Google Play (batchexecute scrape, keyless) ----------------------------
+//
+// Google Play has no public reviews API. The batchexecute endpoint that
+// powers the Play Store web UI accepts an RPC id (UsvDTd) that returns the
+// most recent reviews for a package. The response is wrapped in `)]}'\n`,
+// then a JSON envelope whose third field is itself a stringified JSON array.
+
+const PLAY_RPC = "UsvDTd";
+
+interface PlayReviewParsed {
+  id: string;
+  rating: number;
+  text: string;
+  author: string;
+  avatarUrl?: string;
+  thumbsUp: number;
+  version?: string;
+  timestampMs: number;
+}
+
+function safeArrayAt(value: unknown, idx: number): unknown {
+  return Array.isArray(value) ? value[idx] : undefined;
+}
+
+function parsePlayReview(raw: unknown): PlayReviewParsed | null {
+  if (!Array.isArray(raw)) return null;
+  const id = typeof raw[0] === "string" ? raw[0] : null;
+  if (!id) return null;
+  const authorBlock = safeArrayAt(raw, 1);
+  const author =
+    typeof safeArrayAt(authorBlock, 0) === "string"
+      ? (safeArrayAt(authorBlock, 0) as string)
+      : "Anonymous";
+  const avatarTriple = safeArrayAt(safeArrayAt(authorBlock, 1), 3);
+  const avatarUrl =
+    typeof safeArrayAt(avatarTriple, 2) === "string"
+      ? (safeArrayAt(avatarTriple, 2) as string)
+      : undefined;
+  const rating = typeof raw[2] === "number" ? raw[2] : 0;
+  const text = typeof raw[4] === "string" ? raw[4] : "";
+  const ts = safeArrayAt(raw, 5);
+  const seconds = typeof safeArrayAt(ts, 0) === "number" ? (safeArrayAt(ts, 0) as number) : 0;
+  const thumbsUp = typeof raw[6] === "number" ? raw[6] : 0;
+  const version = typeof raw[10] === "string" ? raw[10] : undefined;
+  return {
+    id,
+    rating,
+    text,
+    author,
+    avatarUrl,
+    thumbsUp,
+    version,
+    timestampMs: seconds * 1000,
+  };
+}
+
+async function fetchGooglePlayReviews(
+  appId: string,
+  country: string,
+): Promise<FeedItem<AppReviewMeta>[]> {
+  // [null,null,[2,1,[40,null,null],null,[]],[appId,7]] — 7 = newest, 40 = page size
+  const reqArg = JSON.stringify([
+    null,
+    null,
+    [2, 1, [40, null, null], null, []],
+    [appId, 7],
+  ]);
+  const fReq = JSON.stringify([[[PLAY_RPC, reqArg, null, "generic"]]]);
+  const body = new URLSearchParams({ "f.req": fReq });
+  const url = `https://play.google.com/_/PlayStoreUi/data/batchexecute?hl=en&gl=${encodeURIComponent(country)}`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
+      accept: "*/*",
+      "user-agent": UA,
+    },
+    body: body.toString(),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Google Play ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const text = await res.text();
+  // Strip `)]}'` prefix.
+  const stripped = text.replace(/^\)\]\}'\s*/, "");
+  const envelope = JSON.parse(stripped) as unknown[];
+  const firstFrame = Array.isArray(envelope) ? (envelope[0] as unknown[]) : null;
+  const payloadStr =
+    Array.isArray(firstFrame) && typeof firstFrame[2] === "string"
+      ? (firstFrame[2] as string)
+      : null;
+  if (!payloadStr) return [];
+  const payload = JSON.parse(payloadStr) as unknown[];
+  const reviewList = Array.isArray(payload[0]) ? (payload[0] as unknown[]) : [];
+
+  const items: FeedItem<AppReviewMeta>[] = [];
+  for (const r of reviewList) {
+    const parsed = parsePlayReview(r);
+    if (!parsed) continue;
+    items.push({
+      id: `google-play-${parsed.id}`,
+      author: {
+        name: parsed.author,
+        handle: parsed.author,
+        avatarUrl: parsed.avatarUrl,
+      },
+      content: parsed.text,
+      url: `https://play.google.com/store/apps/details?id=${encodeURIComponent(appId)}&reviewId=${encodeURIComponent(parsed.id)}`,
+      createdAt: new Date(parsed.timestampMs || Date.now()).toISOString(),
+      meta: {
+        rating: parsed.rating,
+        version: parsed.version,
+        country,
+        platform: "google-play",
+        thumbsUp: parsed.thumbsUp,
+      },
+    });
+  }
+  return items;
+}
+
+// ---- Public entry point ----------------------------------------------------
+
+export async function fetchReviews(
+  platform: AppReviewPlatform,
+  appId: string,
+  country: string,
+): Promise<FeedItem<AppReviewMeta>[]> {
+  const id = appId.trim();
+  if (!id) throw new Error("App ID is required.");
+  const c = (country.trim() || "us").toLowerCase();
+  if (platform === "app-store") {
+    if (!/^\d+$/.test(id)) {
+      throw new Error("App Store ID must be numeric (e.g. 284882215).");
+    }
+    return fetchAppStoreReviews(id, c);
+  }
+  return fetchGooglePlayReviews(id, c);
+}

--- a/lib/integrations/blockscout.ts
+++ b/lib/integrations/blockscout.ts
@@ -1,0 +1,304 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// Multi-chain Blockscout REST v2 client. Keyless by default. If
+// `BLOCKSCOUT_API_KEY` is set, it's appended as `?apikey=` to every request
+// (Blockscout's Pro tier accepts the same param across all instances), which
+// raises rate limits without changing call sites.
+
+export const SUPPORTED_CHAINS = [
+  "ethereum",
+  "base",
+  "optimism",
+  "arbitrum",
+  "polygon",
+  "gnosis",
+  "scroll",
+  "celo",
+  "zksync",
+] as const;
+
+export type Chain = (typeof SUPPORTED_CHAINS)[number];
+
+interface ChainInfo {
+  chainId: number;
+  host: string;
+  nativeSymbol: string;
+  label: string;
+}
+
+const CHAINS: Record<Chain, ChainInfo> = {
+  ethereum: { chainId: 1, host: "eth.blockscout.com", nativeSymbol: "ETH", label: "Ethereum" },
+  base: { chainId: 8453, host: "base.blockscout.com", nativeSymbol: "ETH", label: "Base" },
+  optimism: { chainId: 10, host: "optimism.blockscout.com", nativeSymbol: "ETH", label: "Optimism" },
+  arbitrum: { chainId: 42161, host: "arbitrum.blockscout.com", nativeSymbol: "ETH", label: "Arbitrum" },
+  polygon: { chainId: 137, host: "polygon.blockscout.com", nativeSymbol: "POL", label: "Polygon" },
+  gnosis: { chainId: 100, host: "gnosis.blockscout.com", nativeSymbol: "xDAI", label: "Gnosis" },
+  scroll: { chainId: 534352, host: "scroll.blockscout.com", nativeSymbol: "ETH", label: "Scroll" },
+  celo: { chainId: 42220, host: "celo.blockscout.com", nativeSymbol: "CELO", label: "Celo" },
+  zksync: { chainId: 324, host: "zksync.blockscout.com", nativeSymbol: "ETH", label: "zkSync" },
+};
+
+export function getChainInfo(chain: Chain): ChainInfo {
+  return CHAINS[chain];
+}
+
+export function explorerTxUrl(chain: Chain, hash: string): string {
+  return `https://${CHAINS[chain].host}/tx/${hash}`;
+}
+
+export function explorerAddressUrl(chain: Chain, address: string): string {
+  return `https://${CHAINS[chain].host}/address/${address}`;
+}
+
+export interface WalletTxMeta {
+  chainId: number;
+  hash: string;
+  from: string;
+  to: string;
+  value: string;
+  valueUsd?: number;
+  method?: string;
+  status: "success" | "failed";
+  blockNumber: number;
+  gasUsed?: string;
+  [key: string]: unknown;
+}
+
+interface BSAddressRef {
+  hash?: string;
+  name?: string | null;
+  is_contract?: boolean;
+}
+
+interface BSTokenInfo {
+  symbol?: string | null;
+  decimals?: string | null;
+  exchange_rate?: string | null;
+}
+
+interface BSTokenTransfer {
+  from?: BSAddressRef;
+  to?: BSAddressRef;
+  total?: { value?: string | null; decimals?: string | null };
+  token?: BSTokenInfo;
+}
+
+interface BSTransaction {
+  hash: string;
+  from?: BSAddressRef;
+  to?: BSAddressRef | null;
+  value?: string | null;
+  fee?: { value?: string | null } | null;
+  gas_used?: string | null;
+  block_number?: number | null;
+  block?: number | null;
+  status?: string | null;
+  result?: string | null;
+  method?: string | null;
+  timestamp?: string | null;
+  tx_types?: string[];
+  transaction_types?: string[];
+  exchange_rate?: string | null;
+  token_transfers?: BSTokenTransfer[];
+}
+
+interface BSResponse<T> {
+  items?: T[];
+  next_page_params?: Record<string, unknown> | null;
+  message?: string;
+}
+
+const EVM_ADDR_RE = /^0x[a-fA-F0-9]{40}$/;
+
+export function isValidEvmAddress(addr: string): boolean {
+  return EVM_ADDR_RE.test(addr.trim());
+}
+
+function buildUrl(
+  chain: Chain,
+  path: string,
+  params?: Record<string, string>,
+): string {
+  const url = new URL(`https://${CHAINS[chain].host}/api/v2${path}`);
+  if (params) {
+    for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  }
+  const key = process.env.BLOCKSCOUT_API_KEY;
+  if (key) url.searchParams.set("apikey", key);
+  return url.toString();
+}
+
+export function encodeCursor(next: Record<string, unknown> | null | undefined): string | undefined {
+  if (!next || Object.keys(next).length === 0) return undefined;
+  const json = JSON.stringify(next);
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+export function decodeCursor(cursor?: string): Record<string, string> | undefined {
+  if (!cursor) return undefined;
+  try {
+    const json = Buffer.from(cursor, "base64url").toString("utf8");
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (v === null || v === undefined) continue;
+      out[k] = String(v);
+    }
+    return out;
+  } catch {
+    return undefined;
+  }
+}
+
+function formatUnits(raw: string, decimals: number): string {
+  const negative = raw.startsWith("-");
+  const digits = (negative ? raw.slice(1) : raw).replace(/^0+/, "") || "0";
+  if (decimals === 0) return (negative ? "-" : "") + digits;
+  const padded = digits.padStart(decimals + 1, "0");
+  const whole = padded.slice(0, padded.length - decimals);
+  const frac = padded.slice(padded.length - decimals).replace(/0+$/, "");
+  const sign = negative ? "-" : "";
+  return frac ? `${sign}${whole}.${frac}` : `${sign}${whole}`;
+}
+
+function trimDecimals(value: string, maxFrac = 6): string {
+  const [whole, frac] = value.split(".");
+  if (!frac) return whole;
+  const trimmed = frac.slice(0, maxFrac).replace(/0+$/, "");
+  return trimmed ? `${whole}.${trimmed}` : whole;
+}
+
+function pickValueDisplay(
+  tx: BSTransaction,
+  nativeSymbol: string,
+): { display: string; symbol: string; rawWei: string; rate?: number } {
+  const valueWei = tx.value && tx.value !== "0" ? tx.value : null;
+  if (valueWei) {
+    const human = formatUnits(valueWei, 18);
+    const rate = parseFloatOrUndef(tx.exchange_rate);
+    return {
+      display: trimDecimals(human, 6),
+      symbol: nativeSymbol,
+      rawWei: valueWei,
+      rate,
+    };
+  }
+
+  const transfer = tx.token_transfers?.[0];
+  if (transfer?.total?.value && transfer.token) {
+    const decimals = Number(transfer.total.decimals ?? transfer.token.decimals ?? "18") || 0;
+    const symbol = transfer.token.symbol ?? "TOKEN";
+    const display = trimDecimals(formatUnits(transfer.total.value, decimals), 6);
+    const rate = parseFloatOrUndef(transfer.token.exchange_rate);
+    return { display, symbol, rawWei: transfer.total.value, rate };
+  }
+
+  return { display: "0", symbol: nativeSymbol, rawWei: "0" };
+}
+
+function parseFloatOrUndef(s?: string | null): number | undefined {
+  if (!s) return undefined;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function statusFrom(tx: BSTransaction): "success" | "failed" {
+  const s = (tx.status ?? tx.result ?? "").toString().toLowerCase();
+  if (s === "ok" || s === "success") return "success";
+  if (s === "error" || s === "failed" || s === "fail") return "failed";
+  return "success";
+}
+
+export async function fetchAddressTransactions(
+  chain: Chain,
+  address: string,
+  cursor?: string,
+): Promise<{ items: FeedItem<WalletTxMeta>[]; nextCursor?: string }> {
+  if (!isValidEvmAddress(address)) {
+    throw new Error(
+      `Invalid address "${address}". Expected a 0x-prefixed 42-character EVM address.`,
+    );
+  }
+  const info = CHAINS[chain];
+  const params = decodeCursor(cursor);
+  const url = buildUrl(chain, `/addresses/${address}/transactions`, params);
+
+  const res = await fetch(url, {
+    headers: { accept: "application/json", "user-agent": "minitor/0.1" },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Blockscout ${info.host} ${res.status}: ${body.slice(0, 200)}`);
+  }
+
+  const json = (await res.json()) as BSResponse<BSTransaction>;
+  if (json.message && !json.items) {
+    throw new Error(`Blockscout ${info.host}: ${json.message}`);
+  }
+
+  const items = (json.items ?? []).map((tx): FeedItem<WalletTxMeta> => {
+    const value = pickValueDisplay(tx, info.nativeSymbol);
+    const valueNum = Number(value.display);
+    const valueUsd =
+      value.rate !== undefined && Number.isFinite(valueNum) && valueNum > 0
+        ? valueNum * value.rate
+        : undefined;
+    const status = statusFrom(tx);
+    const blockNumber = tx.block_number ?? tx.block ?? 0;
+    const fromAddr = tx.from?.hash ?? "";
+    const toAddr = tx.to?.hash ?? "";
+    const methodRaw = tx.method?.trim() || undefined;
+    const method = methodRaw ?? inferMethodLabel(tx, address, fromAddr);
+
+    return {
+      id: `${info.chainId}-${tx.hash}`,
+      author: {
+        name: shortAddress(fromAddr || address),
+        handle: fromAddr || address,
+        avatarUrl: `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(fromAddr || address)}`,
+      },
+      content: `${value.display} ${value.symbol}`,
+      url: explorerTxUrl(chain, tx.hash),
+      createdAt: tx.timestamp ?? new Date().toISOString(),
+      meta: {
+        chainId: info.chainId,
+        hash: tx.hash,
+        from: fromAddr,
+        to: toAddr,
+        value: `${value.display} ${value.symbol}`,
+        valueUsd,
+        method,
+        status,
+        blockNumber,
+        gasUsed: tx.gas_used ?? undefined,
+      },
+    };
+  });
+
+  return {
+    items,
+    nextCursor: encodeCursor(json.next_page_params ?? undefined),
+  };
+}
+
+function shortAddress(addr: string): string {
+  if (!addr) return "unknown";
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function inferMethodLabel(
+  tx: BSTransaction,
+  watched: string,
+  from: string,
+): string | undefined {
+  const types = tx.tx_types ?? tx.transaction_types ?? [];
+  if (types.includes("token_transfer")) return "Token transfer";
+  if (types.includes("coin_transfer")) {
+    return from.toLowerCase() === watched.toLowerCase() ? "Send" : "Receive";
+  }
+  if (types.includes("contract_call")) return "Contract call";
+  if (types.includes("contract_creation")) return "Contract creation";
+  return undefined;
+}

--- a/lib/integrations/github-backlinks.ts
+++ b/lib/integrations/github-backlinks.ts
@@ -1,0 +1,174 @@
+import type { FeedItem } from "@/lib/columns/types";
+import { fetchGitHub } from "@/lib/integrations/github";
+import { fetchHackerNews } from "@/lib/integrations/hackernews";
+import { searchReddit } from "@/lib/integrations/reddit";
+import { fetchFeed, googleNewsUrl } from "@/lib/integrations/rss";
+import { grokWebSearch } from "@/lib/integrations/xai";
+
+export type BacklinkSource =
+  | "hn"
+  | "reddit"
+  | "google-news"
+  | "bing-news"
+  | "github"
+  | "web";
+
+export interface BacklinksConfig {
+  repo: string;
+  includeIssues?: boolean;
+  includeWebSearch?: boolean;
+  limitPerSource?: number;
+}
+
+export interface NormalizedRepo {
+  ownerRepo: string;
+  canonicalUrl: string;
+}
+
+export function normalizeRepo(input: string): NormalizedRepo {
+  const trimmed = input.trim();
+  if (!trimmed) throw new Error("Repo is required (owner/repo or full URL).");
+  const stripped = trimmed
+    .replace(/^https?:\/\//i, "")
+    .replace(/^github\.com\//i, "")
+    .replace(/\.git$/i, "")
+    .replace(/\/+$/, "");
+  if (!/^[\w.-]+\/[\w.-]+$/.test(stripped)) {
+    throw new Error(
+      `Invalid repo "${input}". Use owner/repo (e.g. vercel/next.js) or https://github.com/owner/repo.`,
+    );
+  }
+  return {
+    ownerRepo: stripped,
+    canonicalUrl: `https://github.com/${stripped}`,
+  };
+}
+
+const TRACKING_PARAMS = new Set([
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "fbclid",
+  "gclid",
+  "mc_cid",
+  "mc_eid",
+  "ref",
+]);
+
+function canonicalize(url: string): string {
+  try {
+    const u = new URL(url);
+    u.hostname = u.hostname.toLowerCase().replace(/^www\./, "");
+    for (const p of [...u.searchParams.keys()]) {
+      if (TRACKING_PARAMS.has(p.toLowerCase())) u.searchParams.delete(p);
+    }
+    u.hash = "";
+    let s = u.toString();
+    if (s.endsWith("/")) s = s.slice(0, -1);
+    return s;
+  } catch {
+    return url;
+  }
+}
+
+function tag(
+  items: FeedItem[],
+  source: BacklinkSource,
+  canonicalUrl: string,
+): FeedItem[] {
+  return items.map((it) => ({
+    ...it,
+    id: `${source}-${it.id}`,
+    meta: { ...(it.meta ?? {}), source, canonicalUrl },
+  }));
+}
+
+export async function fetchBacklinks(
+  config: BacklinksConfig,
+): Promise<FeedItem[]> {
+  const { ownerRepo, canonicalUrl } = normalizeRepo(config.repo);
+  const limit = config.limitPerSource ?? 8;
+
+  const tasks: Promise<FeedItem[]>[] = [];
+
+  // Algolia indexes HN submissions by URL — full URL query matches against the url field.
+  tasks.push(
+    fetchHackerNews("query", canonicalUrl, limit).then((items) =>
+      tag(items, "hn", canonicalUrl),
+    ),
+  );
+
+  // Reddit search — returns posts whose body or link URL matches.
+  tasks.push(
+    searchReddit(canonicalUrl, limit).then((items) =>
+      tag(items, "reddit", canonicalUrl),
+    ),
+  );
+
+  // Google News + Bing News scoped to canonical URL OR owner/repo phrase.
+  const newsQuery = `"${canonicalUrl}" OR "${ownerRepo}"`;
+  tasks.push(
+    fetchFeed(googleNewsUrl(newsQuery), limit).then((items) =>
+      tag(items, "google-news", canonicalUrl),
+    ),
+  );
+  const bingUrl = `https://www.bing.com/news/search?q=${encodeURIComponent(
+    newsQuery,
+  )}&format=rss`;
+  tasks.push(
+    fetchFeed(bingUrl, limit).then((items) =>
+      tag(items, "bing-news", canonicalUrl),
+    ),
+  );
+
+  // GitHub issues/PRs across the rest of GitHub that mention this repo URL.
+  // -repo:owner/name strips out the repo's own self-references.
+  if (config.includeIssues ?? true) {
+    const ghQuery = `${canonicalUrl} -repo:${ownerRepo}`;
+    tasks.push(
+      fetchGitHub("issues", { query: ghQuery }, limit).then((items) =>
+        tag(items, "github", canonicalUrl),
+      ),
+    );
+  }
+
+  // Optional Grok web search — only when XAI_API_KEY is set and user opts in.
+  if (config.includeWebSearch) {
+    tasks.push(
+      grokWebSearch(`pages linking to "${canonicalUrl}"`, limit).then(
+        (items) => tag(items, "web", canonicalUrl),
+      ),
+    );
+  }
+
+  const settled = await Promise.allSettled(tasks);
+  const errors: string[] = [];
+  const all: FeedItem[] = [];
+  for (const r of settled) {
+    if (r.status === "fulfilled") {
+      all.push(...r.value);
+    } else {
+      errors.push(
+        r.reason instanceof Error ? r.reason.message : String(r.reason),
+      );
+    }
+  }
+
+  if (all.length === 0 && errors.length > 0) {
+    throw new Error(`All sources failed:\n${errors.join("\n")}`);
+  }
+
+  const seen = new Set<string>();
+  const deduped: FeedItem[] = [];
+  for (const it of all) {
+    const key = canonicalize(it.url ?? it.id);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(it);
+  }
+
+  deduped.sort((a, b) => +new Date(b.createdAt) - +new Date(a.createdAt));
+  return deduped.slice(0, limit * 2);
+}

--- a/lib/integrations/github.ts
+++ b/lib/integrations/github.ts
@@ -4,6 +4,8 @@ const API = "https://api.github.com";
 
 export type GHMode = "trending" | "releases" | "issues";
 
+export type GHSearchScope = "repositories" | "issues" | "code" | "commits";
+
 interface GHRepo {
   id: number;
   full_name: string;
@@ -50,6 +52,27 @@ interface GHSearchResponse<T> {
   items?: T[];
   message?: string;
   total_count?: number;
+}
+
+interface GHPullRequest {
+  id: number;
+  number: number;
+  title: string;
+  body: string | null;
+  html_url: string;
+  state: "open" | "closed";
+  draft: boolean;
+  created_at: string;
+  updated_at: string;
+  merged_at: string | null;
+  closed_at: string | null;
+  comments?: number;
+  additions?: number;
+  deletions?: number;
+  changed_files?: number;
+  base: { ref: string };
+  head: { ref: string };
+  user?: { login: string; avatar_url?: string } | null;
 }
 
 function headers(): HeadersInit {
@@ -224,6 +247,82 @@ async function fetchIssues(
   });
 }
 
+export interface GHPRItemMeta {
+  number: number;
+  state: "open" | "closed" | "merged";
+  isDraft: boolean;
+  additions?: number;
+  deletions?: number;
+  changedFiles?: number;
+  baseBranch: string;
+  headBranch: string;
+  commentsCount: number;
+  repo: string;
+  mergedAt?: string;
+}
+
+export async function fetchPullRequests(
+  repo: string,
+  state: "open" | "closed" | "all",
+  sort: "created" | "updated",
+  limit: number,
+  page = 1,
+): Promise<FeedItem<GHPRItemMeta>[]> {
+  const clean = repo.trim().replace(/^https?:\/\/github\.com\//, "");
+  if (!/^[\w.-]+\/[\w.-]+$/.test(clean)) {
+    throw new Error(`Invalid repo "${repo}". Use owner/repo (e.g. vercel/next.js).`);
+  }
+  const params = new URLSearchParams({
+    state,
+    sort,
+    direction: "desc",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const prs = await ghFetch<GHPullRequest[]>(
+    `${API}/repos/${clean}/pulls?${params}`,
+  );
+  return prs.slice(0, limit).map((p) => {
+    const user = p.user?.login ?? "anonymous";
+    const merged = p.state === "closed" && !!p.merged_at;
+    const display: GHPRItemMeta["state"] = merged
+      ? "merged"
+      : p.state === "closed"
+        ? "closed"
+        : "open";
+    const body = (p.body ?? "").trim();
+    const trimmed =
+      body.length > 400 ? `${body.slice(0, 400).trimEnd()}…` : body;
+    const sortField = sort === "created" ? p.created_at : p.updated_at;
+    return {
+      id: `pr-${p.id}`,
+      author: {
+        name: user,
+        handle: user,
+        avatarUrl:
+          p.user?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(user)}`,
+      },
+      content: trimmed ? `${p.title}\n\n${trimmed}` : p.title,
+      url: p.html_url,
+      createdAt: sortField,
+      meta: {
+        number: p.number,
+        state: display,
+        isDraft: p.draft,
+        additions: p.additions,
+        deletions: p.deletions,
+        changedFiles: p.changed_files,
+        baseBranch: p.base.ref,
+        headBranch: p.head.ref,
+        commentsCount: p.comments ?? 0,
+        repo: clean,
+        mergedAt: p.merged_at ?? undefined,
+      },
+    } satisfies FeedItem<GHPRItemMeta>;
+  });
+}
+
 export async function fetchGitHub(
   mode: GHMode,
   config: { language?: string; period?: string; repo?: string; query?: string },
@@ -243,4 +342,546 @@ export async function fetchGitHub(
       return fetchTrending(config.language ?? "", period, limit, page);
     }
   }
+}
+
+// ---- Free-form search across scopes (used by github-search plugin) ---------
+
+interface GHCodeResult {
+  sha: string;
+  name: string;
+  path: string;
+  html_url: string;
+  repository: {
+    full_name: string;
+    pushed_at?: string;
+    owner?: { login: string; avatar_url?: string };
+  };
+  text_matches?: Array<{ fragment?: string }>;
+}
+
+interface GHCommitResult {
+  sha: string;
+  html_url: string;
+  commit: {
+    message: string;
+    author?: { name?: string; email?: string; date?: string };
+  };
+  author?: { login: string; avatar_url?: string } | null;
+  repository: { full_name: string };
+}
+
+function buildQuery(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+  // GitHub indexes URLs in code/issues but tokenizes on punctuation, so a
+  // bare URL becomes many separate matches. Quote it for an exact match —
+  // unless the user already wrapped it themselves.
+  if (/^https?:\/\//i.test(trimmed) && !/^".*"$/.test(trimmed)) {
+    return `"${trimmed}"`;
+  }
+  return trimmed;
+}
+
+async function searchRepos(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  const params = new URLSearchParams({
+    q: query,
+    sort: "updated",
+    order: "desc",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const json = await ghFetch<GHSearchResponse<GHRepo>>(
+    `${API}/search/repositories?${params}`,
+  );
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((r) => {
+    const owner = r.owner?.login ?? r.full_name.split("/")[0] ?? "github";
+    return {
+      id: `ghs-repo-${r.id}`,
+      author: {
+        name: owner,
+        handle: owner,
+        avatarUrl:
+          r.owner?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(owner)}`,
+      },
+      content: r.description
+        ? `${r.full_name}\n\n${r.description}`
+        : r.full_name,
+      url: r.html_url,
+      createdAt: r.pushed_at ?? r.created_at,
+      meta: {
+        scope: "repositories" as const,
+        repo: r.full_name,
+        stars: r.stargazers_count,
+        forks: r.forks_count,
+        language: r.language ?? undefined,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+async function searchIssuesScope(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  const params = new URLSearchParams({
+    q: query,
+    sort: "updated",
+    order: "desc",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const json = await ghFetch<GHSearchResponse<GHIssue>>(
+    `${API}/search/issues?${params}`,
+  );
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((i) => {
+    const user = i.user?.login ?? "anonymous";
+    const isPr = !!i.pull_request;
+    const repo = i.repository_url.replace(`${API}/repos/`, "");
+    const body = (i.body ?? "").trim();
+    const trimmed =
+      body.length > 400 ? `${body.slice(0, 400).trimEnd()}…` : body;
+    return {
+      id: `ghs-iss-${i.id}`,
+      author: {
+        name: user,
+        handle: user,
+        avatarUrl:
+          i.user?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(user)}`,
+      },
+      content: trimmed ? `${i.title}\n\n${trimmed}` : i.title,
+      url: i.html_url,
+      createdAt: i.updated_at ?? i.created_at,
+      meta: {
+        scope: "issues" as const,
+        repo,
+        number: i.number,
+        state: i.state,
+        comments: i.comments,
+        isPr,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+async function searchCode(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error(
+      "GitHub code search requires a token. Set GITHUB_TOKEN in your env (read-only public scope is enough).",
+    );
+  }
+  const params = new URLSearchParams({
+    q: query,
+    per_page: String(limit),
+    page: String(page),
+  });
+  const res = await fetch(`${API}/search/code?${params}`, {
+    headers: {
+      ...(headers() as Record<string, string>),
+      // text-match returns a `fragment` snippet around each hit
+      accept: "application/vnd.github.text-match+json",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as GHSearchResponse<GHCodeResult>;
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((c) => {
+    const owner =
+      c.repository.owner?.login ??
+      c.repository.full_name.split("/")[0] ??
+      "github";
+    const fragment = (c.text_matches?.[0]?.fragment ?? "").trim();
+    const snippet =
+      fragment.length > 400
+        ? `${fragment.slice(0, 400).trimEnd()}…`
+        : fragment;
+    const title = `${c.repository.full_name} · ${c.path}`;
+    return {
+      id: `ghs-code-${c.repository.full_name}-${c.sha}-${c.path}`,
+      author: {
+        name: owner,
+        handle: owner,
+        avatarUrl:
+          c.repository.owner?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(owner)}`,
+      },
+      content: snippet ? `${title}\n\n${snippet}` : title,
+      url: c.html_url,
+      createdAt: c.repository.pushed_at ?? new Date().toISOString(),
+      meta: {
+        scope: "code" as const,
+        repo: c.repository.full_name,
+        path: c.path,
+        sha: c.sha,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+async function searchCommits(
+  query: string,
+  limit: number,
+  page: number,
+): Promise<FeedItem[]> {
+  const params = new URLSearchParams({
+    q: query,
+    sort: "author-date",
+    order: "desc",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const json = await ghFetch<GHSearchResponse<GHCommitResult>>(
+    `${API}/search/commits?${params}`,
+  );
+  if (json.message) throw new Error(json.message);
+  return (json.items ?? []).slice(0, limit).map((c) => {
+    const handle =
+      c.author?.login ?? c.commit.author?.name ?? "unknown";
+    const message = (c.commit.message ?? "").trim();
+    const [firstLine, ...rest] = message.split("\n");
+    const restJoined = rest.join("\n").trim();
+    const trimmed =
+      restJoined.length > 400
+        ? `${restJoined.slice(0, 400).trimEnd()}…`
+        : restJoined;
+    return {
+      id: `ghs-commit-${c.sha}`,
+      author: {
+        name: handle,
+        handle,
+        avatarUrl:
+          c.author?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(handle)}`,
+      },
+      content: trimmed ? `${firstLine}\n\n${trimmed}` : firstLine,
+      url: c.html_url,
+      createdAt: c.commit.author?.date ?? new Date().toISOString(),
+      meta: {
+        scope: "commits" as const,
+        repo: c.repository.full_name,
+        sha: c.sha,
+      },
+    } satisfies FeedItem;
+  });
+}
+
+export async function searchGitHub(
+  scope: GHSearchScope,
+  rawQuery: string,
+  limit = 12,
+  page = 1,
+): Promise<FeedItem[]> {
+  const query = buildQuery(rawQuery);
+  if (!query) {
+    throw new Error("Query is required for GitHub search.");
+  }
+  switch (scope) {
+    case "repositories":
+      return searchRepos(query, limit, page);
+    case "issues":
+      return searchIssuesScope(query, limit, page);
+    case "code":
+      return searchCode(query, limit, page);
+    case "commits":
+      return searchCommits(query, limit, page);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stargazers + forks (used by the github-watchers plugin)
+// ---------------------------------------------------------------------------
+
+export interface GHWatcherItemMeta {
+  kind: "star" | "fork";
+  repo: string;
+  forkUrl?: string;
+  starredAt?: string;
+  forkedAt?: string;
+}
+
+export type GHWatcherItem = FeedItem<GHWatcherItemMeta>;
+
+export interface GHWatcherPage {
+  items: GHWatcherItem[];
+  nextCursor?: string;
+}
+
+export function normalizeGitHubRepo(input: string): string {
+  const clean = input
+    .trim()
+    .replace(/^https?:\/\//, "")
+    .replace(/^github\.com\//, "")
+    .replace(/\/+$/, "");
+  if (!/^[\w.-]+\/[\w.-]+$/.test(clean)) {
+    throw new Error(
+      `Invalid repo "${input}". Use owner/repo (e.g. vercel/next.js).`,
+    );
+  }
+  return clean;
+}
+
+function parseLastPage(linkHeader: string | null): number | undefined {
+  if (!linkHeader) return undefined;
+  // Link: <...&page=42>; rel="last", <...&page=2>; rel="next"
+  for (const part of linkHeader.split(",")) {
+    const m = /<([^>]+)>;\s*rel="last"/.exec(part.trim());
+    if (m) {
+      try {
+        const u = new URL(m[1]);
+        const p = u.searchParams.get("page");
+        if (p) return Number(p);
+      } catch {
+        // ignore
+      }
+    }
+  }
+  return undefined;
+}
+
+interface GHStargazerEdgeREST {
+  starred_at: string;
+  user: { login: string; avatar_url?: string; html_url?: string };
+}
+
+async function ghFetchStargazersPageREST(
+  fullRepo: string,
+  page: number,
+  perPage: number,
+): Promise<{ items: GHWatcherItem[]; lastPage?: number }> {
+  const params = new URLSearchParams({
+    per_page: String(perPage),
+    page: String(page),
+  });
+  const url = `${API}/repos/${fullRepo}/stargazers?${params}`;
+  const res = await fetch(url, {
+    headers: {
+      ...headers(),
+      // star+json is required to receive `starred_at` timestamps.
+      accept: "application/vnd.github.star+json",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const lastPage = parseLastPage(res.headers.get("link"));
+  const json = (await res.json()) as GHStargazerEdgeREST[];
+  const items = json.map((edge) => {
+    const u = edge.user;
+    return {
+      id: `gh-star-${fullRepo}-${u.login}`,
+      author: {
+        name: u.login,
+        handle: u.login,
+        avatarUrl:
+          u.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(u.login)}`,
+      },
+      content: `${u.login} starred ${fullRepo}`,
+      url: u.html_url ?? `https://github.com/${u.login}`,
+      createdAt: edge.starred_at,
+      meta: {
+        kind: "star",
+        repo: fullRepo,
+        starredAt: edge.starred_at,
+      },
+    } satisfies GHWatcherItem;
+  });
+  return { items, lastPage };
+}
+
+interface GHGraphQLStargazersResponse {
+  data?: {
+    repository: {
+      stargazers: {
+        pageInfo: { endCursor: string | null; hasNextPage: boolean };
+        edges: Array<{
+          starredAt: string;
+          node: { login: string; avatarUrl?: string; url?: string };
+        }>;
+      } | null;
+    } | null;
+  };
+  errors?: Array<{ message: string }>;
+}
+
+async function fetchStargazersGraphQL(
+  fullRepo: string,
+  limit: number,
+  cursor?: string,
+): Promise<GHWatcherPage> {
+  const [owner, name] = fullRepo.split("/");
+  const query = `
+    query($owner:String!, $name:String!, $first:Int!, $after:String) {
+      repository(owner:$owner, name:$name) {
+        stargazers(first:$first, after:$after, orderBy:{field:STARRED_AT, direction:DESC}) {
+          pageInfo { endCursor hasNextPage }
+          edges {
+            starredAt
+            node { login avatarUrl url }
+          }
+        }
+      }
+    }
+  `;
+  const res = await fetch(`${API}/graphql`, {
+    method: "POST",
+    headers: { ...headers(), "content-type": "application/json" },
+    body: JSON.stringify({
+      query,
+      variables: { owner, name, first: limit, after: cursor ?? null },
+    }),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub GraphQL ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as GHGraphQLStargazersResponse;
+  if (json.errors?.length) {
+    throw new Error(json.errors.map((e) => e.message).join("; "));
+  }
+  const sg = json.data?.repository?.stargazers;
+  if (!sg) throw new Error(`Repository ${fullRepo} not found.`);
+  const items = sg.edges.map((edge) => {
+    const u = edge.node;
+    return {
+      id: `gh-star-${fullRepo}-${u.login}`,
+      author: {
+        name: u.login,
+        handle: u.login,
+        avatarUrl:
+          u.avatarUrl ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(u.login)}`,
+      },
+      content: `${u.login} starred ${fullRepo}`,
+      url: u.url ?? `https://github.com/${u.login}`,
+      createdAt: edge.starredAt,
+      meta: {
+        kind: "star",
+        repo: fullRepo,
+        starredAt: edge.starredAt,
+      },
+    } satisfies GHWatcherItem;
+  });
+  return {
+    items,
+    nextCursor:
+      sg.pageInfo.hasNextPage && sg.pageInfo.endCursor
+        ? `gql:${sg.pageInfo.endCursor}`
+        : undefined,
+  };
+}
+
+async function fetchStargazersREST(
+  fullRepo: string,
+  limit: number,
+  cursor?: string,
+): Promise<GHWatcherPage> {
+  // REST sorts oldest-first. To surface newest-first we must walk the Link
+  // header to find the last page, then page backwards from there.
+  let pageToFetch: number;
+  if (cursor) {
+    pageToFetch = Number(cursor);
+    if (!Number.isFinite(pageToFetch) || pageToFetch < 1) {
+      return { items: [] };
+    }
+  } else {
+    const probe = await ghFetchStargazersPageREST(fullRepo, 1, limit);
+    pageToFetch = probe.lastPage ?? 1;
+  }
+  const { items } = await ghFetchStargazersPageREST(
+    fullRepo,
+    pageToFetch,
+    limit,
+  );
+  items.reverse();
+  return {
+    items,
+    nextCursor: pageToFetch > 1 ? String(pageToFetch - 1) : undefined,
+  };
+}
+
+export async function fetchStargazers(
+  repo: string,
+  limit = 12,
+  cursor?: string,
+): Promise<GHWatcherPage> {
+  const fullRepo = normalizeGitHubRepo(repo);
+  if (process.env.GITHUB_TOKEN) {
+    return fetchStargazersGraphQL(
+      fullRepo,
+      limit,
+      cursor?.startsWith("gql:") ? cursor.slice(4) : undefined,
+    );
+  }
+  return fetchStargazersREST(fullRepo, limit, cursor);
+}
+
+interface GHForkREST {
+  id: number;
+  full_name: string;
+  html_url: string;
+  created_at: string;
+  owner?: { login: string; avatar_url?: string; html_url?: string };
+}
+
+export async function fetchForks(
+  repo: string,
+  limit = 12,
+  cursor?: string,
+): Promise<GHWatcherPage> {
+  const fullRepo = normalizeGitHubRepo(repo);
+  const page = cursor ? Number(cursor) || 1 : 1;
+  const params = new URLSearchParams({
+    sort: "newest",
+    per_page: String(limit),
+    page: String(page),
+  });
+  const forks = await ghFetch<GHForkREST[]>(
+    `${API}/repos/${fullRepo}/forks?${params}`,
+  );
+  const items: GHWatcherItem[] = forks.map((f) => {
+    const owner = f.owner?.login ?? f.full_name.split("/")[0] ?? "github";
+    return {
+      id: `gh-fork-${f.id}`,
+      author: {
+        name: owner,
+        handle: owner,
+        avatarUrl:
+          f.owner?.avatar_url ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(owner)}`,
+      },
+      content: `${owner} forked ${fullRepo}`,
+      url: f.owner?.html_url ?? `https://github.com/${owner}`,
+      createdAt: f.created_at,
+      meta: {
+        kind: "fork",
+        repo: fullRepo,
+        forkUrl: f.html_url,
+        forkedAt: f.created_at,
+      },
+    };
+  });
+  return {
+    items,
+    nextCursor: items.length === limit ? String(page + 1) : undefined,
+  };
 }

--- a/lib/integrations/hackernews.ts
+++ b/lib/integrations/hackernews.ts
@@ -18,6 +18,8 @@ interface AlgoliaHit {
   created_at?: string;
   created_at_i?: number;
   story_text?: string;
+  comment_text?: string;
+  story_id?: number;
   _tags?: string[];
 }
 
@@ -126,4 +128,147 @@ export async function fetchHackerNews(
 ): Promise<FeedItem[]> {
   const { items } = await fetchHackerNewsPage(mode, query, limit, 0);
   return items;
+}
+
+// ---- Mentions search ------------------------------------------------------
+
+export type HNSearchScope = "all" | "stories" | "comments";
+export type HNSearchSort = "relevance" | "date";
+
+export interface HNSearchHitMeta {
+  points: number;
+  comments: number;
+  commentsUrl: string;
+  externalUrl?: string;
+  kind: "story" | "comment";
+  storyTitle?: string;
+}
+
+function looksLikeUrl(s: string): boolean {
+  const t = s.trim();
+  if (!t) return false;
+  if (/^https?:\/\//i.test(t)) return true;
+  if (/^www\./i.test(t)) return true;
+  // bare domain or domain+path: at least one dot, recognizable TLD-ish suffix.
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)+(\/[^\s]*)?$/i.test(t);
+}
+
+function normalizeUrlForSearch(s: string): string {
+  return s
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/\/+$/, "");
+}
+
+function decodeSnippet(s: string | undefined): string {
+  return (
+    s
+      ?.replace(/<[^>]+>/g, "")
+      .replace(/&#x27;/g, "'")
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, "&")
+      .trim() ?? ""
+  );
+}
+
+function isCommentHit(h: AlgoliaHit): boolean {
+  if (Array.isArray(h._tags) && h._tags.includes("comment")) return true;
+  return typeof h.comment_text === "string" && h.comment_text.length > 0;
+}
+
+function mapSearchHit(h: AlgoliaHit): FeedItem<HNSearchHitMeta> {
+  const comment = isCommentHit(h);
+  const storyTitle = h.story_title ?? h.title ?? "(untitled)";
+  const externalUrl = h.url ?? h.story_url;
+  const itemUrl = `https://news.ycombinator.com/item?id=${h.objectID}`;
+  const author = h.author ?? "anonymous";
+  const createdMs =
+    typeof h.created_at_i === "number"
+      ? h.created_at_i * 1000
+      : h.created_at
+        ? Date.parse(h.created_at)
+        : Date.now();
+
+  const snippet = decodeSnippet(comment ? h.comment_text : h.story_text);
+  const content = comment
+    ? snippet || `Comment on “${storyTitle}”`
+    : snippet
+      ? `${storyTitle}\n\n${snippet}`
+      : storyTitle;
+
+  return {
+    id: h.objectID,
+    author: {
+      name: author,
+      handle: author,
+      avatarUrl: `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(author)}`,
+    },
+    content,
+    url: comment ? itemUrl : (externalUrl ?? itemUrl),
+    createdAt: new Date(createdMs).toISOString(),
+    meta: {
+      points: h.points ?? 0,
+      comments: h.num_comments ?? 0,
+      commentsUrl: itemUrl,
+      externalUrl: externalUrl ?? undefined,
+      kind: comment ? "comment" : "story",
+      storyTitle: comment ? storyTitle : undefined,
+    },
+  };
+}
+
+export async function searchHackerNewsByUrlOrKeyword(
+  input: string,
+  opts: {
+    scope: HNSearchScope;
+    sort: HNSearchSort;
+    limit: number;
+    page: number;
+  },
+): Promise<{ items: FeedItem<HNSearchHitMeta>[]; hasMore: boolean }> {
+  const { scope, sort, limit, page } = opts;
+  const trimmed = input.trim();
+  if (!trimmed) return { items: [], hasMore: false };
+
+  const params = new URLSearchParams({
+    hitsPerPage: String(limit),
+    page: String(page),
+  });
+
+  const isUrl = looksLikeUrl(trimmed);
+  if (isUrl) {
+    params.set("query", normalizeUrlForSearch(trimmed));
+    // Algolia attribute scoping — only match against the indexed URL field
+    // so domain queries don't get diluted by title/comment matches.
+    params.set("restrictSearchableAttributes", "url");
+  } else {
+    params.set("query", trimmed);
+  }
+
+  switch (scope) {
+    case "stories":
+      params.set("tags", "story");
+      break;
+    case "comments":
+      params.set("tags", "comment");
+      break;
+    case "all":
+      params.set("tags", "(story,comment)");
+      break;
+  }
+
+  const path = sort === "date" ? "search_by_date" : "search";
+  const res = await fetch(`${ALGOLIA}/${path}?${params}`, {
+    headers: { accept: "application/json" },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`HN ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  const json = (await res.json()) as AlgoliaResponse;
+  const hits = json.hits ?? [];
+  const totalPages = typeof json.nbPages === "number" ? json.nbPages : 1;
+  const hasMore = page + 1 < totalPages && hits.length === limit;
+  return { items: hits.slice(0, limit).map(mapSearchHit), hasMore };
 }

--- a/lib/integrations/instagram.ts
+++ b/lib/integrations/instagram.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import type { FeedItem } from "@/lib/columns/types";
+import { grokWebSearch } from "./xai";
+
+// Instagram has no public hashtag/keyword search — Graph API requires per-user
+// OAuth + Business/Creator accounts (locked down 2018). This module wraps
+// grokWebSearch with a site:instagram.com filter as the default fetcher.
+//
+// To swap in a paid scraper later (Apify / Bright Data / Phantombuster /
+// RapidAPI), replace the body of `fetchInstagram` and update the plugin's
+// `capabilities.requiresEnv`. The signature is the seam — callers don't care
+// which backend produced the items.
+export async function fetchInstagram(query: string): Promise<FeedItem[]> {
+  const q = query.trim();
+  if (!q) return [];
+  const isUrl = /^https?:\/\//i.test(q);
+  const filter = isUrl
+    ? `site:instagram.com ${JSON.stringify(q)}`
+    : `site:instagram.com ${q}`;
+  return grokWebSearch(filter);
+}

--- a/lib/integrations/linkedin.ts
+++ b/lib/integrations/linkedin.ts
@@ -1,0 +1,48 @@
+import "server-only";
+
+// LinkedIn has no public search API and the official Marketing/REST API is
+// closed for this use case. We piggy-back on xAI Grok's web_search tool with a
+// site:linkedin.com/posts filter — same pattern as the web-search plugin, but
+// query-shaped and post-filtered to LinkedIn-only results.
+
+import type { FeedItem } from "@/lib/columns/types";
+import { grokWebSearch } from "@/lib/integrations/xai";
+
+function isLinkedinUrl(u: string | undefined): boolean {
+  if (!u) return false;
+  try {
+    const host = new URL(u).hostname.toLowerCase();
+    return host === "linkedin.com" || host.endsWith(".linkedin.com");
+  } catch {
+    return false;
+  }
+}
+
+function composeQuery(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return "site:linkedin.com/posts";
+  const isUrl = /^https?:\/\//i.test(trimmed);
+  const term = isUrl ? `"${trimmed}"` : trimmed;
+  return `site:linkedin.com/posts ${term}`;
+}
+
+export async function searchLinkedinPosts(
+  query: string,
+  limit = 8,
+): Promise<FeedItem[]> {
+  const composed = composeQuery(query);
+  const items = await grokWebSearch(composed, limit * 2);
+  return items
+    .filter((i) => isLinkedinUrl(i.url))
+    .map((i) => ({
+      ...i,
+      meta: {
+        source:
+          typeof i.author?.name === "string" && i.author.name
+            ? i.author.name
+            : "LinkedIn",
+        isLinkedin: true,
+      },
+    }))
+    .slice(0, limit);
+}

--- a/lib/integrations/rednote.ts
+++ b/lib/integrations/rednote.ts
@@ -1,0 +1,28 @@
+import type { FeedItem } from "@/lib/columns/types";
+import { grokWebSearch } from "@/lib/integrations/xai";
+
+// Rednote (Xiaohongshu / 小红书 / xhs) has no public API and aggressively
+// blocks anonymous scraping. The official open API is invitation-only for
+// brand partners. Best-effort path: scope a Grok web search to xhs domains.
+// Coverage is limited to pages indexed by public crawlers + shared
+// xhslink.com short URLs. To upgrade to a paid scraper (Bright Data, Apify,
+// RapidAPI), add a `process.env`-gated branch above the grok fallback —
+// callers don't change.
+const REDNOTE_DOMAINS =
+  "site:xiaohongshu.com OR site:xhs.cn OR site:xhslink.com";
+
+export async function fetchRednoteMentions(
+  query: string,
+  limit = 10,
+): Promise<FeedItem[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  const scoped = `${trimmed} (${REDNOTE_DOMAINS})`;
+  const items = await grokWebSearch(scoped, limit);
+
+  return items.map((item) => ({
+    ...item,
+    meta: { source: item.author.name, kind: "rednote" as const },
+  }));
+}

--- a/lib/integrations/substack.ts
+++ b/lib/integrations/substack.ts
@@ -1,0 +1,137 @@
+import "server-only";
+
+// Substack has no global, key-free search API (substack.com/api/v1/post/search
+// exists but always returns empty results without auth). Per-publication RSS
+// is stable and zero-dep — every Substack newsletter exposes <handle>.substack.com/feed.
+// We fetch one feed per handle in parallel, optionally filter items by a
+// keyword or URL, and merge them newest-first.
+
+import type { FeedItem } from "@/lib/columns/types";
+import { fetchFeed } from "@/lib/integrations/rss";
+
+export interface SubstackMeta {
+  publication: string;
+  feedTitle?: string;
+  source: string;
+}
+
+export interface ParsedHandle {
+  handle: string;
+  feedUrl: string;
+}
+
+export function parseHandles(input: string): ParsedHandle[] {
+  const seen = new Set<string>();
+  const out: ParsedHandle[] = [];
+  for (const raw of input.split(/[\s,]+/)) {
+    const piece = raw.trim();
+    if (!piece) continue;
+    const handle = handleFromInput(piece);
+    if (!handle || seen.has(handle)) continue;
+    seen.add(handle);
+    out.push({ handle, feedUrl: `https://${handle}.substack.com/feed` });
+  }
+  return out;
+}
+
+function handleFromInput(s: string): string | null {
+  const lower = s.toLowerCase();
+  // Full URL or bare host: extract the subdomain before .substack.com.
+  const urlMatch = lower.match(
+    /^(?:https?:\/\/)?([a-z0-9-]+)\.substack\.com\b/,
+  );
+  if (urlMatch) return urlMatch[1];
+  // Plain handle. Allow alphanumerics and hyphens; reject anything else.
+  if (/^[a-z0-9][a-z0-9-]*$/.test(lower)) return lower;
+  return null;
+}
+
+function looksLikeUrl(s: string): boolean {
+  const t = s.trim();
+  if (!t) return false;
+  if (/^https?:\/\//i.test(t)) return true;
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)+(\/[^\s]*)?$/i.test(t);
+}
+
+function normalizeUrlForMatch(s: string): string {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/^www\./, "")
+    .replace(/\/+$/, "");
+}
+
+function matchesQuery(item: FeedItem, query: string): boolean {
+  const q = query.trim();
+  if (!q) return true;
+  if (looksLikeUrl(q)) {
+    const needle = normalizeUrlForMatch(q);
+    const hay = (item.url ?? "").toLowerCase();
+    return hay.includes(needle);
+  }
+  const needle = q.toLowerCase();
+  return (
+    item.content.toLowerCase().includes(needle) ||
+    (item.url?.toLowerCase().includes(needle) ?? false)
+  );
+}
+
+export async function searchSubstackPublications(
+  handles: ParsedHandle[],
+  query: string,
+  perFeed = 20,
+  totalLimit = 30,
+): Promise<FeedItem<SubstackMeta>[]> {
+  if (handles.length === 0) return [];
+
+  const results = await Promise.allSettled(
+    handles.map(async ({ handle, feedUrl }) => {
+      const items = await fetchFeed(feedUrl, perFeed);
+      return items.map((item) =>
+        tagWithPublication(item, handle, feedUrl),
+      );
+    }),
+  );
+
+  const merged: FeedItem<SubstackMeta>[] = [];
+  for (const r of results) {
+    if (r.status === "fulfilled") merged.push(...r.value);
+  }
+
+  const filtered = query.trim()
+    ? merged.filter((it) => matchesQuery(it, query))
+    : merged;
+
+  filtered.sort(
+    (a, b) =>
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  return filtered.slice(0, totalLimit);
+}
+
+function tagWithPublication(
+  item: FeedItem,
+  handle: string,
+  feedUrl: string,
+): FeedItem<SubstackMeta> {
+  const publication = `${handle}.substack.com`;
+  const prevMeta = item.meta as { source?: string; feedTitle?: string } | undefined;
+  const feedTitle = prevMeta?.feedTitle ?? publication;
+  const source = prevMeta?.source ?? feedTitle;
+  return {
+    ...item,
+    // Prefix with publication to avoid id collisions across feeds.
+    id: `${publication}#${item.id || item.url || feedUrl}`,
+    author: {
+      ...item.author,
+      name: feedTitle,
+      handle: publication,
+      avatarUrl:
+        item.author.avatarUrl ??
+        `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(publication)}`,
+    },
+    meta: { publication, feedTitle, source },
+  };
+}

--- a/lib/integrations/telegram.ts
+++ b/lib/integrations/telegram.ts
@@ -1,0 +1,266 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// Telegram has no public search API for channels without a bot token + MTProto,
+// and bot tokens can't read arbitrary channels. The reliable no-auth path is
+// the server-rendered preview at https://t.me/s/<channel>, which lists the
+// channel's recent posts as parseable HTML. We fetch each requested channel,
+// parse posts, and filter on our side.
+
+const UA = "Mozilla/5.0 (compatible; minitor/0.1; +https://github.com/anthropics/claude-code)";
+const BASE = "https://t.me/s";
+
+const NAMED_ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&apos;": "'",
+  "&#39;": "'",
+  "&#33;": "!",
+  "&nbsp;": " ",
+};
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&(?:amp|lt|gt|quot|apos|nbsp|#39|#33);/g, (m) => NAMED_ENTITIES[m] ?? m)
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)));
+}
+
+// <br> → newline; emoji <i>/<tg-emoji> → keep inner text; everything else stripped.
+function htmlToText(html: string): string {
+  const withBreaks = html
+    .replace(/<br\s*\/?\s*>/gi, "\n")
+    .replace(/<\/p\s*>/gi, "\n");
+  const stripped = withBreaks
+    .replace(/<[^>]+>/g, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n");
+  return decodeEntities(stripped).trim();
+}
+
+function parseViews(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const t = raw.trim();
+  const m = /^([0-9]+(?:\.[0-9]+)?)\s*([KMG]?)$/i.exec(t);
+  if (!m) {
+    const n = Number(t.replace(/[^\d]/g, ""));
+    return Number.isFinite(n) ? n : undefined;
+  }
+  const base = Number(m[1]);
+  const mult =
+    m[2].toUpperCase() === "K"
+      ? 1_000
+      : m[2].toUpperCase() === "M"
+        ? 1_000_000
+        : m[2].toUpperCase() === "G"
+          ? 1_000_000_000
+          : 1;
+  return Math.round(base * mult);
+}
+
+function normalizeChannelHandle(raw: string): string {
+  return raw
+    .trim()
+    .replace(/^@+/, "")
+    .replace(/^https?:\/\/t\.me\//i, "")
+    .replace(/^t\.me\//i, "")
+    .replace(/^s\//, "")
+    .replace(/[\s/].*$/, "");
+}
+
+export function parseChannelList(raw: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const part of raw.split(/[\s,]+/)) {
+    const handle = normalizeChannelHandle(part);
+    if (handle && !seen.has(handle.toLowerCase())) {
+      seen.add(handle.toLowerCase());
+      out.push(handle);
+    }
+  }
+  return out;
+}
+
+interface ParsedPost {
+  channel: string;
+  channelTitle?: string;
+  postId: string;
+  url: string;
+  textHtml: string;
+  textPlain: string;
+  createdAt: string;
+  views?: number;
+  authorName?: string;
+  avatarUrl?: string;
+}
+
+function extractChannelTitle(html: string): string | undefined {
+  const m =
+    /tgme_channel_info_header_title"[^>]*>\s*(?:<span[^>]*>)?([^<]+)/i.exec(html) ||
+    /tgme_page_title"[^>]*>\s*(?:<span[^>]*>)?([^<]+)/i.exec(html);
+  return m ? decodeEntities(m[1]).trim() : undefined;
+}
+
+function parseChannelHtml(html: string, fallbackChannel: string): ParsedPost[] {
+  const channelTitle = extractChannelTitle(html);
+  const blocks = html.split(/<div class="tgme_widget_message_wrap[^"]*"/);
+  const posts: ParsedPost[] = [];
+
+  for (let i = 1; i < blocks.length; i++) {
+    const chunk = blocks[i];
+    const dataPost = /data-post="([^"/]+)\/(\d+)"/.exec(chunk);
+    if (!dataPost) continue;
+    const channel = dataPost[1];
+    const postId = dataPost[2];
+
+    const dateMatch =
+      /<a class="tgme_widget_message_date"[^>]*href="(https?:\/\/t\.me\/[^"]+)"[^>]*>\s*<time[^>]*datetime="([^"]+)"/i.exec(
+        chunk,
+      );
+    if (!dateMatch) continue;
+    const url = dateMatch[1];
+    const createdAt = new Date(dateMatch[2]).toISOString();
+
+    const textMatch =
+      /<div class="tgme_widget_message_text js-message_text"[^>]*>([\s\S]*?)<\/div>/i.exec(
+        chunk,
+      );
+    const textHtml = textMatch ? textMatch[1] : "";
+    const textPlain = textHtml ? htmlToText(textHtml) : "";
+
+    const viewsMatch = /tgme_widget_message_views"[^>]*>([^<]+)</i.exec(chunk);
+    const views = parseViews(viewsMatch?.[1]);
+
+    const ownerMatch =
+      /tgme_widget_message_owner_name"[^>]*>(?:<span[^>]*>)?([^<]+)/i.exec(chunk);
+    const authorName = ownerMatch ? decodeEntities(ownerMatch[1]).trim() : undefined;
+
+    const avatarMatch =
+      /tgme_widget_message_user_photo[^>]*>\s*<img[^>]+src="([^"]+)"/i.exec(chunk);
+
+    posts.push({
+      channel: channel || fallbackChannel,
+      channelTitle,
+      postId,
+      url,
+      textHtml,
+      textPlain,
+      createdAt,
+      views,
+      authorName,
+      avatarUrl: avatarMatch?.[1],
+    });
+  }
+  return posts;
+}
+
+async function fetchChannelPage(channel: string): Promise<ParsedPost[]> {
+  const url = `${BASE}/${encodeURIComponent(channel)}`;
+  const res = await fetch(url, {
+    headers: { "user-agent": UA, accept: "text/html" },
+    cache: "no-store",
+    redirect: "follow",
+  });
+  if (!res.ok) {
+    if (res.status === 404) return [];
+    throw new Error(`Telegram ${res.status} for @${channel}`);
+  }
+  const html = await res.text();
+  return parseChannelHtml(html, channel);
+}
+
+function looksLikeUrl(s: string): boolean {
+  const t = s.trim();
+  if (!t) return false;
+  if (/^https?:\/\//i.test(t)) return true;
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)+(\/[^\s]*)?$/i.test(t);
+}
+
+function urlNeedles(raw: string): string[] {
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) return [];
+  const stripped = trimmed
+    .replace(/^https?:\/\//, "")
+    .replace(/^www\./, "")
+    .replace(/\/+$/, "");
+  const noPath = stripped.split("/")[0];
+  return Array.from(new Set([trimmed, stripped, noPath])).filter(Boolean);
+}
+
+function postMatches(
+  post: ParsedPost,
+  query: string,
+  matchMode: "keyword" | "url",
+): boolean {
+  const q = query.trim();
+  if (!q) return true;
+  const mode = matchMode === "url" || (matchMode === "keyword" && looksLikeUrl(q))
+    ? "url"
+    : "keyword";
+
+  if (mode === "url") {
+    const haystack = `${post.textHtml}\n${post.textPlain}`.toLowerCase();
+    return urlNeedles(q).some((n) => haystack.includes(n));
+  }
+  return post.textPlain.toLowerCase().includes(q.toLowerCase());
+}
+
+export interface TelegramHitMeta {
+  channel: string;
+  channelTitle?: string;
+  postId: string;
+  views?: number;
+  [key: string]: unknown;
+}
+
+export interface TelegramSearchOpts {
+  channels: string;
+  query: string;
+  matchMode: "keyword" | "url";
+  limit: number;
+}
+
+export async function fetchTelegramChannelMentions(
+  opts: TelegramSearchOpts,
+): Promise<FeedItem<TelegramHitMeta>[]> {
+  const handles = parseChannelList(opts.channels);
+  if (handles.length === 0) return [];
+
+  const pages = await Promise.all(
+    handles.map((h) =>
+      fetchChannelPage(h).catch(() => [] as ParsedPost[]),
+    ),
+  );
+
+  const merged: ParsedPost[] = [];
+  for (const page of pages) {
+    for (const post of page) {
+      if (postMatches(post, opts.query, opts.matchMode)) merged.push(post);
+    }
+  }
+  merged.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+
+  return merged.slice(0, opts.limit).map((p) => {
+    const author = p.authorName ?? p.channelTitle ?? p.channel;
+    return {
+      id: `${p.channel}/${p.postId}`,
+      author: {
+        name: author,
+        handle: p.channel,
+        avatarUrl:
+          p.avatarUrl ??
+          `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(p.channel)}`,
+      },
+      content: p.textPlain || "(no text)",
+      url: p.url,
+      createdAt: p.createdAt,
+      meta: {
+        channel: p.channel,
+        channelTitle: p.channelTitle,
+        postId: p.postId,
+        views: p.views,
+      },
+    };
+  });
+}

--- a/lib/integrations/tiktok.ts
+++ b/lib/integrations/tiktok.ts
@@ -1,0 +1,44 @@
+import type { FeedItem } from "@/lib/columns/types";
+import { grokWebSearch } from "@/lib/integrations/xai";
+
+export interface TikTokMeta {
+  source: "tiktok";
+  username?: string;
+  videoId?: string;
+}
+
+function parseTikTokUrl(url: string): { username?: string; videoId?: string } {
+  const m = /tiktok\.com\/@([^/?#]+)\/video\/(\d+)/i.exec(url);
+  if (m) return { username: m[1], videoId: m[2] };
+  return {};
+}
+
+export async function searchTikTok(
+  query: string,
+  limit = 6,
+): Promise<FeedItem<TikTokMeta>[]> {
+  const q = query.trim();
+  if (!q) return [];
+  const composed = `site:tiktok.com ${q}`;
+  const items = await grokWebSearch(composed, limit);
+  return items
+    .filter((it): it is FeedItem & { url: string } =>
+      typeof it.url === "string" && /tiktok\.com/i.test(it.url),
+    )
+    .map((it): FeedItem<TikTokMeta> => {
+      const parsed = parseTikTokUrl(it.url);
+      const username = parsed.username;
+      const author = username
+        ? {
+            name: username,
+            handle: username,
+            avatarUrl: `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(username)}`,
+          }
+        : it.author;
+      return {
+        ...it,
+        author,
+        meta: { source: "tiktok", ...parsed },
+      };
+    });
+}

--- a/lib/integrations/weibo.ts
+++ b/lib/integrations/weibo.ts
@@ -1,0 +1,196 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// m.weibo.cn — Weibo's mobile site exposes a JSON search endpoint with no auth.
+// Far more parseable than scraping s.weibo.com HTML, but the host blocks most
+// non-CN egress IPs and rate-limits aggressively. Errors bubble up so the
+// column card can surface "no results" or the upstream message.
+
+const SEARCH_URL = "https://m.weibo.cn/api/container/getIndex";
+
+interface WeiboUser {
+  id?: number;
+  screen_name?: string;
+  profile_image_url?: string;
+  profile_url?: string;
+}
+
+interface WeiboMblog {
+  id?: string;
+  idstr?: string;
+  bid?: string;
+  mid?: string;
+  text?: string;
+  created_at?: string;
+  user?: WeiboUser;
+  reposts_count?: number;
+  comments_count?: number;
+  attitudes_count?: number;
+  source?: string;
+  retweeted_status?: WeiboMblog;
+}
+
+interface WeiboCard {
+  card_type?: number;
+  mblog?: WeiboMblog;
+  card_group?: WeiboCard[];
+}
+
+interface WeiboSearchResponse {
+  ok?: number;
+  msg?: string;
+  data?: {
+    cardlistInfo?: { total?: number; page?: number };
+    cards?: WeiboCard[];
+  };
+}
+
+export interface WeiboSearchMeta {
+  likes: number;
+  retweets: number;
+  replies: number;
+}
+
+function* iterMblogs(cards: WeiboCard[]): Generator<WeiboMblog> {
+  for (const c of cards) {
+    if (c.mblog) yield c.mblog;
+    if (c.card_group) {
+      for (const inner of c.card_group) {
+        if (inner.mblog) yield inner.mblog;
+      }
+    }
+  }
+}
+
+const HTML_ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&nbsp;": " ",
+};
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&(?:amp|lt|gt|quot|#39|nbsp);/g, (m) => HTML_ENTITIES[m] ?? m)
+    .trim();
+}
+
+function parseWeiboDate(raw: string | undefined): string {
+  const now = new Date();
+  if (!raw) return now.toISOString();
+  const s = raw.trim();
+
+  if (s === "刚刚") return now.toISOString();
+
+  const min = s.match(/^(\d+)\s*分钟前$/);
+  if (min) return new Date(now.getTime() - Number(min[1]) * 60_000).toISOString();
+
+  const hour = s.match(/^(\d+)\s*小时前$/);
+  if (hour) return new Date(now.getTime() - Number(hour[1]) * 3_600_000).toISOString();
+
+  const day = s.match(/^(\d+)\s*天前$/);
+  if (day) return new Date(now.getTime() - Number(day[1]) * 86_400_000).toISOString();
+
+  const yesterday = s.match(/^昨天\s+(\d{1,2}):(\d{2})$/);
+  if (yesterday) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - 1);
+    d.setHours(Number(yesterday[1]), Number(yesterday[2]), 0, 0);
+    return d.toISOString();
+  }
+
+  const md = s.match(/^(\d{1,2})-(\d{1,2})(?:\s+(\d{1,2}):(\d{2}))?$/);
+  if (md) {
+    const d = new Date(
+      now.getFullYear(),
+      Number(md[1]) - 1,
+      Number(md[2]),
+      md[3] ? Number(md[3]) : 0,
+      md[4] ? Number(md[4]) : 0,
+    );
+    return d.toISOString();
+  }
+
+  const parsed = new Date(s);
+  if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+
+  return now.toISOString();
+}
+
+function toFeedItem(m: WeiboMblog): FeedItem<WeiboSearchMeta> | null {
+  const text = stripHtml(m.text ?? "");
+  if (!text) return null;
+  const id = m.idstr ?? m.id ?? m.mid;
+  const bid = m.bid ?? id;
+  if (!id || !bid) return null;
+
+  const user = m.user ?? {};
+  const userId = user.id !== undefined ? String(user.id) : "";
+  const handle = user.screen_name ?? userId;
+
+  return {
+    id: `weibo-${id}`,
+    author: {
+      name: user.screen_name ?? "微博用户",
+      handle: handle || undefined,
+      avatarUrl: user.profile_image_url,
+    },
+    content: text,
+    url: userId ? `https://weibo.com/${userId}/${bid}` : `https://m.weibo.cn/status/${bid}`,
+    createdAt: parseWeiboDate(m.created_at),
+    meta: {
+      likes: Number(m.attitudes_count ?? 0),
+      retweets: Number(m.reposts_count ?? 0),
+      replies: Number(m.comments_count ?? 0),
+    },
+  };
+}
+
+export async function searchWeibo(
+  query: string,
+  limit = 20,
+): Promise<FeedItem<WeiboSearchMeta>[]> {
+  const q = query.trim();
+  if (!q) return [];
+
+  // 100103type=61 = post-only search (vs type=1 which mixes users & topics).
+  const containerid = `100103type=61&q=${q}`;
+  const url = `${SEARCH_URL}?containerid=${encodeURIComponent(containerid)}&page_type=searchall`;
+
+  const res = await fetch(url, {
+    headers: {
+      "user-agent":
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+      accept: "application/json, text/plain, */*",
+      "accept-language": "zh-CN,zh;q=0.9,en;q=0.8",
+      referer: `https://m.weibo.cn/search?containerid=${encodeURIComponent(containerid)}`,
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(`Weibo ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+
+  const json = (await res.json()) as WeiboSearchResponse;
+  if (json.ok !== 1) {
+    if (json.msg) throw new Error(`Weibo: ${json.msg}`);
+    return [];
+  }
+  const cards = json.data?.cards ?? [];
+
+  const items: FeedItem<WeiboSearchMeta>[] = [];
+  const seen = new Set<string>();
+  for (const m of iterMblogs(cards)) {
+    const item = toFeedItem(m);
+    if (!item) continue;
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    items.push(item);
+    if (items.length >= limit) break;
+  }
+  return items;
+}

--- a/lib/integrations/xai.ts
+++ b/lib/integrations/xai.ts
@@ -309,3 +309,17 @@ export async function grokNewsSearch(query: string, limit = 6): Promise<FeedItem
     .filter((i): i is FeedItem => i !== null)
     .slice(0, limit);
 }
+
+export async function grokFacebookSearch(query: string, limit = 6): Promise<FeedItem[]> {
+  const q = query.trim();
+  const scoped = q ? `site:facebook.com ${q}` : "site:facebook.com";
+  const prompt = `Search the web for the ${limit} most recent public Facebook posts or pages matching: ${JSON.stringify(
+    scoped,
+  )}. Restrict results to facebook.com URLs (posts, page wall items, public group posts). Sort newest first. For each, set "source" to the page or profile name (not the domain), and "title" to a short snippet from the post. Return ONLY a JSON array (no prose, no code fences) matching this shape: ${WEB_ITEM_SHAPE}.`;
+  const items = await callGrok({ prompt, tools: [{ type: "web_search" }] });
+  return items
+    .map((g) => toWebFeedItem(g, "web"))
+    .filter((i): i is FeedItem => i !== null)
+    .filter((i) => /(^|\.)facebook\.com\//i.test(i.url ?? ""))
+    .slice(0, limit);
+}


### PR DESCRIPTION
## Summary

Single replacement for 15 open stacked PRs (#4 through #18). All add new column-type plugins and conflict on the same 3 registry files.

**New plugins (15)**: instagram, rednote, hacker-news-search, github-search, tiktok, weibo-search, substack, linkedin, facebook, github-backlinks, wallet-tx, github-prs, telegram-search, app-reviews, github-watchers.

**How merged**: Each plugin folder is taken as-is from its PR (no conflicts — disjoint paths). Shared file changes:
- `lib/integrations/github.ts` — composed from #7 (search) + #15 (PRs) + #18 (watchers); all three are pure additions and were 3-way merged.
- `lib/integrations/hackernews.ts` — append from the #6 chain.
- `lib/integrations/xai.ts` — `grokFacebookSearch` from #12.
- `manifest.ts`, `registry.ts`, `server-registry.ts` — hand-rewritten to register all 15 plugins. camelCase aliases consistent with existing style.

## Test plan

- [x] `npm run build` passes (TS + Next 16 + parity check at server-registry init)
- [x] `npm run lint` clean
- [ ] Smoke test each new column type in dev
- [ ] Close #4–#18 once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)