### PR TITLE
feat(plugins): add github-releases column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 | Category | Columns |
 |----------|---------|
 | **Social — X / Reddit / HN / Farcaster** (5) | `x-search`, `x-trending`, `reddit`, `hacker-news`, `farcaster` |
-| **GitHub** (8) | `github-trending`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks` |
+| **GitHub** (8) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks` |
 | **News & web** (4) | `bing` (Web search), `google-news`, `news-search`, `rss` |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |

--- a/lib/columns/plugins/github-releases/client.tsx
+++ b/lib/columns/plugins/github-releases/client.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Tag } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type GHReleasesConfig, type GHReleasesMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<GHReleasesConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghr-repo">Repository</Label>
+        <Input
+          id="ghr-repo"
+          placeholder="vercel/next.js"
+          value={value.repo}
+          onChange={(e) => onChange({ ...value, repo: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          <code>owner/repo</code> or full GitHub URL.
+        </p>
+      </div>
+      <label className="flex items-center gap-2 text-[12.5px] text-foreground/90">
+        <input
+          type="checkbox"
+          className="size-3.5 accent-current"
+          checked={value.includePrereleases}
+          onChange={(e) =>
+            onChange({ ...value, includePrereleases: e.target.checked })
+          }
+        />
+        Include pre-releases
+      </label>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<GHReleasesMeta>) {
+  const m = item.meta;
+  const repo = m?.repo ?? item.author.name ?? "";
+  const tag = m?.tag ?? "";
+  const isPre = !!m?.prerelease;
+
+  // Releases come in as `${title}\n\n${body?}` from the integration layer.
+  const [title, ...rest] = item.content.split("\n\n");
+  const body = rest.join("\n\n").trim();
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(34, 197, 94, 0.22)" }}
+        >
+          <Tag className="size-3" />
+          {isPre ? "pre-release" : "release"}
+        </span>
+        {repo && (
+          <span className="truncate text-foreground/80">{repo}</span>
+        )}
+        {tag && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="truncate font-mono text-[10.5px] text-foreground/70">
+              {tag}
+            </span>
+          </>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {title}
+      </h3>
+      {body && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words whitespace-pre-line">
+          {body}
+        </p>
+      )}
+    </a>
+  );
+}
+
+export const column = defineColumnUI<GHReleasesConfig, GHReleasesMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-releases/plugin.ts
+++ b/lib/columns/plugins/github-releases/plugin.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { Tag } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  repo: z.string().default(""),
+  includePrereleases: z.boolean().default(true),
+});
+
+export type GHReleasesConfig = z.infer<typeof schema>;
+
+export interface GHReleasesMeta {
+  kind?: "release";
+  repo?: string;
+  tag?: string;
+  prerelease?: boolean;
+}
+
+export const meta: PluginMeta<GHReleasesConfig, GHReleasesMeta> = {
+  id: "github-releases",
+  label: "GitHub releases",
+  description: "Latest releases for a GitHub repo, newest first.",
+  icon: Tag,
+  accent: "#22c55e",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const r = c.repo.trim();
+    return r ? `Releases · ${r}` : "GitHub · Releases";
+  },
+  capabilities: {
+    paginated: true,
+    rateLimitHint: "60 req/hr without GITHUB_TOKEN, 5000 with.",
+  },
+};

