### PR TITLE
feat(plugins): add polymarket prediction-markets column

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 34 column types out of the box — social feeds, news, GitHub, app reviews, on-chain transactions, Chinese hot boards.
+- 35 column types out of the box — social feeds, news, GitHub, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -41,7 +41,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -63,7 +63,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 | **News & web** (5) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters` |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |
-| **Apps & on-chain** (3) | `apple-reviews`, `play-reviews`, `wallet-tx` |
+| **Apps & on-chain** (4) | `apple-reviews`, `play-reviews`, `wallet-tx`, `polymarket` |
 | **China hot boards** (6) | `weibo-hot`, `zhihu-hot`, `douyin-hot`, `bilibili-hot`, `toutiao`, `baidu-hot` |
 
 Full plugin manifest: [`lib/columns/plugins/manifest.ts`](lib/columns/plugins/manifest.ts). Add a new source by copying [`lib/columns/plugins/_template/`](lib/columns/plugins/_template/) — see [`lib/columns/README.md`](lib/columns/README.md) for the full contract.

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -38,6 +38,7 @@ import { meta as githubForks } from "./github-forks/plugin";
 import { meta as githubReleases } from "./github-releases/plugin";
 import { meta as bluesky } from "./bluesky/plugin";
 import { meta as lobsters } from "./lobsters/plugin";
+import { meta as polymarket } from "./polymarket/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -74,6 +75,7 @@ export const PLUGIN_METAS = [
   githubReleases,
   bluesky,
   lobsters,
+  polymarket,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/plugins/polymarket/client.tsx
+++ b/lib/columns/plugins/polymarket/client.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { Calendar, Droplets, TrendingUp } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type PolymarketConfig, type PolymarketMeta } from "./plugin";
+
+function formatUsd(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "$0";
+  if (n < 1000) return `$${Math.round(n)}`;
+  if (n < 1_000_000) return `$${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  if (n < 1_000_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  return `$${(n / 1_000_000_000).toFixed(1)}B`;
+}
+
+function formatPct(p: number): string {
+  // Gamma serves probabilities in 0–1 decimal form. Round to a whole percent
+  // — Polymarket's own UI also rounds; keeping decimals here would create
+  // false precision against a market that's actively trading.
+  if (!Number.isFinite(p)) return "—";
+  const v = Math.max(0, Math.min(1, p));
+  return `${Math.round(v * 100)}%`;
+}
+
+function formatEndDate(iso?: string): string | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return null;
+  const now = Date.now();
+  const diffDays = Math.round((t - now) / 86_400_000);
+  if (diffDays < 0) return "ended";
+  if (diffDays === 0) return "ends today";
+  if (diffDays === 1) return "ends tomorrow";
+  if (diffDays < 7) return `ends in ${diffDays}d`;
+  if (diffDays < 30) return `ends in ${Math.round(diffDays / 7)}w`;
+  if (diffDays < 365) return `ends in ${Math.round(diffDays / 30)}mo`;
+  return `ends in ${Math.round(diffDays / 365)}y`;
+}
+
+function ConfigForm({ value, onChange }: ConfigFormProps<PolymarketConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Sort</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as PolymarketConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="trending">Trending (24h volume)</SelectItem>
+            <SelectItem value="newest">Newest</SelectItem>
+            <SelectItem value="ending-soon">Ending soon</SelectItem>
+            <SelectItem value="tag">By tag…</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      {value.mode === "tag" && (
+        <div className="grid gap-1.5">
+          <Label htmlFor="poly-tag">Tag slug</Label>
+          <Input
+            id="poly-tag"
+            placeholder="politics, sports, crypto, world, entertainment…"
+            value={value.tag}
+            onChange={(e) => onChange({ ...value, tag: e.target.value })}
+          />
+          <p className="text-xs text-muted-foreground">
+            Lowercase tag slug — see{" "}
+            <a
+              href="https://polymarket.com"
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              polymarket.com
+            </a>{" "}
+            category pages for the canonical list. Empty falls back to
+            Trending.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<PolymarketMeta>) {
+  const m = item.meta;
+  const outcomes = m?.outcomes ?? [];
+  const top = outcomes.slice(0, 2);
+  const isBinary = outcomes.length === 2;
+  const volume = m?.volume24hUsd ?? 0;
+  const liquidity = m?.liquidityUsd ?? 0;
+  const endsLabel = formatEndDate(m?.endDate);
+
+  const [title, ...rest] = item.content.split("\n\n");
+  const snippet = rest.join("\n\n").trim();
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(45, 156, 219, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[9px] font-bold leading-none text-white"
+            style={{ backgroundColor: "#2D9CDB" }}
+          >
+            P
+          </span>
+          Polymarket
+        </span>
+        {m?.category && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="text-foreground/80">{m.category}</span>
+          </>
+        )}
+        {endsLabel && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="inline-flex items-center gap-1 tabular-nums">
+              <Calendar className="size-3" />
+              {endsLabel}
+            </span>
+          </>
+        )}
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {title}
+      </h3>
+      {snippet && (
+        <p className="mt-1 line-clamp-2 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {snippet}
+        </p>
+      )}
+      {top.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {top.map((o, idx) => {
+            const pct = formatPct(o.price);
+            const leading = isBinary && idx === 0;
+            return (
+              <span
+                key={`${o.label}-${idx}`}
+                className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[11.5px] tabular-nums ring-1"
+                style={{
+                  backgroundColor: leading
+                    ? "rgba(45, 156, 219, 0.18)"
+                    : "rgba(148, 163, 184, 0.10)",
+                  color: leading ? "#1a6fa3" : undefined,
+                  borderColor: "transparent",
+                }}
+              >
+                <span className="font-medium">{o.label}</span>
+                <span className="text-muted-foreground">·</span>
+                <span className="font-semibold">{pct}</span>
+              </span>
+            );
+          })}
+          {outcomes.length > top.length && (
+            <span className="self-center text-[11px] text-muted-foreground">
+              +{outcomes.length - top.length} more
+            </span>
+          )}
+        </div>
+      )}
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <TrendingUp className="size-3.5" />
+          <span className="tabular-nums">{formatUsd(volume)}</span>
+          <span className="text-muted-foreground/70">24h</span>
+        </span>
+        <span className="flex items-center gap-1">
+          <Droplets className="size-3.5" />
+          <span className="tabular-nums">{formatUsd(liquidity)}</span>
+          <span className="text-muted-foreground/70">liq</span>
+        </span>
+      </div>
+    </a>
+  );
+}
+
+export const column = defineColumnUI<PolymarketConfig, PolymarketMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/polymarket/plugin.ts
+++ b/lib/columns/plugins/polymarket/plugin.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { BarChart3 } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  mode: z.enum(["trending", "newest", "ending-soon", "tag"]).default("trending"),
+  tag: z.string().default(""),
+});
+
+export type PolymarketConfig = z.infer<typeof schema>;
+
+export interface PolymarketMeta {
+  outcomes: { label: string; price: number }[];
+  volume24hUsd: number;
+  liquidityUsd: number;
+  endDate?: string;
+  category?: string;
+  conditionId?: string;
+  imageUrl?: string;
+}
+
+const MODE_LABELS: Record<PolymarketConfig["mode"], string> = {
+  trending: "Trending",
+  newest: "Newest",
+  "ending-soon": "Ending soon",
+  tag: "Tag",
+};
+
+export const meta: PluginMeta<PolymarketConfig, PolymarketMeta> = {
+  id: "polymarket",
+  label: "Polymarket",
+  description:
+    "Live prediction markets — sort by 24h volume, newest, or ending-soon, or filter by tag (politics, sports, crypto, world…).",
+  icon: BarChart3,
+  // Polymarket's brand palette leans on a saturated electric blue (#2D9CDB
+  // is the primary they use across polymarket.com and their token chips).
+  // Distinct from wallet-tx's #627eea so the two blockchain-cluster columns
+  // stay visually differentiated when stacked together.
+  accent: "#2D9CDB",
+  category: "blockchain",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.mode === "tag" && c.tag.trim()
+      ? `Polymarket · ${c.tag.trim()}`
+      : `Polymarket · ${MODE_LABELS[c.mode]}`,
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/polymarket/server.ts
+++ b/lib/columns/plugins/polymarket/server.ts
@@ -1,0 +1,36 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchPolymarketPage } from "@/lib/integrations/polymarket";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type PolymarketConfig, type PolymarketMeta } from "./plugin";
+
+const fetch: ServerFetcher<PolymarketConfig, PolymarketMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  // Tag mode requires a tag — fall back to trending if the user picked tag
+  // without filling one in, so the column always renders the most-traded
+  // markets rather than throwing on an empty `tag_slug=`.
+  const effectiveMode =
+    config.mode === "tag" && !config.tag.trim() ? "trending" : config.mode;
+  const r = await fetchPolymarketPage(
+    effectiveMode,
+    config.tag,
+    PAGE_SIZE,
+    page,
+  );
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<PolymarketConfig, PolymarketMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -46,6 +46,7 @@ import { column as githubForks } from "@/lib/columns/plugins/github-forks/client
 import { column as githubReleases } from "@/lib/columns/plugins/github-releases/client";
 import { column as bluesky } from "@/lib/columns/plugins/bluesky/client";
 import { column as lobsters } from "@/lib/columns/plugins/lobsters/client";
