### PR TITLE
feat(arxiv): surface arxiv:comment under the abstract

### DIFF
--- a/lib/columns/plugins/arxiv/client.tsx
+++ b/lib/columns/plugins/arxiv/client.tsx
@@ -104,6 +104,7 @@ function ItemRenderer({ item }: ItemRendererProps<ArxivMeta>) {
   const arxivId = m?.arxivId ?? "";
   const pdfUrl = m?.pdfUrl;
   const isRevision = !!m?.isRevision;
+  const comment = m?.comment ?? "";
 
   return (
     <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
@@ -173,6 +174,11 @@ function ItemRenderer({ item }: ItemRendererProps<ArxivMeta>) {
       {abstract && (
         <p className="mt-1.5 text-[12.5px] leading-snug text-muted-foreground/90">
           {truncate(abstract, 280)}
+        </p>
+      )}
+      {comment && (
+        <p className="mt-1 text-[11.5px] italic leading-snug text-muted-foreground/75">
+          {truncate(comment, 140)}
         </p>
       )}
       <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">

--- a/lib/columns/plugins/arxiv/plugin.ts
+++ b/lib/columns/plugins/arxiv/plugin.ts
@@ -35,6 +35,7 @@ export interface ArxivMeta {
   publishedAt: string;
   updatedAt: string;
   isRevision: boolean;
+  comment?: string;
 }
 
 const CATEGORY_LABELS: Record<(typeof CATEGORIES)[number], string> = {

--- a/lib/integrations/arxiv.ts
+++ b/lib/integrations/arxiv.ts
@@ -44,6 +44,12 @@ export interface ArxivMeta {
   // Distinguishes a freshly published paper from a v2/v3 revision — useful
   // for picking out genuinely new work in `updated` mode.
   isRevision: boolean;
+  // Free-form `<arxiv:comment>` from the Atom entry. Authors typically use it
+  // for venue acceptance ("Accepted to ICML 2026", "SIGGRAPH 2026"), code
+  // links ("Code: https://github.com/..."), or page count ("33 pages"). ~56%
+  // of recent cs.LG entries populate it; the renderer hides the line when
+  // empty.
+  comment?: string;
 }
 
 const NAMED_ENTITIES: Record<string, string> = {
@@ -188,6 +194,7 @@ function mapEntry(entry: string): FeedItem<ArxivMeta> | null {
   const abstract = clean(getTag(entry, "summary"));
   const authors = extractAuthors(entry);
   const { primary, all } = extractCategories(entry);
+  const comment = clean(getTag(entry, "arxiv:comment"));
 
   const publishedRaw = getTag(entry, "published").trim();
   const updatedRaw = getTag(entry, "updated").trim();
@@ -243,6 +250,7 @@ function mapEntry(entry: string): FeedItem<ArxivMeta> | null {
         ? new Date(updatedMs).toISOString()
         : new Date(createdMs).toISOString(),
       isRevision,
+      comment: comment || undefined,
     },
   };
 }


### PR DESCRIPTION
## Summary
- Followup to #31. The arXiv Atom response includes `<arxiv:comment>` on roughly half of entries — venue acceptance (`Accepted to ICML 2026`, `SIGGRAPH 2026`), code repo links (`Code: https://github.com/...`), or page count. The parser shipped in #31 ignored the field.
- This PR extracts it into `ArxivMeta.comment` and renders it as a small italic line below the abstract, truncated to 140 chars. Hidden when empty, so cards without a comment stay as compact as before.

## Sample comments seen in cs.LG newest-50 (28 of 50 populated)
- `SIGGRAPH 2026`
- `Accepted to ICML 2026`
- `Published in TISMIR. Project repository: https://github.com/...`
- `Code: https://github.com/lihongzhao99/MMDG_Benchmark`
- `33 pages`

## Changes
- `lib/integrations/arxiv.ts` — add `comment?: string` to `ArxivMeta`; extract via `clean(getTag(entry, "arxiv:comment"))` in `mapEntry`; emit `comment || undefined` so the meta blob never carries an empty string.
- `lib/columns/plugins/arxiv/plugin.ts` — mirror the field on the renderer-side `ArxivMeta` (already duplicated for the client/server boundary).
- `lib/columns/plugins/arxiv/client.tsx` — render the comment as `text-[11.5px] italic text-muted-foreground/75` under the abstract; truncated to 140 chars; conditional on non-empty.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `npm run lint` passes (verified locally)
- [ ] Open an arXiv column on `cs.LG` newest, confirm comment lines render under entries that have one and stay hidden for entries that don't
- [ ] Long comments (e.g. multi-sentence appendix notes) truncate cleanly with `…`