--- a/lib/columns/plugins/github-releases/server.ts
+++ b/lib/columns/plugins/github-releases/server.ts
@@ -1,0 +1,41 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchGitHub } from "@/lib/integrations/github";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type GHReleasesConfig, type GHReleasesMeta } from "./plugin";
+
+const fetch: ServerFetcher<GHReleasesConfig, GHReleasesMeta> = async (
+  config,
+  cursor,
+) => {
+  const repo = config.repo.trim();
+  if (!repo) throw new Error("Repository is required (owner/repo).");
+  const page = cursor ? Number(cursor) || 1 : 1;
+  const all = (await fetchGitHub(
+    "releases",
+    { repo },
+    PAGE_SIZE,
+    page,
+  )) as FeedItem<GHReleasesMeta>[];
+  const items = config.includePrereleases
+    ? all
+    : all.filter((it) => !it.meta?.prerelease);
+  // Pagination cursor mirrors github-trending: when the upstream page is full,
+  // there may be more on the next page. Filtering pre-releases shortens the
+  // visible page but doesn't shorten the upstream — so use `all.length` for
+  // the has-more decision, not `items.length`.
+  return {
+    items,
+    nextCursor: all.length === PAGE_SIZE ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<GHReleasesConfig, GHReleasesMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -34,6 +34,7 @@ import { meta as appleReviews } from "./apple-reviews/plugin";
 import { meta as playReviews } from "./play-reviews/plugin";
 import { meta as githubStars } from "./github-stars/plugin";
 import { meta as githubForks } from "./github-forks/plugin";
+import { meta as githubReleases } from "./github-releases/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -66,6 +67,7 @@ export const PLUGIN_METAS = [
   playReviews,
   githubStars,
   githubForks,
+  githubReleases,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -42,6 +42,7 @@ import { column as appleReviews } from "@/lib/columns/plugins/apple-reviews/clie
 import { column as playReviews } from "@/lib/columns/plugins/play-reviews/client";
 import { column as githubStars } from "@/lib/columns/plugins/github-stars/client";
 import { column as githubForks } from "@/lib/columns/plugins/github-forks/client";
+import { column as githubReleases } from "@/lib/columns/plugins/github-releases/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -77,6 +78,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "play-reviews": playReviews,
   "github-stars": githubStars,
   "github-forks": githubForks,
+  "github-releases": githubReleases,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -38,6 +38,7 @@ import { server as appleReviews } from "@/lib/columns/plugins/apple-reviews/serv
 import { server as playReviews } from "@/lib/columns/plugins/play-reviews/server";
 import { server as githubStars } from "@/lib/columns/plugins/github-stars/server";
 import { server as githubForks } from "@/lib/columns/plugins/github-forks/server";
+import { server as githubReleases } from "@/lib/columns/plugins/github-releases/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -70,6 +71,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "play-reviews": playReviews,
   "github-stars": githubStars,
   "github-forks": githubForks,
+  "github-releases": githubReleases,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than


### PR DESCRIPTION
## What

Adds the eighth GitHub plugin to minitor: a per-repo release feed, newest first, with optional pre-release filtering.

## Why

Minitor already tracks 7 GitHub angles: `github-trending`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks`. Releases is the obvious missing one — operators currently have to either drop down to a generic `rss` column on the repo's `releases.atom` feed (loses tag + pre-release metadata, no per-source rendering) or skip release watching altogether.

The integration layer at `lib/integrations/github.ts` already had a `fetchReleases` function and a `"releases"` branch in `fetchGitHub`, used by no plugin until now. This PR exposes the existing fetcher as a first-class column with a configurable pre-release toggle.

The README's GitHub row already said `(8)` but the type list only had 7 entries — that count was right for the planned set, wrong for the shipped set. Adding `github-releases` brings the table in line.

## How it works

- **`lib/columns/plugins/github-releases/plugin.ts`** — Zod schema `{ repo: string, includePrereleases: boolean = true }`, Tag icon (lucide), green `#22c55e` accent (distinct from orange flame on `github-trending`, yellow star on `github-stars`), `paginated: true` capability with the same rate-limit hint as the rest of the GitHub cluster.
- **`lib/columns/plugins/github-releases/server.ts`** — calls the existing `fetchGitHub('releases', { repo }, PAGE_SIZE, page)`. Pagination cursor mirrors `github-trending`: when the upstream page returns `PAGE_SIZE` items, advance to the next page **regardless** of how many items the local pre-release filter dropped — otherwise `includePrereleases: false` would stop pagination early on a release-heavy repo.
- **`lib/columns/plugins/github-releases/client.tsx`** — `ConfigForm` with a repo input and an \"Include pre-releases\" checkbox. `ItemRenderer` shows a release/pre-release pill, repo name, monospace tag, relative time, the release title in serif (matching `github-trending`'s heading treatment), and the body truncated to 3 lines.
- **`manifest.ts` + `registry.ts` + `server-registry.ts`** — the 3 standard registry entries. The parity check at server module init throws if any of the three drift, so this is the trio that matters for keeping the new plugin from 404'ing.

## Changes

- \`lib/columns/plugins/github-releases/plugin.ts\` (new)
- \`lib/columns/plugins/github-releases/server.ts\` (new)
- \`lib/columns/plugins/github-releases/client.tsx\` (new)
- \`lib/columns/plugins/manifest.ts\` (+1 import, +1 entry)
- \`lib/columns/registry.ts\` (+1 import, +1 map entry)
- \`lib/columns/server-registry.ts\` (+1 import, +1 map entry)
- \`README.md\` (GitHub row: 7 → 8 entries listed, count was already \`(8)\`)

## Test plan

- [ ] \`./minitor\` → Add column → expect \"GitHub releases\" with the Tag icon + green pill in the picker
- [ ] Set repo to \`vercel/next.js\` (release-heavy, pre-releases common) → expect a populated feed with v15.x release + canary pre-releases visible
- [ ] Toggle \"Include pre-releases\" off → expect canary entries to disappear, stable releases to remain
- [ ] Click \"Load more\" on a 12-item full page → expect page 2 to load (cursor advances)
- [ ] Set repo to a private/non-existent repo → expect a clear error in the column header rather than a silent empty state
- [ ] Restart server → expect no parity-check throw at module init (manifest / UI / server are all aligned)

---
*Built autonomously by Aeon*