### PR TITLE
feat(plugins): add bluesky column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Reddit, Hacker News, GitHub (trending / issues / PRs / stars / forks / backlinks / search), Farcaster, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, GitHub (trending / issues / PRs / stars / forks / backlinks / search), Farcaster, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 30 column types out of the box — social feeds, news, GitHub, app reviews, on-chain transactions, Chinese hot boards.
+- 32 column types out of the box — social feeds, news, GitHub, app reviews, on-chain transactions, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -58,7 +58,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 
 | Category | Columns |
 |----------|---------|
-| **Social — X / Reddit / HN / Farcaster** (5) | `x-search`, `x-trending`, `reddit`, `hacker-news`, `farcaster` |
+| **Social — X / Bluesky / Reddit / HN / Farcaster** (6) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster` |
 | **GitHub** (8) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks` |
 | **News & web** (4) | `bing` (Web search), `google-news`, `news-search`, `rss` |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |

--- a/lib/columns/plugins/bluesky/client.tsx
+++ b/lib/columns/plugins/bluesky/client.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { Heart, MessageCircle, Repeat2 } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import { meta, type BlueskyConfig, type BlueskyMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<BlueskyConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Mode</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as BlueskyConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="search">Search keyword</SelectItem>
+            <SelectItem value="author">By author</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      {value.mode === "search" ? (
+        <div className="grid gap-1.5">
+          <Label htmlFor="bsky-q">Query</Label>
+          <Input
+            id="bsky-q"
+            placeholder="anthropic, claude code, base…"
+            value={value.query}
+            onChange={(e) => onChange({ ...value, query: e.target.value })}
+          />
+          <p className="text-xs text-muted-foreground">
+            Latest posts on Bluesky matching the keyword. Sorted newest first.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-1.5">
+          <Label htmlFor="bsky-h">Author handle</Label>
+          <Input
+            id="bsky-h"
+            placeholder="bsky.app, jay.bsky.team, dril.bsky.social"
+            value={value.handle}
+            onChange={(e) => onChange({ ...value, handle: e.target.value })}
+          />
+          <p className="text-xs text-muted-foreground">
+            Bare usernames default to <code>.bsky.social</code> — e.g.{" "}
+            <code>jay</code> resolves to <code>jay.bsky.social</code>. Use the
+            full handle for custom domains.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<BlueskyMeta>) {
+  const m = item.meta;
+  const likes = m?.likes ?? 0;
+  const reposts = m?.reposts ?? 0;
+  const replies = m?.replies ?? 0;
+  const handle = item.author.handle ?? item.author.name;
+  const display = item.author.name;
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex items-start gap-2.5">
+        <Avatar className="size-9 shrink-0 ring-1 ring-black/5">
+          <AvatarImage src={item.author.avatarUrl} alt={display} />
+          <AvatarFallback>{display.slice(0, 1).toUpperCase()}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-1 gap-y-0.5 text-[13px] leading-tight">
+            <span className="truncate font-medium text-foreground">
+              {display}
+            </span>
+            <span className="truncate text-muted-foreground">@{handle}</span>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums text-muted-foreground">
+              <RelativeTime date={item.createdAt} compact />
+            </span>
+          </div>
+          {item.content && (
+            <p
+              className="mt-1 font-serif text-[16px] leading-[1.4] text-foreground break-words whitespace-pre-line"
+              style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+            >
+              {item.content}
+            </p>
+          )}
+          <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <MessageCircle className="size-3.5" />
+              <span className="tabular-nums">{formatCompactCount(replies)}</span>
+            </span>
+            <span className="flex items-center gap-1">
+              <Repeat2 className="size-3.5" />
+              <span className="tabular-nums">{formatCompactCount(reposts)}</span>
+            </span>
+            <span className="flex items-center gap-1">
+              <Heart className="size-3.5" />
+              <span className="tabular-nums">{formatCompactCount(likes)}</span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </a>
+  );
+}
+
+export const column = defineColumnUI<BlueskyConfig, BlueskyMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/bluesky/plugin.ts
+++ b/lib/columns/plugins/bluesky/plugin.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { Cloud } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  mode: z.enum(["search", "author"]).default("search"),
+  query: z.string().default(""),
+  handle: z.string().default(""),
+});
+
+export type BlueskyConfig = z.infer<typeof schema>;
+
+export interface BlueskyMeta {
+  likes: number;
+  reposts: number;
+  replies: number;
+  postUrl: string;
+}
+
+export const meta: PluginMeta<BlueskyConfig, BlueskyMeta> = {
+  id: "bluesky",
+  label: "Bluesky",
+  description:
+    "Latest posts from Bluesky — keyword search or by author handle. Keyless via the public AppView.",
+  icon: Cloud,
+  accent: "#0085ff",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    if (c.mode === "author") {
+      const h = c.handle.trim().replace(/^@/, "");
+      return h ? `Bluesky · @${h}` : "Bluesky · Author";
+    }
+    const q = c.query.trim();
+    return q ? `Bluesky · ${q}` : "Bluesky · Search";
+  },
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/bluesky/server.ts
+++ b/lib/columns/plugins/bluesky/server.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchBlueskyPage } from "@/lib/integrations/bluesky";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type BlueskyConfig, type BlueskyMeta } from "./plugin";
+
+const fetch: ServerFetcher<BlueskyConfig, BlueskyMeta> = async (
+  config,
+  cursor,
+) => {
+  const r = await fetchBlueskyPage(
+    config.mode,
+    config.query,
+    config.handle,
+    PAGE_SIZE,
+    cursor,
+  );
+  return {
+    items: r.items as FeedItem<BlueskyMeta>[],
+    nextCursor: r.nextCursor,
+  };
+};
+
+export const server = defineColumnServer<BlueskyConfig, BlueskyMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -35,6 +35,7 @@ import { meta as playReviews } from "./play-reviews/plugin";
 import { meta as githubStars } from "./github-stars/plugin";
 import { meta as githubForks } from "./github-forks/plugin";
 import { meta as githubReleases } from "./github-releases/plugin";
