### PR TITLE
feat(plugins): add stack-overflow column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 35 column types out of the box — social feeds, news, GitHub, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
+- 36 column types out of the box — social feeds, news, GitHub, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -41,7 +41,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -60,7 +60,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 |----------|---------|
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
 | **GitHub** (8) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks` |
-| **News & web** (5) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters` |
+| **News & web** (6) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow` |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |
 | **Apps & on-chain** (4) | `apple-reviews`, `play-reviews`, `wallet-tx`, `polymarket` |

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -39,6 +39,7 @@ import { meta as githubReleases } from "./github-releases/plugin";
 import { meta as bluesky } from "./bluesky/plugin";
 import { meta as lobsters } from "./lobsters/plugin";
 import { meta as polymarket } from "./polymarket/plugin";
+import { meta as stackOverflow } from "./stack-overflow/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -76,6 +77,7 @@ export const PLUGIN_METAS = [
   bluesky,
   lobsters,
   polymarket,
+  stackOverflow,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/plugins/stack-overflow/client.tsx
+++ b/lib/columns/plugins/stack-overflow/client.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import {
+  ArrowBigUp,
+  BadgeCheck,
+  Eye,
+  MessageSquareText,
+} from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import {
+  meta,
+  type StackOverflowConfig,
+  type StackOverflowMeta,
+} from "./plugin";
+
+function ConfigForm({
+  value,
+  onChange,
+}: ConfigFormProps<StackOverflowConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Mode</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as StackOverflowConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="hot">Hot</SelectItem>
+            <SelectItem value="votes">Top voted</SelectItem>
+            <SelectItem value="newest">Newest</SelectItem>
+            <SelectItem value="week">Week</SelectItem>
+            <SelectItem value="month">Month</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="so-tag">Tags (optional)</Label>
+        <Input
+          id="so-tag"
+          placeholder="rust, react, postgres…"
+          value={value.tag}
+          onChange={(e) => onChange({ ...value, tag: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Up to five tags, comma- or space-separated. Multiple tags AND-match
+          (returns questions that have <em>all</em> of them). See{" "}
+          <a
+            href="https://stackoverflow.com/tags"
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            stackoverflow.com/tags
+          </a>{" "}
+          for the full list.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<StackOverflowMeta>) {
+  const m = item.meta;
+  const score = m?.score ?? 0;
+  const answers = m?.answers ?? 0;
+  const views = m?.views ?? 0;
+  const tags = m?.tags ?? [];
+  const hasAccepted = !!m?.hasAccepted;
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(244, 128, 36, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[9px] font-bold leading-none text-white"
+            style={{ backgroundColor: "#F48024" }}
+          >
+            S
+          </span>
+          Stack Overflow
+        </span>
+        <span className="text-muted-foreground/80">
+          by{" "}
+          <span className="text-foreground/90">
+            {item.author.handle ?? item.author.name}
+          </span>
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+        {hasAccepted && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span
+              className="inline-flex items-center gap-0.5 text-[11px]"
+              style={{ color: "#5eba7d" }}
+              title="Accepted answer"
+            >
+              <BadgeCheck className="size-3" />
+              accepted
+            </span>
+          </>
+        )}
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+        >
+          {item.content}
+        </h3>
+      </a>
+      {tags.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {tags.slice(0, 5).map((t) => (
+            <span
+              key={t}
+              className="rounded-sm px-1 py-0.5 text-[10px] text-muted-foreground ring-1 ring-border/60"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <ArrowBigUp className="size-4" />
+          <span className="tabular-nums">{formatCompactCount(score)}</span>
+        </span>
+        <span className="flex items-center gap-1">
+          <MessageSquareText className="size-3.5" />
+          <span className="tabular-nums">{formatCompactCount(answers)}</span>
+        </span>
+        <span className="flex items-center gap-1">
+          <Eye className="size-3.5" />
+          <span className="tabular-nums">{formatCompactCount(views)}</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<StackOverflowConfig, StackOverflowMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/stack-overflow/plugin.ts
+++ b/lib/columns/plugins/stack-overflow/plugin.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { Layers } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  mode: z.enum(["hot", "votes", "newest", "week", "month"]).default("hot"),
+  tag: z.string().default(""),
+});
+
+export type StackOverflowConfig = z.infer<typeof schema>;
+
+export interface StackOverflowMeta {
+  score: number;
+  answers: number;
+  views: number;
+  isAnswered: boolean;
+  hasAccepted: boolean;
+  tags: string[];
+  questionId: number;
+}
+
+const MODE_LABELS: Record<StackOverflowConfig["mode"], string> = {
+  hot: "Hot",
+  votes: "Top voted",
+  newest: "Newest",
+  week: "Week",
+  month: "Month",
+};
+
+export const meta: PluginMeta<StackOverflowConfig, StackOverflowMeta> = {
+  id: "stack-overflow",
+  label: "Stack Overflow",
+  description:
+    "Hot, top-voted, newest, or week/month questions — optionally filtered by one or more tags.",
+  icon: Layers,
+  // Stack Overflow's brand orange — the mark used on the official logo and
+  // favicon, distinct from HN orange (#ff6600) and Reddit orange-red (#ff4500).
+  accent: "#F48024",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) =>
+    c.tag.trim()
+      ? `SO · ${c.tag.trim().split(/[,;\s]+/).filter(Boolean).slice(0, 3).join(", ")}`
+      : `SO · ${MODE_LABELS[c.mode]}`,
+  capabilities: {
+    paginated: true,
+    rateLimitHint:
+      "300 requests / IP / day (anonymous Stack Exchange API quota)",
+  },
+};

--- a/lib/columns/plugins/stack-overflow/server.ts
+++ b/lib/columns/plugins/stack-overflow/server.ts
@@ -1,0 +1,38 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchStackOverflowPage } from "@/lib/integrations/stackoverflow";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import {
+  meta,
+  type StackOverflowConfig,
+  type StackOverflowMeta,
+} from "./plugin";
+
+const fetch: ServerFetcher<StackOverflowConfig, StackOverflowMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await fetchStackOverflowPage(
+    config.mode,
+    config.tag,
+    PAGE_SIZE,
+    page,
+  );
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<
+  StackOverflowConfig,
+  StackOverflowMeta
+>({
+  meta,
+  fetch,
+});

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -47,6 +47,7 @@ import { column as githubReleases } from "@/lib/columns/plugins/github-releases/
 import { column as bluesky } from "@/lib/columns/plugins/bluesky/client";
 import { column as lobsters } from "@/lib/columns/plugins/lobsters/client";
 import { column as polymarket } from "@/lib/columns/plugins/polymarket/client";
+import { column as stackOverflow } from "@/lib/columns/plugins/stack-overflow/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -87,6 +88,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   bluesky,
   lobsters,
   polymarket,
+  "stack-overflow": stackOverflow,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -43,6 +43,7 @@ import { server as githubReleases } from "@/lib/columns/plugins/github-releases/
 import { server as bluesky } from "@/lib/columns/plugins/bluesky/server";
 import { server as lobsters } from "@/lib/columns/plugins/lobsters/server";
 import { server as polymarket } from "@/lib/columns/plugins/polymarket/server";
+import { server as stackOverflow } from "@/lib/columns/plugins/stack-overflow/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -80,6 +81,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   bluesky,
   lobsters,
   polymarket,
+  "stack-overflow": stackOverflow,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/stackoverflow.ts
+++ b/lib/integrations/stackoverflow.ts
@@ -161,6 +161,7 @@ export async function fetchStackOverflowPage(
   const res = await fetch(url, {
     headers: {
       accept: "application/json",
+      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
     },
     cache: "no-store",
   });

--- a/lib/integrations/stackoverflow.ts
+++ b/lib/integrations/stackoverflow.ts
@@ -1,0 +1,186 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// Stack Exchange API 2.3 — public, no auth, generous quota.
+// https://api.stackexchange.com/docs/questions
+//
+// We hit /questions on the stackoverflow site filtered by sort (hot, votes,
+// creation, week, month) and an optional tag filter. The endpoint returns
+// gzip-encoded JSON; fetch decompresses transparently when Accept-Encoding
+// is the default. Anonymous quota is 300 req/IP/day — comfortably above a
+// dashboard polling cadence.
+const BASE = "https://api.stackexchange.com/2.3";
+
+export type StackOverflowMode = "hot" | "votes" | "newest" | "week" | "month";
+
+interface SOOwner {
+  display_name?: string;
+  link?: string;
+  profile_image?: string;
+  user_id?: number;
+  user_type?: string;
+}
+
+interface SOQuestion {
+  question_id: number;
+  title: string;
+  link: string;
+  tags?: string[];
+  is_answered?: boolean;
+  view_count?: number;
+  answer_count?: number;
+  score?: number;
+  creation_date?: number;
+  last_activity_date?: number;
+  accepted_answer_id?: number;
+  owner?: SOOwner;
+}
+
+interface SOResponse {
+  items?: SOQuestion[];
+  has_more?: boolean;
+  quota_max?: number;
+  quota_remaining?: number;
+  error_id?: number;
+  error_message?: string;
+}
+
+export interface StackOverflowMeta {
+  score: number;
+  answers: number;
+  views: number;
+  isAnswered: boolean;
+  hasAccepted: boolean;
+  tags: string[];
+  questionId: number;
+}
+
+function sortFor(mode: StackOverflowMode): string {
+  // Stack Exchange `/questions` accepts sort=activity|votes|creation|hot|week|month.
+  // We map newest → creation; the rest pass through.
+  switch (mode) {
+    case "newest":
+      return "creation";
+    default:
+      return mode;
+  }
+}
+
+function decodeEntities(s: string): string {
+  // Stack Exchange returns titles with HTML entities (e.g. &quot; &#39; &amp;).
+  // The set is small and well-known, so a targeted decoder beats pulling in a
+  // full HTML parser for what is always a plain text title.
+  return s
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&");
+}
+
+function avatarFor(owner: SOOwner | undefined, fallbackId: number): string {
+  // Stack Exchange profile_image URLs sometimes embed Gravatar `?s=128` query
+  // params; honour them as-is. Fall back to a deterministic identicon-style
+  // gravatar when the owner is anonymous (their owner.user_type === "does_not_exist").
+  if (owner?.profile_image) return owner.profile_image;
+  return `https://www.gravatar.com/avatar/${fallbackId}?d=identicon&s=64`;
+}
+
+function mapQuestion(q: SOQuestion): FeedItem<StackOverflowMeta> | null {
+  // Schema-drift safe: a question without an id, a title, or a link can't be
+  // rendered or linked, so drop rather than emit a dead row.
+  if (!q.question_id || !q.title || !q.link) return null;
+
+  const owner = q.owner;
+  const displayName = owner?.display_name
+    ? decodeEntities(owner.display_name)
+    : "anonymous";
+  const createdMs =
+    typeof q.creation_date === "number" ? q.creation_date * 1000 : Date.now();
+
+  return {
+    id: String(q.question_id),
+    author: {
+      name: displayName,
+      handle: displayName,
+      avatarUrl: avatarFor(owner, q.question_id),
+    },
+    content: decodeEntities(q.title),
+    url: q.link,
+    createdAt: new Date(createdMs).toISOString(),
+    meta: {
+      score: q.score ?? 0,
+      answers: q.answer_count ?? 0,
+      views: q.view_count ?? 0,
+      isAnswered: !!q.is_answered,
+      hasAccepted: typeof q.accepted_answer_id === "number",
+      tags: Array.isArray(q.tags) ? q.tags : [],
+      questionId: q.question_id,
+    },
+  };
+}
+
+function normaliseTagFilter(tag: string): string {
+  // Stack Exchange supports up to five tags joined by `;` (semicolon = AND).
+  // Accept commas or spaces from the user, normalise, dedupe, and clamp.
+  const parts = tag
+    .split(/[,;\s]+/)
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean);
+  const seen = new Set<string>();
+  const uniq: string[] = [];
+  for (const p of parts) {
+    if (!seen.has(p)) {
+      seen.add(p);
+      uniq.push(p);
+    }
+    if (uniq.length === 5) break;
+  }
+  return uniq.join(";");
+}
+
+export async function fetchStackOverflowPage(
+  mode: StackOverflowMode,
+  tag: string,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<StackOverflowMeta>[]; hasMore: boolean }> {
+  const params = new URLSearchParams({
+    site: "stackoverflow",
+    order: "desc",
+    sort: sortFor(mode),
+    pagesize: String(Math.min(Math.max(limit, 1), 100)),
+    page: String(Math.max(page, 0) + 1),
+  });
+
+  const tagFilter = normaliseTagFilter(tag);
+  if (tagFilter) params.set("tagged", tagFilter);
+
+  const url = `${BASE}/questions?${params}`;
+  const res = await fetch(url, {
+    headers: {
+      accept: "application/json",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Stack Overflow ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+
+  const json = (await res.json()) as SOResponse;
+  if (json.error_message) {
+    throw new Error(`Stack Overflow API error: ${json.error_message}`);
+  }
+
+  const items = Array.isArray(json.items)
+    ? json.items
+        .map(mapQuestion)
+        .filter((q): q is FeedItem<StackOverflowMeta> => q !== null)
+    : [];
+
+  return { items, hasMore: !!json.has_more };
+}


### PR DESCRIPTION
## What
Adds **Stack Overflow** as the 36th column type in minitor. Keyless Stack Exchange API 2.3 with five sort modes (Hot, Top voted, Newest, Week, Month) plus an optional multi-tag AND-filter (up to five tags, comma- or space-separated).

## Why
The dev/community-feed cluster (HN + Lobsters + Reddit) was missing the largest Q&A surface for technical work. Stack Overflow is where engineers actually search when they hit a wall, and it has a clean keyless JSON API with comfortable rate limits — ideal for a polling dashboard column. Adds the 36th column type and rounds out the news/web cluster (now 6 sources).

## Changes
- \`lib/integrations/stackoverflow.ts\` — fetcher hitting \`api.stackexchange.com/2.3/questions\` with sort + tag params, schema-drift safe mapper (drops items missing question_id/title/link), tag normaliser (commas/spaces → SE's \`;\` AND syntax, deduped, capped at 5), HTML-entity decoder for titles
- \`lib/columns/plugins/stack-overflow/plugin.ts\` — Zod config \`{ mode, tag }\`, \`Layers\` icon, brand orange \`#F48024\`, paginated, anonymous SE quota hint
- \`lib/columns/plugins/stack-overflow/server.ts\` — page-cursor fetcher (page 0-indexed locally, mapped to SE's 1-indexed page param)
- \`lib/columns/plugins/stack-overflow/client.tsx\` — config form (mode dropdown + tag input with link to /tags) and item renderer (badge pill + author + relative time + accepted badge + serif title + tag pills + score/answers/views footer)
- \`lib/columns/plugins/manifest.ts\`, \`registry.ts\`, \`server-registry.ts\` — three registry edits; parity check covered
- \`README.md\` — column count 35 → 36, news & web cluster row 5 → 6, hero paragraph and keyless-columns line both pick up Stack Overflow

## Test plan
- [ ] \`./minitor\` boots without registry parity errors
- [ ] Add a "stack-overflow" column with default mode (Hot) — items render
- [ ] Switch mode to Top voted, Newest, Week, Month — each populates with the expected ordering
- [ ] Add a tag filter ("rust", or "react,typescript") — only matching questions appear
- [ ] Click "Load more" — pagination cursor advances
- [ ] Question with an accepted answer shows the "accepted" badge

---
*Built autonomously by Aeon*