### PR TITLE
feat(plugins): add mastodon column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, GitHub (trending / issues / PRs / stars / forks / backlinks / search), Farcaster, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, GitHub (trending / issues / PRs / stars / forks / backlinks / search), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 32 column types out of the box — social feeds, news, GitHub, app reviews, on-chain transactions, Chinese hot boards.
+- 33 column types out of the box — social feeds, news, GitHub, app reviews, on-chain transactions, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -58,7 +58,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 
 | Category | Columns |
 |----------|---------|
-| **Social — X / Bluesky / Reddit / HN / Farcaster** (6) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster` |
+| **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
 | **GitHub** (8) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks` |
 | **News & web** (4) | `bing` (Web search), `google-news`, `news-search`, `rss` |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -15,6 +15,7 @@ import { meta as rss } from "./rss/plugin";
 import { meta as googleNews } from "./google-news/plugin";
 import { meta as bing } from "./bing/plugin";
 import { meta as farcaster } from "./farcaster/plugin";
+import { meta as mastodon } from "./mastodon/plugin";
 import { meta as youtube } from "./youtube/plugin";
 import { meta as weiboHot } from "./weibo-hot/plugin";
 import { meta as zhihuHot } from "./zhihu-hot/plugin";
@@ -49,6 +50,7 @@ export const PLUGIN_METAS = [
   googleNews,
   bing,
   farcaster,
+  mastodon,
   youtube,
   weiboHot,
   zhihuHot,

--- a/lib/columns/plugins/mastodon/client.tsx
+++ b/lib/columns/plugins/mastodon/client.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { Heart, MessageCircle, Repeat2 } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import { meta, type MastodonConfig, type MastodonMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<MastodonConfig>) {
+  const isAuthor = value.mode === "author";
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="mast-instance">Instance</Label>
+        <Input
+          id="mast-instance"
+          placeholder="mastodon.social"
+          value={value.instance}
+          onChange={(e) => onChange({ ...value, instance: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Server to query (e.g. <code>mastodon.social</code>,{" "}
+          <code>fosstodon.org</code>, <code>hachyderm.io</code>). For author
+          mode you can also use the <code>user@server</code> form in the
+          handle field and we&apos;ll route to that server automatically.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Mode</Label>
+        <div className="flex gap-1.5">
+          <button
+            type="button"
+            className={`flex-1 rounded-md border px-3 py-1.5 text-sm transition-colors ${
+              value.mode === "hashtag"
+                ? "border-foreground bg-foreground/5"
+                : "border-border hover:bg-surface/60"
+            }`}
+            onClick={() => onChange({ ...value, mode: "hashtag" })}
+          >
+            Hashtag
+          </button>
+          <button
+            type="button"
+            className={`flex-1 rounded-md border px-3 py-1.5 text-sm transition-colors ${
+              value.mode === "author"
+                ? "border-foreground bg-foreground/5"
+                : "border-border hover:bg-surface/60"
+            }`}
+            onClick={() => onChange({ ...value, mode: "author" })}
+          >
+            Author
+          </button>
+        </div>
+      </div>
+      {isAuthor ? (
+        <div className="grid gap-1.5">
+          <Label htmlFor="mast-handle">Handle</Label>
+          <Input
+            id="mast-handle"
+            placeholder="gargron, user@fosstodon.org…"
+            value={value.handle}
+            onChange={(e) => onChange({ ...value, handle: e.target.value })}
+          />
+          <p className="text-xs text-muted-foreground">
+            Bare username uses the configured instance. Use{" "}
+            <code>user@server</code> to follow someone on a different server.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-1.5">
+          <Label htmlFor="mast-query">Hashtag</Label>
+          <Input
+            id="mast-query"
+            placeholder="opensource, photography, claudecode…"
+            value={value.query}
+            onChange={(e) => onChange({ ...value, query: e.target.value })}
+          />
+          <p className="text-xs text-muted-foreground">
+            Tag name with or without the <code>#</code>. Hashtag timelines are
+            keyless on every public Mastodon instance.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<MastodonMeta>) {
+  const m = item.meta;
+  const favourites = m?.favourites ?? 0;
+  const reblogs = m?.reblogs ?? 0;
+  const replies = m?.replies ?? 0;
+  const handle = item.author.handle ?? item.author.name;
+  const display = item.author.name;
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex items-start gap-2.5">
+        <Avatar className="size-9 shrink-0 ring-1 ring-black/5">
+          <AvatarImage src={item.author.avatarUrl} alt={display} />
+          <AvatarFallback>{display.slice(0, 1).toUpperCase()}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-1 gap-y-0.5 text-[13px] leading-tight">
+            <span className="truncate font-medium text-foreground">
+              {display}
+            </span>
+            <span className="truncate text-muted-foreground">@{handle}</span>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums text-muted-foreground">
+              <RelativeTime date={item.createdAt} compact />
+            </span>
+          </div>
+          <p
+            className="mt-1 font-serif text-[16px] leading-[1.4] text-foreground break-words whitespace-pre-line"
+            style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+          >
+            {item.content}
+          </p>
+          <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <MessageCircle className="size-3.5" />
+              <span className="tabular-nums">{formatCompactCount(replies)}</span>
+            </span>
+            <span className="flex items-center gap-1">
+              <Repeat2 className="size-3.5" />
+              <span className="tabular-nums">{formatCompactCount(reblogs)}</span>
+            </span>
+            <span className="flex items-center gap-1">
+              <Heart className="size-3.5" />
+              <span className="tabular-nums">
+                {formatCompactCount(favourites)}
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </a>
+  );
+}
+
+export const column = defineColumnUI<MastodonConfig, MastodonMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/mastodon/plugin.ts
+++ b/lib/columns/plugins/mastodon/plugin.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { AtSign } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  instance: z.string().default("mastodon.social"),
+  mode: z.enum(["hashtag", "author"]).default("hashtag"),
+  query: z.string().default(""),
+  handle: z.string().default(""),
+});
+
+export type MastodonConfig = z.infer<typeof schema>;
+
+export interface MastodonMeta {
+  favourites: number;
+  reblogs: number;
+  replies: number;
+  followers: number;
+  visibility: string;
+  bot: boolean;
+  isMastodon: true;
+}
+
+export const meta: PluginMeta<MastodonConfig, MastodonMeta> = {
+  id: "mastodon",
+  label: "Mastodon",
+  description:
+    "Public Mastodon timelines. Hashtag mode (any tag, keyless) or author mode (any user@server, keyless).",
+  icon: AtSign,
+  accent: "#6364ff",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    if (c.mode === "author") {
+      const h = c.handle.trim();
+      if (!h) return "Mastodon · Author";
+      return `Mastodon · @${h.replace(/^@/, "")}`;
+    }
+    const q = c.query.trim().replace(/^#/, "");
+    return q ? `Mastodon · #${q}` : "Mastodon · Hashtag";
+  },
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/mastodon/server.ts
+++ b/lib/columns/plugins/mastodon/server.ts
@@ -1,0 +1,29 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import {
+  fetchMastodonHashtag,
+  fetchMastodonAuthor,
+} from "@/lib/integrations/mastodon";
+import { sliceForPage } from "@/lib/columns/paginate";
+import { meta, type MastodonConfig, type MastodonMeta } from "./plugin";
+
+const fetch: ServerFetcher<MastodonConfig, MastodonMeta> = async (
+  config,
+  cursor,
+) => {
+  const items =
+    config.mode === "author"
+      ? await fetchMastodonAuthor(config.instance, config.handle, 30)
+      : await fetchMastodonHashtag(config.instance, config.query, 30);
+  return sliceForPage(items as FeedItem<MastodonMeta>[], cursor);
+};
+
+export const server = defineColumnServer<MastodonConfig, MastodonMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -23,6 +23,7 @@ import { column as rss } from "@/lib/columns/plugins/rss/client";
 import { column as googleNews } from "@/lib/columns/plugins/google-news/client";
 import { column as bing } from "@/lib/columns/plugins/bing/client";
 import { column as farcaster } from "@/lib/columns/plugins/farcaster/client";
+import { column as mastodon } from "@/lib/columns/plugins/mastodon/client";
 import { column as youtube } from "@/lib/columns/plugins/youtube/client";
 import { column as weiboHot } from "@/lib/columns/plugins/weibo-hot/client";
 import { column as zhihuHot } from "@/lib/columns/plugins/zhihu-hot/client";
@@ -60,6 +61,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "google-news": googleNews,
   bing,
   farcaster,
+  mastodon,
   youtube,
   "weibo-hot": weiboHot,
   "zhihu-hot": zhihuHot,

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -19,6 +19,7 @@ import { server as rss } from "@/lib/columns/plugins/rss/server";
 import { server as googleNews } from "@/lib/columns/plugins/google-news/server";
 import { server as bing } from "@/lib/columns/plugins/bing/server";
 import { server as farcaster } from "@/lib/columns/plugins/farcaster/server";
+import { server as mastodon } from "@/lib/columns/plugins/mastodon/server";
 import { server as youtube } from "@/lib/columns/plugins/youtube/server";
 import { server as weiboHot } from "@/lib/columns/plugins/weibo-hot/server";
 import { server as zhihuHot } from "@/lib/columns/plugins/zhihu-hot/server";
@@ -53,6 +54,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "google-news": googleNews,
   bing,
   farcaster,
+  mastodon,
   youtube,
   "weibo-hot": weiboHot,
   "zhihu-hot": zhihuHot,

--- a/lib/integrations/mastodon.ts
+++ b/lib/integrations/mastodon.ts
@@ -1,0 +1,246 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// Mastodon via the public REST API. Two keyless modes exposed:
+//   - HASHTAG: GET /api/v1/timelines/tag/{tag}      — public timeline by tag
+//   - AUTHOR:  GET /api/v1/accounts/lookup?acct=…   — federated handle lookup
+//              + GET /api/v1/accounts/{id}/statuses — that account's posts
+//
+// Mastodon's full-text status search (/api/v2/search?type=statuses) requires
+// authentication on every public instance and is intentionally NOT used here
+// — keeping the column keyless is the whole point. Hashtag search is the
+// keyless equivalent and covers the vast majority of monitoring use cases.
+//
+// Federation note: any public Mastodon instance exposes these endpoints. The
+// `instance` config is the host the column queries directly. To monitor a
+// user on a different server, set `instance` to *their* server (e.g. for
+// @gargron@mastodon.social, instance="mastodon.social", handle="gargron"),
+// or pass the fully-qualified `user@server` form and we'll route the lookup
+// to that server transparently.
+
+const DEFAULT_INSTANCE = "mastodon.social";
+const HASHTAG_LIMIT = 30;
+const AUTHOR_LIMIT = 30;
+
+interface MastodonAccount {
+  id?: string;
+  username?: string;
+  acct?: string;
+  display_name?: string;
+  avatar?: string;
+  avatar_static?: string;
+  url?: string;
+  followers_count?: number;
+  bot?: boolean;
+}
+
+interface MastodonStatus {
+  id?: string;
+  uri?: string;
+  url?: string;
+  account?: MastodonAccount;
+  content?: string;
+  created_at?: string;
+  reblog?: MastodonStatus | null;
+  reblogs_count?: number;
+  favourites_count?: number;
+  replies_count?: number;
+  visibility?: string;
+  spoiler_text?: string;
+  language?: string;
+}
+
+function normalizeInstance(raw: string | undefined): string {
+  const s = (raw ?? "").trim().replace(/^https?:\/\//, "").replace(/\/+$/, "");
+  return s || DEFAULT_INSTANCE;
+}
+
+function buildHeaders(): HeadersInit {
+  return {
+    accept: "application/json",
+    "user-agent": "minitor/0.1",
+  };
+}
+
+async function mastodonGet<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers: buildHeaders(), cache: "no-store" });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Mastodon ${res.status} (${url}): ${body.slice(0, 240)}`);
+  }
+  return (await res.json()) as T;
+}
+
+// Strip Mastodon's HTML status content down to plain text. Mastodon returns
+// `content` as a sanitized HTML fragment with <p>, <br>, <a>, <span> only —
+// safe to text-strip without a full parser. Newlines come from <br> and </p>.
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>\s*<p[^>]*>/gi, "\n\n")
+    .replace(/<\/?p[^>]*>/gi, "")
+    .replace(/<a [^>]*href="([^"]+)"[^>]*>([^<]*)<\/a>/gi, (_m, _href, text) =>
+      String(text),
+    )
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .trim();
+}
+
+function avatarUrl(account: MastodonAccount | undefined): string {
+  const a = account?.avatar_static ?? account?.avatar;
+  if (a) return a;
+  const seed = account?.username ?? "mastodon";
+  return `https://api.dicebear.com/9.x/avataaars/svg?seed=${encodeURIComponent(seed)}`;
+}
+
+function authorHandle(
+  account: MastodonAccount | undefined,
+  fallbackInstance: string,
+): string {
+  const acct = account?.acct ?? account?.username ?? "";
+  if (!acct) return "unknown";
+  // Local accounts return `acct: "user"`; remote accounts return
+  // `acct: "user@server"`. Normalize local accounts so the rendered handle
+  // includes the column's instance for unambiguous attribution.
+  if (acct.includes("@")) return acct;
+  return `${acct}@${fallbackInstance}`;
+}
+
+function statusUrl(s: MastodonStatus): string | undefined {
+  // `url` is the canonical permalink (handles federation correctly); fall
+  // back to `uri` (the ActivityPub object id) only when `url` is missing.
+  return s.url ?? s.uri;
+}
+
+function statusToFeedItem(
+  s: MastodonStatus,
+  instance: string,
+): FeedItem | null {
+  // Skip boosts (reblogs) on author timelines — the column attribution would
+  // otherwise be misleading ("by @actor" but content authored by someone
+  // else). Hashtag timeline doesn't include reblogs by default, but keep the
+  // guard anyway in case the upstream contract changes.
+  if (s.reblog) return null;
+
+  const id = s.id;
+  const url = statusUrl(s);
+  if (!id || !url) return null;
+
+  const text = stripHtml(s.content ?? "").trim();
+  if (!text) return null;
+
+  const account = s.account;
+  const handle = authorHandle(account, instance);
+  const display = account?.display_name?.trim() || account?.username || handle;
+
+  return {
+    id,
+    author: {
+      name: display,
+      handle,
+      avatarUrl: avatarUrl(account),
+    },
+    content: s.spoiler_text
+      ? `[CW: ${s.spoiler_text.trim()}] ${text}`
+      : text,
+    url,
+    createdAt: s.created_at ?? new Date().toISOString(),
+    meta: {
+      favourites: s.favourites_count ?? 0,
+      reblogs: s.reblogs_count ?? 0,
+      replies: s.replies_count ?? 0,
+      followers: account?.followers_count ?? 0,
+      visibility: s.visibility ?? "public",
+      bot: !!account?.bot,
+      isMastodon: true,
+    },
+  };
+}
+
+function mapStatuses(
+  statuses: MastodonStatus[],
+  instance: string,
+  limit: number,
+): FeedItem[] {
+  return statuses
+    .map((s) => statusToFeedItem(s, instance))
+    .filter((it): it is FeedItem => it !== null)
+    .slice(0, limit);
+}
+
+export async function fetchMastodonHashtag(
+  rawInstance: string,
+  hashtag: string,
+  limit = HASHTAG_LIMIT,
+): Promise<FeedItem[]> {
+  const tag = hashtag.trim().replace(/^#/, "");
+  if (!tag) throw new Error("Hashtag is required.");
+  const instance = normalizeInstance(rawInstance);
+  const params = new URLSearchParams({
+    limit: String(limit),
+    only_media: "false",
+  });
+  const url = `https://${instance}/api/v1/timelines/tag/${encodeURIComponent(
+    tag,
+  )}?${params}`;
+  const json = await mastodonGet<MastodonStatus[]>(url);
+  return mapStatuses(json, instance, limit);
+}
+
+// Splits a handle into (server, localpart). Accepts:
+//   "user"               → (configured instance, "user")
+//   "@user"              → strip @, route via configured instance
+//   "user@server"        → ("server", "user")  — federated lookup
+//   "@user@server"       → strip leading @, ("server", "user")
+function parseHandle(
+  raw: string,
+  configuredInstance: string,
+): { server: string; localpart: string } {
+  const trimmed = raw.trim().replace(/^@/, "");
+  if (!trimmed) throw new Error("Handle is required.");
+  const at = trimmed.indexOf("@");
+  if (at === -1) {
+    return { server: configuredInstance, localpart: trimmed };
+  }
+  return {
+    server: normalizeInstance(trimmed.slice(at + 1)),
+    localpart: trimmed.slice(0, at),
+  };
+}
+
+export async function fetchMastodonAuthor(
+  rawInstance: string,
+  handle: string,
+  limit = AUTHOR_LIMIT,
+): Promise<FeedItem[]> {
+  const configured = normalizeInstance(rawInstance);
+  const { server, localpart } = parseHandle(handle, configured);
+
+  // Look the account up on its own server — that's the only place /lookup
+  // can resolve a local username without authentication on most instances.
+  const acct = `${localpart}`;
+  const lookupUrl = `https://${server}/api/v1/accounts/lookup?acct=${encodeURIComponent(
+    acct,
+  )}`;
+  const account = await mastodonGet<MastodonAccount>(lookupUrl);
+  if (!account.id) {
+    throw new Error(`Couldn't resolve @${localpart} on ${server}.`);
+  }
+
+  const params = new URLSearchParams({
+    limit: String(limit),
+    exclude_replies: "true",
+    exclude_reblogs: "true",
+  });
+  const statusesUrl = `https://${server}/api/v1/accounts/${encodeURIComponent(
+    account.id,
+  )}/statuses?${params}`;
+  const statuses = await mastodonGet<MastodonStatus[]>(statusesUrl);
+  return mapStatuses(statuses, server, limit);
+}


### PR DESCRIPTION
## What

31st column type, 6th in the Social cluster (X / Reddit / HN / Farcaster / Bluesky / Mastodon). Two keyless modes:

- **Hashtag** — public timeline by tag via `GET /api/v1/timelines/tag/{tag}`
- **Author** — federated user@server lookup via `GET /api/v1/accounts/lookup` + `GET /api/v1/accounts/{id}/statuses`

Mastodon's full-text status search (`/api/v2/search?type=statuses`) requires authentication on every public instance and is intentionally NOT used — the keyless contract is the whole point. Hashtag search is the keyless equivalent and covers the vast majority of monitoring use cases.

## Why

Closes May-2 repo-actions idea #4 (Mastodon Column for minitor) — completes the decentralized social trifecta in minitor (Bluesky shipped May 2 in PR #25 + Farcaster + Mastodon today). With minitor's Bluesky column shipping yesterday and Farcaster already in main, Mastodon is the obvious gap in the federated/decentralized social cluster. README's Social row counts 5 → 6 entries; column total 30 → 31.

## Mastodon-specific quirks (all handled in the integration layer)

- **HTML content** — Mastodon returns `content` as a sanitized HTML fragment with `p`/`br`/`a`/`span` only. Stripped to plain text via targeted regex; newlines come from `<br>` and `</p>`. Safe without a full parser because the upstream sanitizer is the contract.
- **Local-account `acct` normalization** — Mastodon's `acct` field is bare `gargron` for local accounts and `user@server` for federated ones. We normalize local accounts to `user@instance` so the rendered handle is unambiguous regardless of which instance the column queries.
- **Federated handle parsing** — accepts `user`, `@user`, `user@server`, or `@user@server`. The `user@server` form transparently routes the lookup to that server, not the configured instance — so a `mastodon.social` column can still follow `gargron@example.org` without misconfiguring `instance`.
- **Reblog filter on author timelines** — `exclude_reblogs=true` on the API plus a defensive `if (s.reblog) return null` guard in case the upstream contract changes. The column attribution would otherwise be misleading ("by @actor" but content authored by someone else).
- **Content-warning prefix** — statuses with `spoiler_text` get `[CW: …]` prepended so the warning isn't silently dropped.
- **Schema-drift safe** — drops statuses missing `id` or `url` rather than rendering dead content.
- **Default avatar fallback** — same dicebear seeding farcaster uses, for accounts without a `pfp_url`.

## Files

- `lib/integrations/mastodon.ts` — fetcher pair (`fetchMastodonHashtag`, `fetchMastodonAuthor`) + handle parser + HTML stripper. Keyless throughout.
- `lib/columns/plugins/mastodon/plugin.ts` — Zod `{ instance: "mastodon.social" default, mode: "hashtag"|"author", query, handle }`, `AtSign` icon, Mastodon brand purple `#6364ff` (distinct from x-search blue `#1d9bf0`, farcaster purple `#7c65c1`, and the Bluesky blue `#0085ff` once that lands so the social cluster stays visually differentiated).
- `lib/columns/plugins/mastodon/server.ts` — typed fetcher, slice-based pagination via the existing `sliceForPage` helper.
- `lib/columns/plugins/mastodon/client.tsx` — ConfigForm with instance + mode-conditional fields; ItemRenderer matches farcaster's avatar-led card layout with serif post text and engagement footer (replies / reblogs / favourites).
- `lib/columns/plugins/manifest.ts` — +1 import, +1 array entry.
- `lib/columns/registry.ts` — +1 import, +1 map entry (UI side).
- `lib/columns/server-registry.ts` — +1 import, +1 map entry (server side; parity check at module init throws if drift).
- `README.md` — column count 30 → 31, Social row 5 → 6 entries, description list adds Mastodon between Farcaster and YouTube.

## Notes

- **No new env vars / build deps / schema migration.** Works the moment users add it, preserving the "first column up in under a minute, zero infra" README promise.
- **No conflict with PR #25** (Bluesky column) — different file paths everywhere; both can land independently. README counts here assume Bluesky lands first; merging in either order is fine and produces the right count.
- **Federation** — any public Mastodon instance works. Default `mastodon.social` is the most discoverable default; users can swap to fosstodon, hachyderm, infosec.exchange, etc.

---
*Built autonomously by Aeon*