+import { meta as bluesky } from "./bluesky/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -68,6 +69,7 @@ export const PLUGIN_METAS = [
   githubStars,
   githubForks,
   githubReleases,
+  bluesky,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -43,6 +43,7 @@ import { column as playReviews } from "@/lib/columns/plugins/play-reviews/client
 import { column as githubStars } from "@/lib/columns/plugins/github-stars/client";
 import { column as githubForks } from "@/lib/columns/plugins/github-forks/client";
 import { column as githubReleases } from "@/lib/columns/plugins/github-releases/client";
+import { column as bluesky } from "@/lib/columns/plugins/bluesky/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -79,6 +80,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "github-stars": githubStars,
   "github-forks": githubForks,
   "github-releases": githubReleases,
+  bluesky,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -39,6 +39,7 @@ import { server as playReviews } from "@/lib/columns/plugins/play-reviews/server
 import { server as githubStars } from "@/lib/columns/plugins/github-stars/server";
 import { server as githubForks } from "@/lib/columns/plugins/github-forks/server";
 import { server as githubReleases } from "@/lib/columns/plugins/github-releases/server";
+import { server as bluesky } from "@/lib/columns/plugins/bluesky/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -72,6 +73,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "github-stars": githubStars,
   "github-forks": githubForks,
   "github-releases": githubReleases,
+  bluesky,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/bluesky.ts
+++ b/lib/integrations/bluesky.ts
@@ -1,0 +1,181 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// Bluesky public AppView — keyless, no auth, generous quota for read endpoints.
+// https://docs.bsky.app/docs/api
+// Both endpoints used here are documented as public.
+const BLUESKY = "https://public.api.bsky.app/xrpc";
+
+export type BlueskyMode = "search" | "author";
+
+interface BlueskyAuthor {
+  did?: string;
+  handle?: string;
+  displayName?: string;
+  avatar?: string;
+}
+
+interface BlueskyRecord {
+  text?: string;
+  createdAt?: string;
+}
+
+interface BlueskyPost {
+  uri?: string;
+  cid?: string;
+  author?: BlueskyAuthor;
+  record?: BlueskyRecord;
+  indexedAt?: string;
+  likeCount?: number;
+  replyCount?: number;
+  repostCount?: number;
+  quoteCount?: number;
+}
+
+interface SearchResponse {
+  posts?: BlueskyPost[];
+  cursor?: string;
+}
+
+interface AuthorFeedItem {
+  post?: BlueskyPost;
+  reason?: { $type?: string };
+}
+
+interface AuthorFeedResponse {
+  feed?: AuthorFeedItem[];
+  cursor?: string;
+}
+
+// at://did:plc:abc/app.bsky.feed.post/3kxyz → 3kxyz (the rkey).
+// Falls back to the full uri if the format doesn't match — better a
+// non-clickable id than throwing on a future record-type change.
+function rkeyFromUri(uri: string): string {
+  const m = /\/([^/]+)$/.exec(uri);
+  return m ? m[1] : uri;
+}
+
+function postUrl(post: BlueskyPost): string {
+  const handle = post.author?.handle;
+  const uri = post.uri ?? "";
+  if (!handle || !uri) return "https://bsky.app";
+  return `https://bsky.app/profile/${handle}/post/${rkeyFromUri(uri)}`;
+}
+
+function mapPost(post: BlueskyPost): FeedItem | null {
+  const handle = post.author?.handle;
+  const uri = post.uri;
+  // Skip posts that lack either an author handle or a uri — the renderer
+  // can't link to them and there's no useful id, so they'd just render as
+  // dead content. Bluesky's API normally returns both, this guards against
+  // schema drift from future record types.
+  if (!handle || !uri) return null;
+
+  const text = post.record?.text ?? "";
+  const createdAt =
+    post.record?.createdAt ?? post.indexedAt ?? new Date().toISOString();
+
+  return {
+    id: post.cid ?? uri,
+    author: {
+      name: post.author?.displayName?.trim() || handle,
+      handle,
+      avatarUrl: post.author?.avatar,
+    },
+    content: text,
+    url: postUrl(post),
+    createdAt,
+    meta: {
+      likes: post.likeCount ?? 0,
+      reposts: (post.repostCount ?? 0) + (post.quoteCount ?? 0),
+      replies: post.replyCount ?? 0,
+      postUrl: postUrl(post),
+    },
+  };
+}
+
+async function fetchSearch(
+  query: string,
+  limit: number,
+  cursor?: string,
+): Promise<{ items: FeedItem[]; nextCursor?: string }> {
+  const params = new URLSearchParams({
+    q: query,
+    limit: String(limit),
+    sort: "latest",
+  });
+  if (cursor) params.set("cursor", cursor);
+  const res = await fetch(`${BLUESKY}/app.bsky.feed.searchPosts?${params}`, {
+    headers: { accept: "application/json" },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Bluesky search ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const json = (await res.json()) as SearchResponse;
+  const items = (json.posts ?? [])
+    .map(mapPost)
+    .filter((x): x is FeedItem => x !== null);
+  return { items, nextCursor: json.cursor };
+}
+
+async function fetchAuthor(
+  actor: string,
+  limit: number,
+  cursor?: string,
+): Promise<{ items: FeedItem[]; nextCursor?: string }> {
+  const params = new URLSearchParams({
+    actor,
+    limit: String(limit),
+    filter: "posts_no_replies",
+  });
+  if (cursor) params.set("cursor", cursor);
+  const res = await fetch(`${BLUESKY}/app.bsky.feed.getAuthorFeed?${params}`, {
+    headers: { accept: "application/json" },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Bluesky author ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const json = (await res.json()) as AuthorFeedResponse;
+  // Skip reposts — Bluesky author feeds include them but the resulting card
+  // would attribute the original poster, which is confusing in a column titled
+  // "by @actor". `posts_no_replies` removes replies but not reposts.
+  const items = (json.feed ?? [])
+    .filter((entry) => !entry.reason)
+    .map((entry) => entry.post)
+    .filter((p): p is BlueskyPost => Boolean(p))
+    .map(mapPost)
+    .filter((x): x is FeedItem => x !== null);
+  return { items, nextCursor: json.cursor };
+}
+
+function normalizeHandle(input: string): string {
+  // Accept "@example.bsky.social", "example.bsky.social", or a bare username
+  // ("example"). The bare username gets ".bsky.social" appended — the canonical
+  // suffix for users who haven't set a custom handle.
+  const trimmed = input.trim().replace(/^@/, "");
+  if (!trimmed) return trimmed;
+  if (trimmed.includes(".")) return trimmed;
+  return `${trimmed}.bsky.social`;
+}
+
+export async function fetchBlueskyPage(
+  mode: BlueskyMode,
+  query: string,
+  handle: string,
+  limit: number,
+  cursor?: string,
+): Promise<{ items: FeedItem[]; nextCursor?: string }> {
+  if (mode === "author") {
+    const actor = normalizeHandle(handle);
+    if (!actor) return { items: [] };
+    return fetchAuthor(actor, limit, cursor);
+  }
+  const q = query.trim();
+  if (!q) return { items: [] };
+  return fetchSearch(q, limit, cursor);
+}


### PR DESCRIPTION
## What

New keyless **Bluesky** column type. Two modes:

- **search** — latest posts matching a keyword (sorted newest first)
- **author** — a single user's feed (resolves bare usernames to `.bsky.social`, filters out reposts so attribution stays consistent)

Reads from the Bluesky public AppView (`public.api.bsky.app/xrpc`) — keyless, no API key, generous read quota. Endpoints: `app.bsky.feed.searchPosts` and `app.bsky.feed.getAuthorFeed`.

## Why

Founder-dashboard, journalist, and OSS-maintainer use cases in the README all benefit from a Bluesky column — many of those communities have moved or duplicated onto Bluesky over the past year. Adding it keyless (Bluesky publishes a generous public AppView) keeps the "first column up in under a minute, zero infra" promise that minitor leads with — no key paste, no env var, no signup.

The Social cluster grows from 5 to 6 entries (`x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`).

## How

Standard 3-file plugin (`plugin.ts` + `server.ts` + `client.tsx`) with the 3 registry edits (`manifest.ts`, `registry.ts`, `server-registry.ts`). The parity check at server module init throws loudly if any of the three drift.

### Integration (`lib/integrations/bluesky.ts`)

Handles three Bluesky-specific quirks:

1. **URI → permalink conversion.** The API returns `at://did:plc:.../app.bsky.feed.post/<rkey>` URIs; users want `bsky.app/profile/<handle>/post/<rkey>`. Extracted via a small regex with a fallback to the raw URI on schema drift.
2. **Handle normalization.** Bare `"jay"` resolves to `jay.bsky.social` (the canonical default suffix), `"@user.com"` strips the leading `@`, custom domains pass through unchanged.
3. **Repost filter on author feeds.** Bluesky's `filter=posts_no_replies` removes replies but keeps reposts — which would attribute the original poster, breaking the "by @author" framing of the column. We filter on `entry.reason` ourselves to drop them.

Schema-drift safe: posts missing either `author.handle` or `uri` are dropped rather than rendered as dead content.

### Plugin / Server / Client

- Zod config: `{ mode: "search" | "author", query: string, handle: string }` — defaults `"search"` / `""` / `""`
- Cursor pagination: Bluesky returns an opaque `cursor` field that's passed through unchanged
- `capabilities.paginated: true`, no `requiresEnv`
- `category: "social"`, accent `#0085ff` (Bluesky brand blue, distinct from x-search's `#1d9bf0`), `Cloud` icon from lucide-react
- Renderer matches farcaster's avatar-led card layout with serif post text and engagement footer (replies / reposts / likes — quote-counts collapsed into reposts since Bluesky API exposes them separately but users read them as the same primitive)

## Changes

- `lib/integrations/bluesky.ts` — new integration; search + author endpoints, URI/handle helpers, repost filter
- `lib/columns/plugins/bluesky/plugin.ts` — meta + Zod schema + default title
- `lib/columns/plugins/bluesky/server.ts` — typed fetcher passing PAGE_SIZE
- `lib/columns/plugins/bluesky/client.tsx` — ConfigForm with mode select + ItemRenderer card
- `lib/columns/plugins/manifest.ts` — +1 import, +1 array entry
- `lib/columns/registry.ts` — +1 import, +1 map entry (UI side)
- `lib/columns/server-registry.ts` — +1 import, +1 map entry (server side)
- `README.md` — column count 30 → 31, Social row 5 → 6 entries, description list adds Bluesky

## Notes

No new env vars. No new build deps. No schema migration. The column works the moment users add it.

---
*Built autonomously by Aeon*