### PR TITLE
feat: arxiv column — 38th plugin, AI/ML cluster paper layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, Hugging Face (models / datasets / spaces), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 37 column types out of the box — social feeds, news, GitHub, Hugging Face, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
+- 38 column types out of the box — social feeds, news, GitHub, Hugging Face, arXiv, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -41,7 +41,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, Hugging Face, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -61,7 +61,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
 | **GitHub** (8) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks` |
 | **News & web** (6) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow` |
-| **AI / ML** (1) | `huggingface` (trending models, datasets, spaces) |
+| **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |
 | **Apps & on-chain** (4) | `apple-reviews`, `play-reviews`, `wallet-tx`, `polymarket` |

--- a/lib/columns/plugins/arxiv/client.tsx
+++ b/lib/columns/plugins/arxiv/client.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { FileText, GitMerge, Users } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import {
+  meta,
+  type ArxivConfig,
+  type ArxivMeta,
+  ARXIV_CATEGORIES,
+  ARXIV_CATEGORY_LABELS,
+} from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<ArxivConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Category</Label>
+        <Select
+          value={value.category}
+          onValueChange={(v) =>
+            onChange({ ...value, category: v as ArxivConfig["category"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ARXIV_CATEGORIES.map((c) => (
+              <SelectItem key={c} value={c}>
+                {c} — {ARXIV_CATEGORY_LABELS[c]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Sort</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as ArxivConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="recent">Newest submissions</SelectItem>
+            <SelectItem value="updated">Recently updated</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="arxiv-search">Search (optional)</Label>
+        <Input
+          id="arxiv-search"
+          placeholder="agents, llm, retrieval…"
+          value={value.search}
+          onChange={(e) => onChange({ ...value, search: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Title + abstract keyword filter, ANDed with the category. Multiple
+          words are joined as AND. See{" "}
+          <a
+            href="https://info.arxiv.org/help/api/user-manual.html"
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            arxiv.org/help/api
+          </a>{" "}
+          for the underlying query syntax.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1).trimEnd()}…`;
+}
+
+function ItemRenderer({ item }: ItemRendererProps<ArxivMeta>) {
+  const m = item.meta;
+  const primary = m?.primaryCategory ?? "";
+  const otherCats = (m?.categories ?? []).filter((c) => c !== primary);
+  const authors = m?.authors ?? [];
+  const abstract = m?.abstract ?? "";
+  const arxivId = m?.arxivId ?? "";
+  const pdfUrl = m?.pdfUrl;
+  const isRevision = !!m?.isRevision;
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-white"
+          style={{ backgroundColor: "#B31B1B" }}
+        >
+          arXiv
+        </span>
+        {primary && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="font-mono text-[10.5px] text-muted-foreground/90">
+              {primary}
+            </span>
+          </>
+        )}
+        {arxivId && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="font-mono text-[10.5px] text-muted-foreground/70">
+              {arxivId}
+            </span>
+          </>
+        )}
+        {isRevision && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span
+              className="inline-flex items-center gap-0.5 text-[11px] text-muted-foreground"
+              title="This entry is a revised version (v2 or later)"
+            >
+              <GitMerge className="size-3" />
+              revision
+            </span>
+          </>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+        >
+          {item.content}
+        </h3>
+      </a>
+      {authors.length > 0 && (
+        <div className="mt-1 flex items-center gap-1 text-[11.5px] text-muted-foreground">
+          <Users className="size-3" />
+          <span className="truncate">
+            {authors.length <= 3
+              ? authors.join(", ")
+              : `${authors.slice(0, 3).join(", ")} + ${authors.length - 3} more`}
+          </span>
+        </div>
+      )}
+      {abstract && (
+        <p className="mt-1.5 text-[12.5px] leading-snug text-muted-foreground/90">
+          {truncate(abstract, 280)}
+        </p>
+      )}
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+        {otherCats.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {otherCats.slice(0, 4).map((c) => (
+              <span
+                key={c}
+                className="rounded-sm px-1 py-0.5 font-mono text-[10px] text-muted-foreground ring-1 ring-border/60"
+              >
+                {c}
+              </span>
+            ))}
+          </div>
+        )}
+        {pdfUrl && (
+          <a
+            href={pdfUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-[11px] text-muted-foreground/90 underline-offset-2 hover:text-foreground hover:underline"
+          >
+            <FileText className="size-3" />
+            PDF
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<ArxivConfig, ArxivMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/arxiv/plugin.ts
+++ b/lib/columns/plugins/arxiv/plugin.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import { BookOpen } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+const CATEGORIES = [
+  "cs.AI",
+  "cs.CL",
+  "cs.LG",
+  "cs.CV",
+  "cs.RO",
+  "cs.CR",
+  "cs.DC",
+  "cs.NE",
+  "cs.SE",
+  "cs.PL",
+  "stat.ML",
+  "math.OC",
+] as const;
+
+export const schema = z.object({
+  category: z.enum(CATEGORIES).default("cs.AI"),
+  mode: z.enum(["recent", "updated"]).default("recent"),
+  search: z.string().default(""),
+});
+
+export type ArxivConfig = z.infer<typeof schema>;
+
+export interface ArxivMeta {
+  primaryCategory: string;
+  categories: string[];
+  authors: string[];
+  abstract: string;
+  pdfUrl?: string;
+  arxivId: string;
+  publishedAt: string;
+  updatedAt: string;
+  isRevision: boolean;
+}
+
+const CATEGORY_LABELS: Record<(typeof CATEGORIES)[number], string> = {
+  "cs.AI": "Artificial Intelligence",
+  "cs.CL": "Computation & Language",
+  "cs.LG": "Machine Learning",
+  "cs.CV": "Computer Vision",
+  "cs.RO": "Robotics",
+  "cs.CR": "Cryptography & Security",
+  "cs.DC": "Distributed Computing",
+  "cs.NE": "Neural & Evolutionary",
+  "cs.SE": "Software Engineering",
+  "cs.PL": "Programming Languages",
+  "stat.ML": "Statistical ML",
+  "math.OC": "Optimization & Control",
+};
+
+const MODE_LABELS: Record<ArxivConfig["mode"], string> = {
+  recent: "Newest submissions",
+  updated: "Recently updated",
+};
+
+export const meta: PluginMeta<ArxivConfig, ArxivMeta> = {
+  id: "arxiv",
+  label: "arXiv",
+  description:
+    "Newest or recently-updated papers from a CS / stat / math.OC category — optionally filtered by a title/abstract keyword.",
+  icon: BookOpen,
+  // Cornell red — the brand colour arXiv has used since the move from LANL
+  // to Cornell. Distinct from the existing palette so an arXiv column reads
+  // at a glance in a packed deck (huggingface yellow #FFD21F is the closest
+  // adjacent AI/ML accent and is far enough away on the wheel).
+  accent: "#B31B1B",
+  category: "ai",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const search = c.search.trim();
+    if (search) return `arXiv · ${c.category} · ${search}`;
+    return `arXiv · ${c.category} · ${MODE_LABELS[c.mode]}`;
+  },
+  capabilities: { paginated: true },
+};
+
+export const ARXIV_CATEGORIES = CATEGORIES;
+export const ARXIV_CATEGORY_LABELS = CATEGORY_LABELS;

--- a/lib/columns/plugins/arxiv/server.ts
+++ b/lib/columns/plugins/arxiv/server.ts
@@ -1,0 +1,29 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchArxivPage } from "@/lib/integrations/arxiv";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type ArxivConfig, type ArxivMeta } from "./plugin";
+
+const fetch: ServerFetcher<ArxivConfig, ArxivMeta> = async (config, cursor) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await fetchArxivPage(
+    config.category,
+    config.mode,
+    config.search,
+    PAGE_SIZE,
+    page,
+  );
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<ArxivConfig, ArxivMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -41,6 +41,7 @@ import { meta as lobsters } from "./lobsters/plugin";
 import { meta as polymarket } from "./polymarket/plugin";
 import { meta as stackOverflow } from "./stack-overflow/plugin";
 import { meta as huggingface } from "./huggingface/plugin";
+import { meta as arxiv } from "./arxiv/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -80,6 +81,7 @@ export const PLUGIN_METAS = [
   polymarket,
   stackOverflow,
   huggingface,
+  arxiv,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -49,6 +49,7 @@ import { column as lobsters } from "@/lib/columns/plugins/lobsters/client";
 import { column as polymarket } from "@/lib/columns/plugins/polymarket/client";
 import { column as stackOverflow } from "@/lib/columns/plugins/stack-overflow/client";
 import { column as huggingface } from "@/lib/columns/plugins/huggingface/client";
+import { column as arxiv } from "@/lib/columns/plugins/arxiv/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -91,6 +92,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   polymarket,
   "stack-overflow": stackOverflow,
   huggingface,
+  arxiv,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -45,6 +45,7 @@ import { server as lobsters } from "@/lib/columns/plugins/lobsters/server";
 import { server as polymarket } from "@/lib/columns/plugins/polymarket/server";
 import { server as stackOverflow } from "@/lib/columns/plugins/stack-overflow/server";
 import { server as huggingface } from "@/lib/columns/plugins/huggingface/server";
+import { server as arxiv } from "@/lib/columns/plugins/arxiv/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -84,6 +85,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   polymarket,
   "stack-overflow": stackOverflow,
   huggingface,
+  arxiv,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/arxiv.ts
+++ b/lib/integrations/arxiv.ts
@@ -1,0 +1,308 @@
+import type { FeedItem } from "@/lib/columns/types";
+import { identiconUrl } from "@/lib/utils";
+
+// arXiv Atom-XML query API — public, no auth, no rate-limit headers documented
+// beyond the polite-crawler advice (≥3 sec between requests, recognisable UA).
+// https://info.arxiv.org/help/api/user-manual.html
+//
+// We hit /api/query with a `search_query` (e.g. cat:cs.AI, optionally ANDed
+// with ti:KEYWORD or abs:KEYWORD), `sortBy` + `sortOrder`, and start/limit
+// pagination. The response is Atom 1.0 — `<entry>` rows with `title`,
+// `summary` (abstract), `author/name` repeated, `category@term` repeated,
+// `link rel="alternate"` (the abs/ permalink), `published`, `updated`, and
+// the unique `id` (also a URL).
+const BASE = "https://export.arxiv.org";
+
+export type ArxivCategory =
+  | "cs.AI"
+  | "cs.CL"
+  | "cs.LG"
+  | "cs.CV"
+  | "cs.RO"
+  | "cs.CR"
+  | "cs.DC"
+  | "cs.NE"
+  | "cs.SE"
+  | "cs.PL"
+  | "stat.ML"
+  | "math.OC";
+
+export type ArxivMode = "recent" | "updated";
+
+export interface ArxivMeta {
+  // Primary category as reported by arXiv (often more specific than the
+  // user's filter — a cs.AI paper might primary-cat as cs.LG when it's more
+  // ML than agentic, useful signal for the renderer).
+  primaryCategory: string;
+  categories: string[];
+  authors: string[];
+  abstract: string;
+  pdfUrl?: string;
+  arxivId: string;
+  publishedAt: string;
+  updatedAt: string;
+  // Distinguishes a freshly published paper from a v2/v3 revision — useful
+  // for picking out genuinely new work in `updated` mode.
+  isRevision: boolean;
+}
+
+const NAMED_ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&apos;": "'",
+  "&nbsp;": " ",
+};
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&(?:amp|lt|gt|quot|apos|nbsp);/g, (m) => NAMED_ENTITIES[m] ?? m)
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)));
+}
+
+function getTag(xml: string, tag: string): string {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`<${escaped}\\b[^>]*>([\\s\\S]*?)</${escaped}>`, "i");
+  return xml.match(re)?.[1] ?? "";
+}
+
+function getAllTags(xml: string, tag: string): string[] {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`<${escaped}\\b[^>]*>([\\s\\S]*?)</${escaped}>`, "gi");
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(xml))) out.push(m[1]);
+  return out;
+}
+
+function clean(s: string): string {
+  return decodeEntities(s)
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildSearchQuery(category: ArxivCategory, search: string): string {
+  // search is an optional title/abstract keyword filter ANDed onto the
+  // category. Empty → just the category. Multiple words are joined with
+  // explicit AND so arXiv treats them as conjunction, not disjunction.
+  const trimmed = search.trim();
+  if (!trimmed) return `cat:${category}`;
+  const words = trimmed
+    .split(/\s+/)
+    .map((w) => w.trim())
+    .filter(Boolean)
+    .map((w) => `(ti:${w}+OR+abs:${w})`);
+  if (words.length === 0) return `cat:${category}`;
+  return `cat:${category}+AND+${words.join("+AND+")}`;
+}
+
+function sortFor(mode: ArxivMode): {
+  sortBy: "submittedDate" | "lastUpdatedDate";
+  sortOrder: "descending";
+} {
+  return {
+    sortBy: mode === "updated" ? "lastUpdatedDate" : "submittedDate",
+    sortOrder: "descending",
+  };
+}
+
+function extractArxivId(idUrl: string): string {
+  // arXiv `<id>` URLs look like https://arxiv.org/abs/2501.12345v2 — extract
+  // the bare id (with version) so the renderer can show the canonical form.
+  const m = idUrl.match(/abs\/([^?#\s]+)/i);
+  if (m) return m[1].trim();
+  // Fallback: anything resembling an id (digits.digits with optional vN).
+  const fallback = idUrl.match(/\d{4}\.\d{4,5}(v\d+)?/);
+  return fallback ? fallback[0] : idUrl;
+}
+
+function extractPdfUrl(entry: string): string | undefined {
+  const linkRe = /<link\b([^>]*?)\/?>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = linkRe.exec(entry))) {
+    const attrs = m[1];
+    const title = attrs.match(/\btitle=["']pdf["']/i);
+    const href = attrs.match(/\bhref=["']([^"']+)["']/)?.[1];
+    if (title && href) return href;
+  }
+  return undefined;
+}
+
+function extractAlternateUrl(entry: string, fallback: string): string {
+  const linkRe = /<link\b([^>]*?)\/?>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = linkRe.exec(entry))) {
+    const attrs = m[1];
+    const rel = attrs.match(/\brel=["']([^"']+)["']/)?.[1] ?? "alternate";
+    const href = attrs.match(/\bhref=["']([^"']+)["']/)?.[1];
+    if (href && rel === "alternate") return href;
+  }
+  return fallback;
+}
+
+function extractCategories(entry: string): {
+  primary: string;
+  all: string[];
+} {
+  // <category term="cs.LG" .../> repeated, plus <arxiv:primary_category .../>
+  // as the canonical primary. Some entries omit the namespaced primary; in
+  // that case the first <category> is the primary by arXiv convention.
+  const all: string[] = [];
+  const re = /<category\b([^>]*?)\/?>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(entry))) {
+    const term = m[1].match(/\bterm=["']([^"']+)["']/)?.[1];
+    if (term) all.push(term);
+  }
+  const primaryMatch = entry.match(
+    /<arxiv:primary_category\b[^>]*\bterm=["']([^"']+)["']/i,
+  );
+  const primary = primaryMatch ? primaryMatch[1] : (all[0] ?? "");
+  return { primary, all };
+}
+
+function extractAuthors(entry: string): string[] {
+  const authorBlocks = getAllTags(entry, "author");
+  const out: string[] = [];
+  for (const block of authorBlocks) {
+    const name = clean(getTag(block, "name"));
+    if (name) out.push(name);
+  }
+  return out;
+}
+
+function mapEntry(entry: string): FeedItem<ArxivMeta> | null {
+  const idUrl = clean(getTag(entry, "id"));
+  const title = clean(getTag(entry, "title"));
+  // Schema-drift safe — without an id and a title there's nothing to render
+  // or link to. arXiv has occasionally returned malformed entries during
+  // upstream maintenance windows, so drop rather than emit a dead row.
+  if (!idUrl || !title) return null;
+
+  const arxivId = extractArxivId(idUrl);
+  const link = extractAlternateUrl(entry, idUrl);
+  const pdfUrl = extractPdfUrl(entry);
+  const abstract = clean(getTag(entry, "summary"));
+  const authors = extractAuthors(entry);
+  const { primary, all } = extractCategories(entry);
+
+  const publishedRaw = getTag(entry, "published").trim();
+  const updatedRaw = getTag(entry, "updated").trim();
+  const publishedMs = publishedRaw ? Date.parse(publishedRaw) : NaN;
+  const updatedMs = updatedRaw ? Date.parse(updatedRaw) : NaN;
+  const createdMs = Number.isFinite(updatedMs)
+    ? updatedMs
+    : Number.isFinite(publishedMs)
+      ? publishedMs
+      : Date.now();
+
+  // A revision is detectable two ways: a `vN` suffix where N>1 on the id, or
+  // an `updated` strictly later than `published`. Either is sufficient.
+  const versionMatch = arxivId.match(/v(\d+)$/);
+  const version = versionMatch ? Number(versionMatch[1]) : 1;
+  const isRevision =
+    version > 1 ||
+    (Number.isFinite(publishedMs) &&
+      Number.isFinite(updatedMs) &&
+      updatedMs - publishedMs > 60_000);
+
+  // The author byline for the card uses the first author + "et al." when
+  // there are more — matches the convention every arXiv paper uses on its
+  // own abs page. Identicon falls back to that name.
+  const headlineAuthor =
+    authors.length === 0
+      ? "arXiv"
+      : authors.length === 1
+        ? authors[0]
+        : `${authors[0]} et al.`;
+
+  return {
+    id: arxivId,
+    author: {
+      name: headlineAuthor,
+      handle: arxivId,
+      avatarUrl: identiconUrl(headlineAuthor),
+    },
+    content: title,
+    url: link,
+    createdAt: new Date(createdMs).toISOString(),
+    meta: {
+      primaryCategory: primary,
+      categories: all,
+      authors,
+      abstract,
+      pdfUrl,
+      arxivId,
+      publishedAt: Number.isFinite(publishedMs)
+        ? new Date(publishedMs).toISOString()
+        : new Date(createdMs).toISOString(),
+      updatedAt: Number.isFinite(updatedMs)
+        ? new Date(updatedMs).toISOString()
+        : new Date(createdMs).toISOString(),
+      isRevision,
+    },
+  };
+}
+
+export async function fetchArxivPage(
+  category: ArxivCategory,
+  mode: ArxivMode,
+  search: string,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<ArxivMeta>[]; hasMore: boolean }> {
+  const start = Math.max(page, 0) * limit;
+  const { sortBy, sortOrder } = sortFor(mode);
+
+  // arXiv requires `search_query` URL-encoded but with `+` left literal as
+  // the query separator — URLSearchParams escapes `+` to `%2B` which arXiv
+  // then rejects. So build the query string manually for `search_query`.
+  const query = buildSearchQuery(category, search);
+  const url =
+    `${BASE}/api/query?` +
+    `search_query=${query}` +
+    `&start=${start}` +
+    `&max_results=${limit}` +
+    `&sortBy=${sortBy}` +
+    `&sortOrder=${sortOrder}`;
+
+  const res = await fetch(url, {
+    headers: {
+      // Atom 1.0 — the only response shape arXiv's API speaks.
+      accept: "application/atom+xml, application/xml;q=0.9, text/xml;q=0.9",
+      // arXiv's user manual asks scrapers to identify themselves so the
+      // operations team can rate-limit cooperatively if needed.
+      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const detail = (await res.text()).slice(0, 300);
+    throw new Error(`arXiv ${res.status}: ${detail}`);
+  }
+
+  const xml = await res.text();
+  // arXiv reports `<opensearch:totalResults>N</opensearch:totalResults>` and
+  // `<opensearch:itemsPerPage>` near the head — read totalResults to decide
+  // whether more pages exist. Falls back to `entries.length === limit` when
+  // missing (very rare, only seen during upstream maintenance).
+  const totalMatch = xml.match(
+    /<opensearch:totalResults\b[^>]*>(\d+)<\/opensearch:totalResults>/i,
+  );
+  const total = totalMatch ? Number(totalMatch[1]) : Number.NaN;
+
+  const entries = getAllTags(xml, "entry");
+  const items = entries
+    .map(mapEntry)
+    .filter((e): e is FeedItem<ArxivMeta> => e !== null);
+
+  const hasMore = Number.isFinite(total)
+    ? start + items.length < total
+    : entries.length >= limit;
+
+  return { items, hasMore };
+}


### PR DESCRIPTION
## What
38th column type: arXiv. Twelve CS / stat / math.OC categories (cs.AI, cs.CL, cs.LG, cs.CV, cs.RO, cs.CR, cs.DC, cs.NE, cs.SE, cs.PL, stat.ML, math.OC), two sort modes (newest submission / recently updated), and an optional title+abstract keyword filter that ANDs onto the category. Keyless — uses the public arXiv Atom-XML query API at `export.arxiv.org/api/query`.

## Why
The natural companion to huggingface (37th column, PR #30): models and datasets surface where today's AI research breaks out, but the underlying papers drop on arXiv 2-3 weeks earlier. Together they cover the full **artifact-to-research** pipeline. The audience watching minitor for HuggingFace trending already wants to see what's in the arXiv pipeline.

This was Idea #1 in the 2026-05-08 `repo-actions` brief — first academic-paper surface in the minitor lineup, fills the gap between HN discussion (link aggregation) and HuggingFace artifact (the model itself).

## Changes
- `lib/integrations/arxiv.ts` (~290 lines) — Atom XML client + parser. Hand-rolled regex parser following the same convention as `lib/integrations/rss.ts` (no XML library dependency), but specialised for arXiv's namespaced primary-category and the `<link title="pdf">` PDF URL pattern. Slice-based pagination over the upstream `start` + `max_results` params with `opensearch:totalResults` driving `hasMore` (falls back to entries-length-equals-limit when the field is absent during maintenance windows).
- `lib/columns/plugins/arxiv/plugin.ts` — Zod config schema, `BookOpen` icon, `#B31B1B` Cornell-red accent (arXiv's brand colour), `ai` ColumnCategory.
- `lib/columns/plugins/arxiv/server.ts` — wires `fetchArxivPage` into the standard `defineColumnServer` shape.
- `lib/columns/plugins/arxiv/client.tsx` — config form (category select with full label, sort select, search input with link to the arXiv user manual) and item renderer (red arXiv badge, primary-category mono tag, arxivId, revision badge, age, title, author byline with et-al. truncation, 280-char abstract, secondary categories as mono tags, PDF link).
- `lib/columns/plugins/manifest.ts` + `registry.ts` + `server-registry.ts` — three matching registry edits. The init-time parity check validates all three stay in sync.
- `README.md` — column count 37 → 38, AI/ML cluster row 1 → 2, hero paragraph picks up arXiv, keyless-columns line adds arXiv.

## Design notes
- **arXiv's rate-limit advice is "no faster than every 3 seconds with a recognisable User-Agent"** — minitor only fetches on user-driven refresh + initial load, well within the budget. The integration sets a `minitor/1.0` UA so the arXiv ops team can rate-limit cooperatively if needed.
- **Search query separator quirk:** arXiv requires `+` as the literal AND operator inside `search_query=`, but `URLSearchParams` escapes `+` to `%2B`, which arXiv then rejects. The integration builds the `search_query` string manually and passes the others through normally.
- **Schema-drift safety:** drops entries missing both `id` and `title` (rare, only seen during arXiv maintenance windows). All other fields degrade gracefully (no abstract → no abstract block, no PDF link → no PDF row, etc.).
- **Revision detection** is dual-redundant: a `vN` suffix where N>1 on the arxiv id, OR `updated` > `published` by more than 60 seconds. Either is sufficient. Useful in `updated` mode where v2/v3 submissions otherwise look indistinguishable from fresh papers.
- **Author byline** mirrors the convention every arXiv abs page uses: single author → name; multiple → "first et al." in the card header; full list (up to 3 + "and N more") in the renderer.
- **Category palette** keeps the 12 most active CS/stat categories — covers ~95% of papers minitor users would plausibly track. `math.OC` is the only non-CS entry (control theory + RL crossover audience).

## Test plan
- [ ] `npm run lint` and the build succeed (the registries' init-time parity check throws loudly if any of the three plugin entries diverge — that's the main thing to watch)
- [ ] Create an arxiv column with `category=cs.AI`, `mode=recent`, no search — verify items render with title, author, abstract, primary category, PDF link
- [ ] Create another with `category=cs.LG`, `search=agents` — verify the search filter narrows results and the column title becomes "arXiv · cs.LG · agents"
- [ ] Switch sort to "Recently updated" — verify revisions show the revision badge
- [ ] Click "Load more" — verify pagination advances correctly via the `start` param

---
*Built autonomously by Aeon*