+import { column as polymarket } from "@/lib/columns/plugins/polymarket/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -85,6 +86,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "github-releases": githubReleases,
   bluesky,
   lobsters,
+  polymarket,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -42,6 +42,7 @@ import { server as githubForks } from "@/lib/columns/plugins/github-forks/server
 import { server as githubReleases } from "@/lib/columns/plugins/github-releases/server";
 import { server as bluesky } from "@/lib/columns/plugins/bluesky/server";
 import { server as lobsters } from "@/lib/columns/plugins/lobsters/server";
+import { server as polymarket } from "@/lib/columns/plugins/polymarket/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -78,6 +79,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "github-releases": githubReleases,
   bluesky,
   lobsters,
+  polymarket,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/polymarket.ts
+++ b/lib/integrations/polymarket.ts
@@ -1,0 +1,247 @@
+import type { FeedItem } from "@/lib/columns/types";
+import { identiconUrl } from "@/lib/utils";
+
+// Polymarket Gamma API — public, no auth, generous rate limits.
+// https://docs.polymarket.com/#markets-1 documents the markets endpoint.
+// We use it both for the trending / newest / ending-soon modes (purely
+// query-string variations on the same endpoint) and for the optional
+// tag-slug filter, which Gamma exposes via `tag_slug=`.
+//
+// All numeric fields arrive on the response as numbers (`volumeNum`,
+// `volume24hrNum`, `liquidityNum`, etc.); the parallel string fields are
+// kept around for backwards compatibility with v0 of the API and ignored
+// here. `outcomes` and `outcomePrices` arrive as JSON-serialised strings
+// of arrays — they need an extra parse pass.
+const BASE = "https://gamma-api.polymarket.com";
+
+export type PolymarketMode = "trending" | "newest" | "ending-soon" | "tag";
+
+interface GammaMarketEvent {
+  slug?: string;
+  title?: string;
+}
+
+interface GammaMarket {
+  id?: string | number;
+  question?: string;
+  slug?: string;
+  description?: string;
+  endDate?: string;
+  startDate?: string;
+  image?: string;
+  icon?: string;
+  outcomes?: string;
+  outcomePrices?: string;
+  volume?: string;
+  volumeNum?: number;
+  volume24hr?: string;
+  volume24hrNum?: number;
+  liquidity?: string;
+  liquidityNum?: number;
+  active?: boolean;
+  closed?: boolean;
+  archived?: boolean;
+  conditionId?: string;
+  groupItemTitle?: string;
+  events?: GammaMarketEvent[];
+}
+
+export interface PolymarketMeta {
+  outcomes: { label: string; price: number }[];
+  volume24hUsd: number;
+  liquidityUsd: number;
+  endDate?: string;
+  category?: string;
+  conditionId?: string;
+  imageUrl?: string;
+}
+
+function parseJsonArray(raw: string | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.map((v) => String(v)) : [];
+  } catch {
+    return [];
+  }
+}
+
+function endpointFor(mode: PolymarketMode, tag: string, limit: number, page: number): string {
+  // The Gamma API caps `limit` at 500 per request but we ask for `limit + 1`
+  // to detect the "has more" boundary cleanly. Offset is computed off the
+  // requested page — pages are 0-indexed and `limit` items wide.
+  const params = new URLSearchParams({
+    limit: String(Math.min(limit + 1, 100)),
+    offset: String(page * limit),
+    closed: "false",
+    archived: "false",
+    active: "true",
+  });
+
+  switch (mode) {
+    case "newest":
+      params.set("order", "startDate");
+      params.set("ascending", "false");
+      break;
+    case "ending-soon":
+      // Ascending end-date with a future-only floor — Gamma does not expose a
+      // `endDate>=now` filter directly, but markets whose endDate is already
+      // in the past will normally be `closed:true` (dropped by the active
+      // filter above). Belt-and-braces: we drop any past-dated leftovers in
+      // the mapper as well.
+      params.set("order", "endDate");
+      params.set("ascending", "true");
+      break;
+    case "tag":
+      params.set("order", "volume24hr");
+      params.set("ascending", "false");
+      if (tag.trim()) {
+        params.set("tag_slug", tag.trim().toLowerCase());
+      }
+      break;
+    case "trending":
+    default:
+      // 24h volume is the canonical signal — newest markets are mostly
+      // zero-volume crypto bets; volume picks the markets people are
+      // actually trading right now.
+      params.set("order", "volume24hr");
+      params.set("ascending", "false");
+      break;
+  }
+
+  return `${BASE}/markets?${params.toString()}`;
+}
+
+function permalinkFor(m: GammaMarket): string {
+  const eventSlug = m.events?.find((e) => !!e.slug)?.slug;
+  if (eventSlug) return `https://polymarket.com/event/${eventSlug}`;
+  if (m.slug) return `https://polymarket.com/market/${m.slug}`;
+  return "https://polymarket.com";
+}
+
+function stripHtml(html: string): string {
+  // Gamma `description` is plain text in practice, but a minority of imported
+  // markets carry over light HTML from upstream sources — strip it the same
+  // way Lobsters does to stay safe without a parser dependency.
+  return html
+    .replace(/<\/(p|div|li|br|h[1-6])>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function mapMarket(m: GammaMarket, now: number): FeedItem<PolymarketMeta> | null {
+  // Schema-drift safe — without an id or a question there's nothing to
+  // render, so drop rather than emit a dead row.
+  const id = m.id == null ? "" : String(m.id);
+  const question = (m.question ?? "").trim();
+  if (!id || !question) return null;
+
+  // Active filter on the API is best-effort; some markets slip through with
+  // endDate already in the past. Drop those defensively rather than render
+  // a "predict the past" row.
+  const endMs = m.endDate ? Date.parse(m.endDate) : NaN;
+  if (Number.isFinite(endMs) && endMs < now - 86_400_000) return null;
+
+  const outcomeLabels = parseJsonArray(m.outcomes);
+  const outcomePrices = parseJsonArray(m.outcomePrices).map((p) => {
+    const n = Number(p);
+    return Number.isFinite(n) ? n : 0;
+  });
+  const outcomes = outcomeLabels.map((label, idx) => ({
+    label,
+    price: outcomePrices[idx] ?? 0,
+  }));
+
+  // For binary markets, sort so the leading outcome shows first; for
+  // multi-outcome markets, leave the original order (Polymarket usually
+  // sorts them by likelihood already).
+  if (outcomes.length === 2) {
+    outcomes.sort((a, b) => b.price - a.price);
+  }
+
+  const description = m.description ? stripHtml(m.description) : "";
+  const content = description ? `${question}\n\n${description}` : question;
+
+  const startMs = m.startDate ? Date.parse(m.startDate) : NaN;
+  const createdAt = Number.isFinite(startMs)
+    ? new Date(startMs).toISOString()
+    : new Date(now).toISOString();
+
+  // Pick the best image we have — `image` is usually richer artwork; `icon`
+  // is the smaller round avatar. Prefer image, then icon, then identicon
+  // off the question so every market still has something.
+  const imageUrl =
+    m.image && /^https?:/i.test(m.image)
+      ? m.image
+      : m.icon && /^https?:/i.test(m.icon)
+        ? m.icon
+        : undefined;
+
+  return {
+    id,
+    author: {
+      name: "Polymarket",
+      handle: m.groupItemTitle ?? "polymarket",
+      avatarUrl: imageUrl ?? identiconUrl(question),
+    },
+    content,
+    url: permalinkFor(m),
+    createdAt,
+    meta: {
+      outcomes,
+      volume24hUsd: typeof m.volume24hrNum === "number" ? m.volume24hrNum : 0,
+      liquidityUsd: typeof m.liquidityNum === "number" ? m.liquidityNum : 0,
+      endDate: m.endDate,
+      category: m.groupItemTitle,
+      conditionId: m.conditionId,
+      imageUrl,
+    },
+  };
+}
+
+export async function fetchPolymarketPage(
+  mode: PolymarketMode,
+  tag: string,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<PolymarketMeta>[]; hasMore: boolean }> {
+  const url = endpointFor(mode, tag, limit, page);
+  const res = await fetch(url, {
+    headers: {
+      accept: "application/json",
+      // Polymarket's Gamma API is openly documented as public; identifying
+      // ourselves keeps us in good standing if they ever start enforcing
+      // per-client rate limits.
+      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Polymarket ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+
+  const json = (await res.json()) as GammaMarket[];
+  if (!Array.isArray(json)) {
+    return { items: [], hasMore: false };
+  }
+
+  const now = Date.now();
+  const mapped = json
+    .map((m) => mapMarket(m, now))
+    .filter((m): m is FeedItem<PolymarketMeta> => m !== null);
+
+  // We over-requested by one to cleanly detect the boundary; clamp the
+  // visible slice back to the caller's `limit`.
+  const hasMore = json.length > limit;
+  return { items: mapped.slice(0, limit), hasMore };
+}

--- a/lib/integrations/polymarket.ts
+++ b/lib/integrations/polymarket.ts
@@ -34,8 +34,12 @@ interface GammaMarket {
   outcomePrices?: string;
   volume?: string;
   volumeNum?: number;
-  volume24hr?: string;
-  volume24hrNum?: number;
+  // Gamma returns `volume24hr` as a *number* on live responses (despite older
+  // schema docs typing it as a string); the parallel `volume24hrNum` field is
+  // documented but in practice always null. Read the bare field with a typeof
+  // guard so we keep number values and ignore the legacy string form.
+  volume24hr?: number | string;
+  volume24hrNum?: number | null;
   liquidity?: string;
   liquidityNum?: number;
   active?: boolean;
@@ -196,7 +200,12 @@ function mapMarket(m: GammaMarket, now: number): FeedItem<PolymarketMeta> | null
     createdAt,
     meta: {
       outcomes,
-      volume24hUsd: typeof m.volume24hrNum === "number" ? m.volume24hrNum : 0,
+      volume24hUsd:
+        typeof m.volume24hr === "number"
+          ? m.volume24hr
+          : typeof m.volume24hrNum === "number"
+            ? m.volume24hrNum
+            : 0,
       liquidityUsd: typeof m.liquidityNum === "number" ? m.liquidityNum : 0,
       endDate: m.endDate,
       category: m.groupItemTitle,


### PR DESCRIPTION
## What

35th column type — Polymarket prediction markets. Keyless integration with Polymarket's Gamma API (`gamma-api.polymarket.com`). Four modes:

- **Trending** (default) — sorted by 24h trading volume, the canonical signal on Polymarket.
- **Newest** — sorted by `startDate` desc.
- **Ending soon** — sorted by `endDate` asc with past-dated leftovers dropped defensively.
- **By tag** — Polymarket category (politics, sports, crypto, world, entertainment, …) via `tag_slug` query param. Empty falls back to Trending.

## Why

Closes a market-monitoring gap in the on-chain cluster. `wallet-tx` tracks addresses but until today there was no column for the prediction-market side of crypto. Aeon already monitors Polymarket via the `monitor-polymarket` skill in the upstream agent, so adding it as a minitor column gives that same signal a real-time UI surface — useful for crypto desks, journalists watching political markets, and the increasingly large slice of the audience that uses Polymarket as a forecasting tool rather than a betting platform.

The 24h volume sort is the canonical signal: newest markets are mostly zero-volume crypto bets, while volume picks the markets people are actually trading right now. That's why Trending is the default, with Newest / Ending-soon / Tag as secondary modes for narrower use cases.

## Changes

- \`lib/integrations/polymarket.ts\` — fetcher + mapper. Single \`/markets\` endpoint serves all four modes via query-string variations (\`order\`, \`ascending\`, \`tag_slug\`, \`closed=false\`, \`active=true\`, \`archived=false\`). Pagination via \`offset=page * limit\`, with limit + 1 over-request to detect the has-more boundary cleanly. \`outcomes\` / \`outcomePrices\` arrive as JSON-serialised strings of arrays so they get an extra parse pass with a defensive try/catch. Binary markets sorted leading-outcome-first (so YES/NO shows the higher-probability side first); multi-outcome markets keep upstream order.
- \`lib/columns/plugins/polymarket/plugin.ts\` — Zod \`{ mode: 'trending' | 'newest' | 'ending-soon' | 'tag', tag: string }\`. \`BarChart3\` icon, brand blue \`#2D9CDB\` (distinct from \`wallet-tx\`'s \`#627eea\` so the two blockchain-cluster columns stay visually differentiated when stacked together). Category \`blockchain\`. Default title formats to \`Polymarket · Trending\` / \`Polymarket · {tag}\` etc.
- \`lib/columns/plugins/polymarket/server.ts\` — standard server fetcher; tag mode falls back to trending if \`tag\` is empty so the column always renders something rather than throwing on an empty \`tag_slug=\`.
- \`lib/columns/plugins/polymarket/client.tsx\` — config form (sort select + tag input) and item renderer. Outcome pills (top 2 with leading-outcome highlighting on binary markets, \`+N more\` collapse for multi-outcome), 24h volume + liquidity footer with compact USD formatter, end-date label (\`ends in 5d\` / \`ends today\` / \`ended\` etc), serif title hover treatment matching the rest of the news/markets cluster.
- \`lib/columns/plugins/manifest.ts\`, \`lib/columns/registry.ts\`, \`lib/columns/server-registry.ts\` — register \`polymarket\`. Server-registry parity check at module init throws if drift.
- \`README.md\` — column count 34 → 35, Apps & on-chain row 3 → 4 with \`polymarket\` added, hero paragraph picks up \"Polymarket prediction markets\" alongside \"on-chain wallet activity,\" keyless-columns list updated.

## How it works

The Polymarket Gamma API exposes a single \`/markets\` endpoint that supports field-based sorting, ascending/descending toggles, and filter flags for \`active\`/\`closed\`/\`archived\` — so every mode is just a different query string. Each market includes \`outcomes\` (label array) and \`outcomePrices\` (decimal probabilities 0–1) as JSON-serialised strings; we parse these once and present them as percentage chips.

Five Polymarket-specific quirks are handled in the integration layer:

1. \`outcomes\` / \`outcomePrices\` arrive as JSON-serialised strings of arrays, not arrays — extra parse pass in \`parseJsonArray\`, with a defensive try/catch so a single malformed row doesn't kill the whole batch.
2. Binary markets sorted leading-outcome-first in the renderer; multi-outcome markets keep upstream order (Polymarket already sorts by likelihood).
3. Outcome prices floor/ceil clamped to 0..1 before percent formatting — Gamma occasionally serves >1 prices on resolved markets while \`active=true\` is still flickering; the formatter never prints \"YES 110%\".
4. Past-dated markets dropped defensively in the mapper even though the API is asked \`active=true\` / \`closed=false\` — there's a small window where \`endDate\` has passed but the \`closed\` flag hasn't propagated yet, and \"predict the past\" is a worse failure mode than a missing row.
5. Permalink picks \`events[].slug\` first if the market belongs to an event group (multi-outcome elections share an event page), then market slug, then polymarket.com root — every row routes to a real page rather than a 404.

Schema-drift safe: drops markets missing \`id\` or \`question\` rather than rendering dead rows. User-agent header identifies minitor — Polymarket's Gamma API is openly documented as public, but identifying ourselves keeps us in good standing if they ever start enforcing per-client rate limits.

## What's next

Could add a markets-by-event mode (single event page with all outcomes as a stacked bar) once the per-market view has accumulated usage feedback. Could also add a price-alert capability that pings when a binary market crosses a threshold (e.g. \"alert when Trump 2028 odds cross 30%\") — but that's a separate column type, not this one.

---
*Built autonomously by Aeon*