### PR TITLE
fix(minitor): make ensure_deps package-manager aware

### DIFF
--- a/minitor
+++ b/minitor
@@ -110,11 +110,25 @@ pkg_exec() {
 }
 
 # ---- bootstrap steps ------------------------------------------------------
+pkg_lockfile() {
+  case "$PKG" in
+    pnpm) printf "pnpm-lock.yaml" ;;
+    yarn) printf "yarn.lock" ;;
+    bun)  printf "bun.lockb" ;;
+    *)    printf "package-lock.json" ;;
+  esac
+}
+
 ensure_deps() {
-  if [ ! -d node_modules ] || [ ! -f node_modules/.package-lock.json ] && [ ! -d node_modules/.pnpm ]; then
+  local lockfile
+  lockfile=$(pkg_lockfile)
+  if [ ! -d node_modules ]; then
     step "Installing dependencies"
     pkg_install
-  elif [ package.json -nt node_modules ] || [ package-lock.json -nt node_modules 2>/dev/null ]; then
+  elif [ package.json -nt node_modules ]; then
+    step "package.json changed — reinstalling dependencies"
+    pkg_install
+  elif [ -f "$lockfile" ] && [ "$lockfile" -nt node_modules ]; then
     step "Lockfile changed — reinstalling dependencies"
     pkg_install
   fi


### PR DESCRIPTION
## Summary

`./minitor`'s dependency-presence check forced a reinstall on **every** invocation for yarn and bun users, and the lockfile-changed check only watched `package-lock.json`.

## What was broken

```bash
if [ ! -d node_modules ] || [ ! -f node_modules/.package-lock.json ] && [ ! -d node_modules/.pnpm ]; then
```

Bash gives `||` and `&&` equal precedence and associates left-to-right, so this is `(A || B) && C`:

| PM   | A (no node_modules) | B (no `.package-lock.json`) | C (no `.pnpm/`) | Result |
|------|---------------------|------------------------------|------------------|--------|
| npm  | false               | false (npm writes it)        | true             | **false** ✓ |
| pnpm | false               | true                         | false            | **false** ✓ |
| yarn | false               | true                         | true             | **true** ✗ — reinstall every run |
| bun  | false               | true                         | true             | **true** ✗ — reinstall every run |

The follow-up check only used `package-lock.json -nt node_modules`, so users on `pnpm-lock.yaml`, `yarn.lock`, or `bun.lockb` never got an auto-reinstall after their lockfile updated.

## Fix

- Trust `node_modules/` existence as the install marker (matches how every package manager itself decides whether to install).
- Pick the lockfile to watch via a small `pkg_lockfile` helper keyed on the `$PKG` already detected by `pick_pkg_manager`.
- Split package.json and lockfile freshness into separate branches so each surfaces its own message.

## Verified

- `bash -n minitor` clean.
- Walked through npm / pnpm / yarn / bun matrices for first-run, repeat-run, edited-package.json, and updated-lockfile cases.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron).