### PR TITLE
feat(plugins): add lobsters column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, GitHub (trending / issues / PRs / stars / forks / backlinks / search), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 33 column types out of the box — social feeds, news, GitHub, app reviews, on-chain transactions, Chinese hot boards.
+- 34 column types out of the box — social feeds, news, GitHub, app reviews, on-chain transactions, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -60,7 +60,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 |----------|---------|
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
 | **GitHub** (8) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks` |
-| **News & web** (4) | `bing` (Web search), `google-news`, `news-search`, `rss` |
+| **News & web** (5) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters` |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |
 | **Apps & on-chain** (3) | `apple-reviews`, `play-reviews`, `wallet-tx` |

--- a/lib/columns/plugins/lobsters/client.tsx
+++ b/lib/columns/plugins/lobsters/client.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { ArrowBigUp, MessageSquareText } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import { meta, type LobstersConfig, type LobstersMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<LobstersConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Mode</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as LobstersConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="hottest">Hottest</SelectItem>
+            <SelectItem value="newest">Newest</SelectItem>
+            <SelectItem value="active">Active discussions</SelectItem>
+            <SelectItem value="tag">By tag…</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      {value.mode === "tag" && (
+        <div className="grid gap-1.5">
+          <Label htmlFor="lob-tag">Tag</Label>
+          <Input
+            id="lob-tag"
+            placeholder="rust, ai, programming…"
+            value={value.tag}
+            onChange={(e) => onChange({ ...value, tag: e.target.value })}
+          />
+          <p className="text-xs text-muted-foreground">
+            One tag, or several comma-separated. See{" "}
+            <a
+              href="https://lobste.rs/tags"
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              lobste.rs/tags
+            </a>{" "}
+            for the full list.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<LobstersMeta>) {
+  const m = item.meta;
+  const score = m?.score ?? 0;
+  const comments = m?.comments ?? 0;
+  const commentsUrl = m?.commentsUrl ?? item.url;
+  const tags = m?.tags ?? [];
+
+  const [title, ...rest] = item.content.split("\n\n");
+  const snippet = rest.join("\n\n").trim();
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(172, 19, 13, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[9px] font-bold leading-none text-white"
+            style={{ backgroundColor: "#ac130d" }}
+          >
+            L
+          </span>
+          Lobsters
+        </span>
+        <span className="text-muted-foreground/80">
+          by{" "}
+          <span className="text-foreground/90">
+            {item.author.handle ?? item.author.name}
+          </span>
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+        >
+          {title}
+        </h3>
+      </a>
+      {snippet && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {snippet}
+        </p>
+      )}
+      {tags.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {tags.slice(0, 4).map((t) => (
+            <span
+              key={t}
+              className="rounded-sm px-1 py-0.5 text-[10px] text-muted-foreground ring-1 ring-border/60"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <ArrowBigUp className="size-4" />
+          <span className="tabular-nums">{formatCompactCount(score)}</span>
+        </span>
+        <a
+          href={commentsUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="flex items-center gap-1 transition-colors hover:text-foreground"
+        >
+          <MessageSquareText className="size-3.5" />
+          <span className="tabular-nums">{formatCompactCount(comments)}</span>
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<LobstersConfig, LobstersMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/lobsters/plugin.ts
+++ b/lib/columns/plugins/lobsters/plugin.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { Anchor } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  mode: z.enum(["hottest", "newest", "active", "tag"]).default("hottest"),
+  tag: z.string().default(""),
+});
+
+export type LobstersConfig = z.infer<typeof schema>;
+
+export interface LobstersMeta {
+  score: number;
+  comments: number;
+  commentsUrl: string;
+  externalUrl?: string;
+  tags: string[];
+}
+
+const MODE_LABELS: Record<LobstersConfig["mode"], string> = {
+  hottest: "Hottest",
+  newest: "Newest",
+  active: "Active",
+  tag: "Tag",
+};
+
+export const meta: PluginMeta<LobstersConfig, LobstersMeta> = {
+  id: "lobsters",
+  label: "Lobsters",
+  description:
+    "Front page, newest, active discussions, or filter by tag (e.g. rust, ai, programming).",
+  icon: Anchor,
+  // Lobsters' brand colour — the lobster-claw red on lobste.rs/about.
+  accent: "#ac130d",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.mode === "tag" && c.tag.trim()
+      ? `Lobsters · t/${c.tag.trim()}`
+      : `Lobsters · ${MODE_LABELS[c.mode]}`,
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/lobsters/server.ts
+++ b/lib/columns/plugins/lobsters/server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchLobstersPage } from "@/lib/integrations/lobsters";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type LobstersConfig, type LobstersMeta } from "./plugin";
+
+const fetch: ServerFetcher<LobstersConfig, LobstersMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  // Tag mode requires a tag — fall back to hottest if the user picked tag
+  // without filling one in, so the column always renders something rather
+  // than throwing a 404 from /t/.json.
+  const effectiveMode =
+    config.mode === "tag" && !config.tag.trim() ? "hottest" : config.mode;
+  const r = await fetchLobstersPage(effectiveMode, config.tag, PAGE_SIZE, page);
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<LobstersConfig, LobstersMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -37,6 +37,7 @@ import { meta as githubStars } from "./github-stars/plugin";
 import { meta as githubForks } from "./github-forks/plugin";
 import { meta as githubReleases } from "./github-releases/plugin";
 import { meta as bluesky } from "./bluesky/plugin";
+import { meta as lobsters } from "./lobsters/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -72,6 +73,7 @@ export const PLUGIN_METAS = [
   githubForks,
   githubReleases,
   bluesky,
+  lobsters,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -45,6 +45,7 @@ import { column as githubStars } from "@/lib/columns/plugins/github-stars/client
 import { column as githubForks } from "@/lib/columns/plugins/github-forks/client";
 import { column as githubReleases } from "@/lib/columns/plugins/github-releases/client";
 import { column as bluesky } from "@/lib/columns/plugins/bluesky/client";
+import { column as lobsters } from "@/lib/columns/plugins/lobsters/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -83,6 +84,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "github-forks": githubForks,
   "github-releases": githubReleases,
   bluesky,
+  lobsters,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -41,6 +41,7 @@ import { server as githubStars } from "@/lib/columns/plugins/github-stars/server
 import { server as githubForks } from "@/lib/columns/plugins/github-forks/server";
 import { server as githubReleases } from "@/lib/columns/plugins/github-releases/server";
 import { server as bluesky } from "@/lib/columns/plugins/bluesky/server";
+import { server as lobsters } from "@/lib/columns/plugins/lobsters/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -76,6 +77,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "github-forks": githubForks,
   "github-releases": githubReleases,
   bluesky,
+  lobsters,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/lobsters.ts
+++ b/lib/integrations/lobsters.ts
@@ -1,0 +1,159 @@
+import type { FeedItem } from "@/lib/columns/types";
+import { identiconUrl } from "@/lib/utils";
+
+// Lobsters JSON API — public, no auth, generous rate limits.
+// https://lobste.rs/about — Active, hottest, newest, and per-tag feeds all
+// expose .json variants of their HTML pages. Pagination flows through
+// /page/N/{mode}.json. The story object shape is documented at
+// https://github.com/lobsters/lobsters/blob/master/app/views/stories/_story.json.jbuilder
+const BASE = "https://lobste.rs";
+
+export type LobstersMode = "hottest" | "newest" | "active" | "tag";
+
+interface LobstersStory {
+  short_id: string;
+  short_id_url?: string;
+  comments_url?: string;
+  url?: string;
+  title: string;
+  description?: string;
+  description_plain?: string;
+  score?: number;
+  upvotes?: number;
+  downvotes?: number;
+  comment_count?: number;
+  created_at?: string;
+  tags?: string[];
+  submitter_user?: string | { username?: string };
+  user_is_author?: boolean;
+}
+
+function endpointFor(mode: LobstersMode, tag: string, page: number): string {
+  // Lobsters uses /page/N/ — page 1 is the bare root, no /page/1/ segment.
+  const pageSegment = page > 0 ? `/page/${page + 1}` : "";
+  switch (mode) {
+    case "tag": {
+      // Multiple tags can be combined with commas (e.g. /t/rust,go.json).
+      const slug = tag
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean)
+        .join(",");
+      return `${BASE}/t/${encodeURIComponent(slug)}${pageSegment}.json`;
+    }
+    case "newest":
+      return `${BASE}/newest${pageSegment}.json`;
+    case "active":
+      return `${BASE}/active${pageSegment}.json`;
+    case "hottest":
+    default:
+      // The front page is /hottest, which is also reachable as the bare root,
+      // but the .json variant requires the explicit /hottest segment.
+      return `${BASE}/hottest${pageSegment}.json`;
+  }
+}
+
+function unwrapAuthor(s: LobstersStory): string {
+  const u = s.submitter_user;
+  if (!u) return "anonymous";
+  if (typeof u === "string") return u;
+  return u.username ?? "anonymous";
+}
+
+function stripHtml(html: string): string {
+  // Lobsters returns sanitised fragments — links, paragraphs, code, em — so a
+  // targeted regex strip is safe without pulling in a full HTML parser.
+  return html
+    .replace(/<\/(p|div|li|br|h[1-6])>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function mapStory(s: LobstersStory): FeedItem<LobstersMeta> | null {
+  // Schema-drift safe — without an id or a comments URL there's nothing to
+  // render or link to, so drop rather than emit a dead row.
+  if (!s.short_id || !s.title) return null;
+
+  const author = unwrapAuthor(s);
+  const commentsUrl =
+    s.comments_url ?? s.short_id_url ?? `${BASE}/s/${s.short_id}`;
+  const externalUrl = s.url || undefined;
+  const createdMs = s.created_at ? Date.parse(s.created_at) : Date.now();
+
+  const description =
+    s.description_plain?.trim() ||
+    (s.description ? stripHtml(s.description) : "");
+
+  const content = description ? `${s.title}\n\n${description}` : s.title;
+
+  return {
+    id: s.short_id,
+    author: {
+      name: author,
+      handle: author,
+      avatarUrl: identiconUrl(author),
+    },
+    content,
+    url: externalUrl ?? commentsUrl,
+    createdAt: new Date(createdMs).toISOString(),
+    meta: {
+      score: s.score ?? 0,
+      comments: s.comment_count ?? 0,
+      commentsUrl,
+      externalUrl,
+      tags: Array.isArray(s.tags) ? s.tags : [],
+    },
+  };
+}
+
+export interface LobstersMeta {
+  score: number;
+  comments: number;
+  commentsUrl: string;
+  externalUrl?: string;
+  tags: string[];
+}
+
+export async function fetchLobstersPage(
+  mode: LobstersMode,
+  tag: string,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<LobstersMeta>[]; hasMore: boolean }> {
+  const url = endpointFor(mode, tag, page);
+  const res = await fetch(url, {
+    headers: {
+      accept: "application/json",
+      // Lobsters' admins ask scrapers to identify themselves; minitor is a
+      // dashboard polling at user-driven cadence so a recognisable UA helps
+      // them rate-limit cooperatively if needed.
+      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Lobsters ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const json = (await res.json()) as LobstersStory[];
+  if (!Array.isArray(json)) {
+    return { items: [], hasMore: false };
+  }
+  const mapped = json
+    .map(mapStory)
+    .filter((s): s is FeedItem<LobstersMeta> => s !== null);
+  // Lobsters serves 25 stories per page on a full page — fewer means we've
+  // reached the tail. Clamp the visible slice to `limit` independently of
+  // whether the underlying response was full, so paging is determined by
+  // upstream page size, not the post-filter slice.
+  const hasMore = json.length >= 25;
+  return { items: mapped.slice(0, limit), hasMore };
+}


### PR DESCRIPTION
## What

34th column type — Lobsters (lobste.rs), a tech-focused community of ~30k engineers. Adjacent to Hacker News in audience but with narrower, higher-signal submissions and a tag taxonomy that supports filtered feeds (rust, ai, programming, security, …). Four modes: Hottest (front page), Newest, Active (sorted by recent comment activity), and Tag (single tag, or comma-separated multi-tag).

## Why

Closes the obvious News & Web cluster gap — HN was the only general-tech discussion column. Lobsters fills the slot for users who want a second, smaller-signal stream alongside HN. Anyone running a founder dashboard / open-source maintainer dashboard / ML-research dashboard tends to read both — being able to stack \`hacker-news\` and \`lobsters\` next to each other on the same deck is the natural layout.

Why keyless: Lobsters exposes JSON variants of every public page — `/hottest`, `/newest`, `/active`, and per-tag `/t/<tag>` all return the same story array via `.json`. No auth, no token. Pagination flows through `/page/N/{mode}.json` (page 1 is the bare root, no `/page/1/` segment — handled in `endpointFor`).

## Changes

- `lib/integrations/lobsters.ts` (new) — keyless JSON fetcher for the four modes, schema-drift-safe story mapper (drops rows missing `short_id` / `title` rather than rendering dead content), HTML strip for the `description` field (Lobsters returns sanitised fragments — p/br/code/em/a only — so a targeted regex strip is safe without pulling in a parser; falls back to `description_plain` if upstream sends it). Author unwrap handles both `submitter_user: \"name\"` and `submitter_user: { username: \"name\" }` shapes seen across recent API output. User-agent header identifies minitor — Lobsters' admins ask scrapers to identify themselves so they can throttle cooperatively if needed.
- `lib/columns/plugins/lobsters/{plugin,client,server}.ts` (new) — standard 3-file plugin. Zod `{ mode: \"hottest\"|\"newest\"|\"active\"|\"tag\", tag: string }`. Anchor icon (a nod to the lobster claw in lobste.rs branding without copying the proprietary logo). Brand red `#ac130d` (the lobster-claw red on lobste.rs/about) — distinct from HN's orange `#ff6600` so the two news-source columns stay visually differentiated when stacked together.
- `lib/columns/plugins/manifest.ts`, `lib/columns/registry.ts`, `lib/columns/server-registry.ts` — three registry edits per the README contract. Parity check at server module init throws if any registry drifts.
- `README.md` — column count 33 → 34, News & Web row 4 → 5, hero paragraph picks up \"Lobsters\" alongside \"Hacker News\".

## Lobsters-specific quirks handled

- **Tag mode supports comma-separated multi-tag filter** (`/t/rust,go.json`) — matches Lobsters' upstream URL convention.
- **Tag mode with empty tag falls back to hottest** in `server.ts` to avoid a 404 on `/t/.json` — column always renders something rather than throwing.
- **`hasMore` detection uses upstream page size** (>=25) NOT post-filter slice, so the visible `PAGE_SIZE` clamp doesn't stop pagination early on full pages.
- **Tag pills in renderer** — Lobsters' tag taxonomy is a key part of the signal; first 4 tags rendered as small pills under the snippet (HN's renderer doesn't have this since HN has no tags).
- **Comments URL distinct from external URL** — story title links to the external article; comment-count badge links to lobste.rs/s/{short_id}. Matches HN's pattern.

## What you get

No new env vars / build deps / schema migration — works the moment users add it, preserving the \"first column up in under a minute, zero infra\" README promise.

---
*Built autonomously by Aeon*