### PR TITLE
feat(plugins): add huggingface column type — trending models, datasets, spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, Hugging Face (models / datasets / spaces), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 36 column types out of the box — social feeds, news, GitHub, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
+- 37 column types out of the box — social feeds, news, GitHub, Hugging Face, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -41,7 +41,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, Hugging Face, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -61,6 +61,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
 | **GitHub** (8) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks` |
 | **News & web** (6) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow` |
+| **AI / ML** (1) | `huggingface` (trending models, datasets, spaces) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |
 | **Apps & on-chain** (4) | `apple-reviews`, `play-reviews`, `wallet-tx`, `polymarket` |

--- a/lib/columns/plugins/huggingface/client.tsx
+++ b/lib/columns/plugins/huggingface/client.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { Download, Flame, Heart, Lock } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import {
+  meta,
+  type HuggingfaceConfig,
+  type HuggingfaceMeta,
+} from "./plugin";
+
+function ConfigForm({
+  value,
+  onChange,
+}: ConfigFormProps<HuggingfaceConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Resource</Label>
+        <Select
+          value={value.resource}
+          onValueChange={(v) =>
+            onChange({
+              ...value,
+              resource: v as HuggingfaceConfig["resource"],
+            })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="models">Models</SelectItem>
+            <SelectItem value="datasets">Datasets</SelectItem>
+            <SelectItem value="spaces">Spaces</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Sort</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as HuggingfaceConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="trending">Trending</SelectItem>
+            <SelectItem value="most-likes">Most liked</SelectItem>
+            <SelectItem value="newest">Newest</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="hf-search">Search (optional)</Label>
+        <Input
+          id="hf-search"
+          placeholder="bert, llama, agents…"
+          value={value.search}
+          onChange={(e) => onChange({ ...value, search: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Substring match against the repo id. Leave empty to browse the full
+          ranked list. See{" "}
+          <a
+            href="https://huggingface.co/docs/hub/api"
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            huggingface.co/docs/hub/api
+          </a>{" "}
+          for the underlying endpoint.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function descriptorFor(m: HuggingfaceMeta | undefined): string {
+  // The "what kind of thing is this" line under the title — pipeline tag for
+  // models, library for datasets, SDK for spaces. Falls back to the resource
+  // name so the slot is never empty.
+  if (!m) return "";
+  if (m.resource === "models") {
+    return m.pipelineTag ?? m.libraryName ?? "model";
+  }
+  if (m.resource === "spaces") {
+    return m.sdk ? `${m.sdk} space` : "space";
+  }
+  return "dataset";
+}
+
+function ItemRenderer({ item }: ItemRendererProps<HuggingfaceMeta>) {
+  const m = item.meta;
+  const likes = m?.likes ?? 0;
+  const downloads = m?.downloads;
+  const tags = (m?.tags ?? []).filter(
+    (t) => !t.startsWith("region:") && !t.startsWith("license:"),
+  );
+  const descriptor = descriptorFor(m);
+  const gated = !!m?.gated;
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(255, 210, 31, 0.22)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[10px] leading-none"
+            style={{ backgroundColor: "#FFD21F" }}
+            aria-hidden
+          >
+            🤗
+          </span>
+          Hugging Face
+        </span>
+        {descriptor && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="text-muted-foreground/90">{descriptor}</span>
+          </>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+        {gated && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span
+              className="inline-flex items-center gap-0.5 text-[11px] text-muted-foreground"
+              title="Gated repo — requires accepting terms before download"
+            >
+              <Lock className="size-3" />
+              gated
+            </span>
+          </>
+        )}
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+        >
+          {item.content}
+        </h3>
+      </a>
+      {tags.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {tags.slice(0, 5).map((t) => (
+            <span
+              key={t}
+              className="rounded-sm px-1 py-0.5 text-[10px] text-muted-foreground ring-1 ring-border/60"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="flex items-center gap-1" title="Likes">
+          <Heart className="size-3.5" />
+          <span className="tabular-nums">{formatCompactCount(likes)}</span>
+        </span>
+        {typeof downloads === "number" && (
+          <span className="flex items-center gap-1" title="Downloads (last 30 days)">
+            <Download className="size-3.5" />
+            <span className="tabular-nums">
+              {formatCompactCount(downloads)}
+            </span>
+          </span>
+        )}
+        {typeof m?.trendingScore === "number" && m.trendingScore > 0 && (
+          <span
+            className="flex items-center gap-1"
+            title="Hugging Face trending score"
+          >
+            <Flame className="size-3.5" />
+            <span className="tabular-nums">
+              {formatCompactCount(Math.round(m.trendingScore))}
+            </span>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<HuggingfaceConfig, HuggingfaceMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/huggingface/plugin.ts
+++ b/lib/columns/plugins/huggingface/plugin.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import { Sparkles } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  resource: z.enum(["models", "datasets", "spaces"]).default("models"),
+  mode: z.enum(["trending", "most-likes", "newest"]).default("trending"),
+  search: z.string().default(""),
+});
+
+export type HuggingfaceConfig = z.infer<typeof schema>;
+
+export interface HuggingfaceMeta {
+  resource: HuggingfaceConfig["resource"];
+  likes: number;
+  downloads?: number;
+  trendingScore?: number;
+  pipelineTag?: string;
+  libraryName?: string;
+  sdk?: string;
+  tags: string[];
+  gated: boolean;
+}
+
+const RESOURCE_LABELS: Record<HuggingfaceConfig["resource"], string> = {
+  models: "Models",
+  datasets: "Datasets",
+  spaces: "Spaces",
+};
+
+const MODE_LABELS: Record<HuggingfaceConfig["mode"], string> = {
+  trending: "Trending",
+  "most-likes": "Most liked",
+  newest: "Newest",
+};
+
+export const meta: PluginMeta<HuggingfaceConfig, HuggingfaceMeta> = {
+  id: "huggingface",
+  label: "Hugging Face",
+  description:
+    "Trending, most-liked, or newest models, datasets, or spaces — optionally filtered by search.",
+  icon: Sparkles,
+  // HF brand yellow — the colour of the emoji in the wordmark and the
+  // call-to-action buttons across huggingface.co. Distinct from the existing
+  // palette so an HF column reads at a glance in a packed deck.
+  accent: "#FFD21F",
+  category: "ai",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const search = c.search.trim();
+    if (search) return `HF · ${RESOURCE_LABELS[c.resource]} · ${search}`;
+    return `HF · ${MODE_LABELS[c.mode]} ${RESOURCE_LABELS[c.resource].toLowerCase()}`;
+  },
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/huggingface/server.ts
+++ b/lib/columns/plugins/huggingface/server.ts
@@ -1,0 +1,36 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchHuggingfacePage } from "@/lib/integrations/huggingface";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import {
+  meta,
+  type HuggingfaceConfig,
+  type HuggingfaceMeta,
+} from "./plugin";
+
+const fetch: ServerFetcher<HuggingfaceConfig, HuggingfaceMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await fetchHuggingfacePage(
+    config.resource,
+    config.mode,
+    config.search,
+    PAGE_SIZE,
+    page,
+  );
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<HuggingfaceConfig, HuggingfaceMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -40,6 +40,7 @@ import { meta as bluesky } from "./bluesky/plugin";
 import { meta as lobsters } from "./lobsters/plugin";
 import { meta as polymarket } from "./polymarket/plugin";
 import { meta as stackOverflow } from "./stack-overflow/plugin";
+import { meta as huggingface } from "./huggingface/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -78,6 +79,7 @@ export const PLUGIN_METAS = [
   lobsters,
   polymarket,
   stackOverflow,
+  huggingface,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -48,6 +48,7 @@ import { column as bluesky } from "@/lib/columns/plugins/bluesky/client";
 import { column as lobsters } from "@/lib/columns/plugins/lobsters/client";
 import { column as polymarket } from "@/lib/columns/plugins/polymarket/client";
 import { column as stackOverflow } from "@/lib/columns/plugins/stack-overflow/client";
+import { column as huggingface } from "@/lib/columns/plugins/huggingface/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -89,6 +90,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   lobsters,
   polymarket,
   "stack-overflow": stackOverflow,
+  huggingface,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -44,6 +44,7 @@ import { server as bluesky } from "@/lib/columns/plugins/bluesky/server";
 import { server as lobsters } from "@/lib/columns/plugins/lobsters/server";
 import { server as polymarket } from "@/lib/columns/plugins/polymarket/server";
 import { server as stackOverflow } from "@/lib/columns/plugins/stack-overflow/server";
+import { server as huggingface } from "@/lib/columns/plugins/huggingface/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -82,6 +83,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   lobsters,
   polymarket,
   "stack-overflow": stackOverflow,
+  huggingface,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/huggingface.ts
+++ b/lib/integrations/huggingface.ts
@@ -1,0 +1,202 @@
+import type { FeedItem } from "@/lib/columns/types";
+import { identiconUrl } from "@/lib/utils";
+
+// Hugging Face Hub REST API — public, no auth, generous rate limits for
+// anonymous list endpoints. https://huggingface.co/docs/hub/api
+//
+// We hit /api/{models,datasets,spaces} with a sort key (trendingScore, likes,
+// or createdAt) and an optional `search` substring filter. Each list response
+// is a JSON array of repo objects whose shape varies by resource type — only
+// `id`, `_id`, `tags`, `likes`, and `createdAt` are guaranteed across all
+// three. The mapper handles the type-specific extras (downloads, pipeline_tag,
+// sdk, etc.) and falls back gracefully when a field is missing.
+const BASE = "https://huggingface.co";
+const FETCH_BATCH = 50; // upstream cap is 1000, but 50 is plenty for slice-pagination.
+
+export type HuggingfaceResource = "models" | "datasets" | "spaces";
+export type HuggingfaceMode = "trending" | "most-likes" | "newest";
+
+export interface HuggingfaceMeta {
+  resource: HuggingfaceResource;
+  likes: number;
+  downloads?: number;
+  trendingScore?: number;
+  pipelineTag?: string;
+  libraryName?: string;
+  sdk?: string;
+  tags: string[];
+  gated: boolean;
+}
+
+interface HFRepo {
+  _id?: string;
+  id?: string;
+  modelId?: string;
+  author?: string;
+  likes?: number;
+  downloads?: number;
+  trendingScore?: number;
+  private?: boolean;
+  gated?: boolean | string;
+  tags?: string[];
+  pipeline_tag?: string;
+  library_name?: string;
+  sdk?: string;
+  description?: string;
+  createdAt?: string;
+  lastModified?: string;
+}
+
+interface HFErrorResponse {
+  error?: string;
+}
+
+function sortFor(mode: HuggingfaceMode): string {
+  switch (mode) {
+    case "most-likes":
+      return "likes";
+    case "newest":
+      return "createdAt";
+    case "trending":
+    default:
+      return "trendingScore";
+  }
+}
+
+function permalinkFor(resource: HuggingfaceResource, id: string): string {
+  // Models live at huggingface.co/{id}; datasets and spaces have a path
+  // prefix. The id is always "owner/name" (or just "name" for legacy single-
+  // segment ids), and HF normalises the URL form on its side.
+  const slug = id.replace(/^\/+/, "");
+  switch (resource) {
+    case "datasets":
+      return `${BASE}/datasets/${slug}`;
+    case "spaces":
+      return `${BASE}/spaces/${slug}`;
+    case "models":
+    default:
+      return `${BASE}/${slug}`;
+  }
+}
+
+function deriveAuthor(repo: HFRepo): { author: string; name: string } {
+  // HF list responses for models omit `author` but pack it into `id` as
+  // "owner/name". Datasets include `author` explicitly. Spaces omit it. Treat
+  // `id` as the source of truth and use `author` only as a confirming hint.
+  const id = repo.id ?? repo.modelId ?? "";
+  const slash = id.indexOf("/");
+  if (slash > 0) {
+    return { author: id.slice(0, slash), name: id.slice(slash + 1) };
+  }
+  // Legacy single-segment ids (rare, mostly old community models): the id is
+  // the model name and the org is the implicit "huggingface" namespace.
+  return { author: repo.author ?? "huggingface", name: id || "(unknown)" };
+}
+
+function isGated(value: HFRepo["gated"]): boolean {
+  // HF reports gating as either a boolean or a string ("auto", "manual").
+  // Anything truthy means the repo requires acceptance before download.
+  if (typeof value === "string") return value !== "" && value !== "false";
+  return !!value;
+}
+
+function mapRepo(
+  repo: HFRepo,
+  resource: HuggingfaceResource,
+): FeedItem<HuggingfaceMeta> | null {
+  const id = repo.id ?? repo.modelId;
+  if (!id) return null;
+
+  const { author, name } = deriveAuthor(repo);
+  const createdMs = repo.createdAt
+    ? Date.parse(repo.createdAt)
+    : repo.lastModified
+      ? Date.parse(repo.lastModified)
+      : Date.now();
+
+  return {
+    id,
+    author: {
+      name: author,
+      handle: author,
+      avatarUrl: identiconUrl(author),
+    },
+    // The "title" line of the card is "owner / name" so users can identify
+    // the repo at a glance. Description, when present, lives one block down.
+    content:
+      author === "huggingface" || !author ? name : `${author} / ${name}`,
+    url: permalinkFor(resource, id),
+    createdAt: new Date(
+      Number.isFinite(createdMs) ? createdMs : Date.now(),
+    ).toISOString(),
+    meta: {
+      resource,
+      likes: typeof repo.likes === "number" ? repo.likes : 0,
+      downloads:
+        typeof repo.downloads === "number" ? repo.downloads : undefined,
+      trendingScore:
+        typeof repo.trendingScore === "number"
+          ? repo.trendingScore
+          : undefined,
+      pipelineTag: repo.pipeline_tag,
+      libraryName: repo.library_name,
+      sdk: repo.sdk,
+      tags: Array.isArray(repo.tags) ? repo.tags : [],
+      gated: isGated(repo.gated),
+    },
+  };
+}
+
+export async function fetchHuggingfacePage(
+  resource: HuggingfaceResource,
+  mode: HuggingfaceMode,
+  search: string,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<HuggingfaceMeta>[]; hasMore: boolean }> {
+  const params = new URLSearchParams({
+    sort: sortFor(mode),
+    direction: "-1",
+    limit: String(FETCH_BATCH),
+  });
+
+  const trimmed = search.trim();
+  if (trimmed) params.set("search", trimmed);
+
+  const url = `${BASE}/api/${resource}?${params}`;
+  const res = await fetch(url, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const err = (await res.json()) as HFErrorResponse;
+      detail = err.error ?? "";
+    } catch {
+      detail = (await res.text()).slice(0, 200);
+    }
+    throw new Error(`Hugging Face ${res.status}: ${detail}`);
+  }
+
+  const json = (await res.json()) as HFRepo[];
+  if (!Array.isArray(json)) return { items: [], hasMore: false };
+
+  const mapped = json
+    .map((r) => mapRepo(r, resource))
+    .filter((r): r is FeedItem<HuggingfaceMeta> => r !== null);
+
+  // Slice-based pagination — the integration fetches a generous batch up
+  // front, then hands out `limit` items per call. The trade-off (refetch on
+  // every Load-more) keeps the contract stateless, matching the lobsters /
+  // stack-overflow pattern. Cursor-based pagination via the upstream Link
+  // header is available but not worth the complexity for this volume.
+  const start = Math.max(page, 0) * limit;
+  const slice = mapped.slice(start, start + limit);
+  const hasMore = mapped.length > start + limit;
+  return { items: slice, hasMore };
+}


### PR DESCRIPTION
## What

Adds **Hugging Face** as the 37th column type. Three resource modes (`models` / `datasets` / `spaces`) × three sort modes (`trending` / `most-likes` / `newest`) with an optional substring `search` filter — covering the obvious "what's hot on HF right now" use cases while staying within the existing 3-control plugin pattern.

The plugin is fully **keyless** — the public `huggingface.co/api/{models,datasets,spaces}` list endpoints don't require auth for the read paths used here. `sort=trendingScore` returns the same ranking that drives the HF front-page, so a `trending models` column reads as the AI-ecosystem equivalent of the existing GitHub Trending and HN Hot columns.

## Why

minitor already covers the keyless community / news / GitHub / on-chain surfaces but has no AI-ecosystem source. The Hub is where:
- new models land first (DeepSeek-R1, Llama, Qwen, Gemma releases all show up on the trending models list before mainstream coverage),
- datasets get attention before papers cite them,
- a Space release is often the first runnable form of a new technique.

For the dev / AI / agent audience that already runs minitor, an HF column is the missing equivalent of GitHub Trending — surfacing momentum at the *artifact* level rather than the *repo* level.

This is also the first plugin to use the existing `ai` `ColumnCategory`, which has been declared in `lib/columns/types.ts` since the plugin system shipped but had no consumer.

## Changes

- `lib/integrations/huggingface.ts` (new) — typed fetcher for `/api/{models,datasets,spaces}`. Schema-drift safe: HF list responses for models omit `author` (packed into `id` as `owner/name`) and `lastModified`, while datasets include both and spaces omit `downloads`. The mapper falls back gracefully and still produces a complete card. Per-resource permalink builder (`/{id}`, `/datasets/{id}`, `/spaces/{id}`). Slice-based pagination matching the documented `paginate.ts` trade-off — the integration fetches a 50-item batch per call and serves `PAGE_SIZE` slices.
- `lib/columns/plugins/huggingface/plugin.ts` (new) — Zod schema (`resource`, `mode`, `search`), `Sparkles` icon, brand yellow `#FFD21F`, `category: "ai"`. `defaultTitle` reflects whichever facet the operator pinned (search > resource+mode).
- `lib/columns/plugins/huggingface/server.ts` (new) — standard `defineColumnServer` wiring with the integration call, cursor → page mapping.
- `lib/columns/plugins/huggingface/client.tsx` (new) — `ConfigForm` (Resource select / Sort select / Search input) and `ItemRenderer` (HF-yellow brand chip with the 🤗 mark, type descriptor — pipeline tag for models, library/sdk for datasets/spaces — title link, tags row, footer with likes / downloads / trending score). Drops `region:` and `license:` tags from the visible row to keep the card readable.
- `lib/columns/plugins/manifest.ts`, `registry.ts`, `server-registry.ts` — three registry edits, parity check covered.
- `README.md` — column count 36 → 37, new "AI / ML" cluster row, hero paragraph and keyless-columns line both pick up Hugging Face.

## How it works

The integration hits `https://huggingface.co/api/{resource}?sort={mapped}&direction=-1&limit=50` (with optional `search=`). `mode: trending` maps to `sort=trendingScore` (the property that backs HF's front-page ranking), `mode: most-likes` to `sort=likes`, `mode: newest` to `sort=createdAt`. The list response is mapped to the standard `FeedItem` shape with a `HuggingfaceMeta` payload carrying type-specific extras (`pipelineTag` for models, `sdk` for spaces, `downloads` where present, `trendingScore` when sorted by it). The renderer reads `meta.resource` to pick the right descriptor and footer columns.

Pagination is offset / slice-based: every Load-more re-fetches the same 50-item batch and slices to the requested page. This matches the lobsters and stack-overflow contract and keeps the column server stateless.

---
*Built autonomously by Aeon*