### PR TITLE
feat: DEV.to column — long-form developer articles by tag and recency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 38 column types out of the box — social feeds, news, GitHub, Hugging Face, arXiv, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
+- 39 column types out of the box — social feeds, news, GitHub, Hugging Face, arXiv, DEV.to, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -41,7 +41,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -60,7 +60,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 |----------|---------|
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
 | **GitHub** (8) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks` |
-| **News & web** (6) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow` |
+| **News & web** (7) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto` |
 | **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |

--- a/lib/columns/plugins/devto/client.tsx
+++ b/lib/columns/plugins/devto/client.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { Heart, MessageSquareText, Timer } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import { meta, type DevtoConfig, type DevtoMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<DevtoConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Mode</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as DevtoConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="top">Top — past week</SelectItem>
+            <SelectItem value="rising">Rising — past 24h</SelectItem>
+            <SelectItem value="latest">Latest</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="devto-tag">Tags (optional)</Label>
+        <Input
+          id="devto-tag"
+          placeholder="ai, llm, rust, webdev…"
+          value={value.tag}
+          onChange={(e) => onChange({ ...value, tag: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Up to five tags, comma- or space-separated. Multiple tags AND-match
+          (returns articles tagged with <em>all</em> of them). See{" "}
+          <a
+            href="https://dev.to/tags"
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            dev.to/tags
+          </a>{" "}
+          for the full list.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<DevtoMeta>) {
+  const m = item.meta;
+  const reactions = m?.reactions ?? 0;
+  const comments = m?.comments ?? 0;
+  const readingTime = m?.readingTimeMinutes ?? 0;
+  const tags = m?.tags ?? [];
+  const organization = m?.organization;
+
+  const [title, ...rest] = item.content.split("\n\n");
+  const description = rest.join("\n\n").trim();
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(59, 73, 223, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[9px] font-bold leading-none text-white"
+            style={{ backgroundColor: "#3b49df" }}
+          >
+            D
+          </span>
+          DEV
+        </span>
+        <span className="text-muted-foreground/80">
+          by{" "}
+          <span className="text-foreground/90">
+            {item.author.handle ?? item.author.name}
+          </span>
+        </span>
+        {organization && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="text-muted-foreground/80">
+              for{" "}
+              <span className="text-foreground/90">{organization.name}</span>
+            </span>
+          </>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+        >
+          {title}
+        </h3>
+      </a>
+      {description && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {description}
+        </p>
+      )}
+      {tags.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {tags.slice(0, 4).map((t) => (
+            <span
+              key={t}
+              className="rounded-sm px-1 py-0.5 text-[10px] text-muted-foreground ring-1 ring-border/60"
+            >
+              #{t}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <Heart className="size-3.5" />
+          <span className="tabular-nums">{formatCompactCount(reactions)}</span>
+        </span>
+        <span className="flex items-center gap-1">
+          <MessageSquareText className="size-3.5" />
+          <span className="tabular-nums">{formatCompactCount(comments)}</span>
+        </span>
+        {readingTime > 0 && (
+          <span className="flex items-center gap-1">
+            <Timer className="size-3.5" />
+            <span className="tabular-nums">{readingTime}m read</span>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<DevtoConfig, DevtoMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/devto/plugin.ts
+++ b/lib/columns/plugins/devto/plugin.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { Code2 } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  mode: z.enum(["top", "latest", "rising"]).default("top"),
+  tag: z.string().default(""),
+});
+
+export type DevtoConfig = z.infer<typeof schema>;
+
+export interface DevtoMeta {
+  reactions: number;
+  comments: number;
+  readingTimeMinutes: number;
+  tags: string[];
+  organization?: { name: string; slug: string; avatarUrl?: string };
+  coverImage?: string;
+}
+
+const MODE_LABELS: Record<DevtoConfig["mode"], string> = {
+  top: "Top week",
+  latest: "Latest",
+  rising: "Rising 24h",
+};
+
+export const meta: PluginMeta<DevtoConfig, DevtoMeta> = {
+  id: "devto",
+  label: "DEV.to",
+  description:
+    "Top, latest, or rising articles — optionally filtered by one or more tags (e.g. ai, llm, rust, webdev).",
+  icon: Code2,
+  // DEV.to's brand indigo — the colour used on the navbar and the `</>` mark
+  // on dev.to/about. Distinct from the existing palette: substack orange
+  // #ff7b30, lobsters #ac130d, stack-overflow #F48024, hacker-news flame.
+  accent: "#3b49df",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const tags = c.tag
+      .trim()
+      .split(/[,;\s]+/)
+      .filter(Boolean)
+      .slice(0, 3);
+    if (tags.length > 0) return `DEV · ${tags.join(", ")}`;
+    return `DEV · ${MODE_LABELS[c.mode]}`;
+  },
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/devto/server.ts
+++ b/lib/columns/plugins/devto/server.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchDevtoPage } from "@/lib/integrations/devto";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type DevtoConfig, type DevtoMeta } from "./plugin";
+
+const fetch: ServerFetcher<DevtoConfig, DevtoMeta> = async (config, cursor) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await fetchDevtoPage(config.mode, config.tag, PAGE_SIZE, page);
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<DevtoConfig, DevtoMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -42,6 +42,7 @@ import { meta as polymarket } from "./polymarket/plugin";
 import { meta as stackOverflow } from "./stack-overflow/plugin";
 import { meta as huggingface } from "./huggingface/plugin";
 import { meta as arxiv } from "./arxiv/plugin";
+import { meta as devto } from "./devto/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -82,6 +83,7 @@ export const PLUGIN_METAS = [
   stackOverflow,
   huggingface,
   arxiv,
+  devto,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -50,6 +50,7 @@ import { column as polymarket } from "@/lib/columns/plugins/polymarket/client";
 import { column as stackOverflow } from "@/lib/columns/plugins/stack-overflow/client";
 import { column as huggingface } from "@/lib/columns/plugins/huggingface/client";
 import { column as arxiv } from "@/lib/columns/plugins/arxiv/client";
+import { column as devto } from "@/lib/columns/plugins/devto/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -93,6 +94,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "stack-overflow": stackOverflow,
   huggingface,
   arxiv,
+  devto,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -46,6 +46,7 @@ import { server as polymarket } from "@/lib/columns/plugins/polymarket/server";
 import { server as stackOverflow } from "@/lib/columns/plugins/stack-overflow/server";
 import { server as huggingface } from "@/lib/columns/plugins/huggingface/server";
 import { server as arxiv } from "@/lib/columns/plugins/arxiv/server";
+import { server as devto } from "@/lib/columns/plugins/devto/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -86,6 +87,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "stack-overflow": stackOverflow,
   huggingface,
   arxiv,
+  devto,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/devto.ts
+++ b/lib/integrations/devto.ts
@@ -1,0 +1,236 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// DEV.to public REST API — keyless for read endpoints.
+// https://developers.forem.com/api/v1#tag/articles
+//
+// /api/articles is the main feed; query params shape the slice:
+//   - top=N            most-reacted in the last N days (1, 7, 30, 365…)
+//   - tag=slug         single-tag filter (combine with top= for "best of week
+//                      in `ai`")
+//   - tags=slug,slug2  comma-separated AND across tags
+//   - per_page=30      page size, max 1000
+//   - page=N           1-indexed pagination
+//   - state=fresh      relaxed sort: ranks recent posts above raw reactions
+//
+// Anonymous reads aren't rate-limited per docs (Forem self-hosting routes the
+// same endpoint, so cadence is on the Forem hosts, not the API consumer).
+const BASE = "https://dev.to/api";
+
+export type DevtoMode = "top" | "latest" | "rising";
+
+interface DevtoUser {
+  name?: string;
+  username?: string;
+  twitter_username?: string | null;
+  github_username?: string | null;
+  website_url?: string | null;
+  profile_image?: string;
+  profile_image_90?: string;
+}
+
+interface DevtoOrganization {
+  name?: string;
+  username?: string;
+  slug?: string;
+  profile_image?: string;
+}
+
+interface DevtoArticle {
+  id?: number;
+  type_of?: string;
+  title?: string;
+  description?: string;
+  url?: string;
+  canonical_url?: string;
+  cover_image?: string | null;
+  social_image?: string;
+  reading_time_minutes?: number;
+  published_at?: string;
+  edited_at?: string | null;
+  crossposted_at?: string | null;
+  comments_count?: number;
+  public_reactions_count?: number;
+  positive_reactions_count?: number;
+  tag_list?: string[] | string;
+  tags?: string;
+  user?: DevtoUser;
+  organization?: DevtoOrganization;
+}
+
+export interface DevtoMeta {
+  reactions: number;
+  comments: number;
+  readingTimeMinutes: number;
+  tags: string[];
+  organization?: { name: string; slug: string; avatarUrl?: string };
+  coverImage?: string;
+}
+
+function normaliseTagFilter(tag: string): string[] {
+  // Accept commas / semicolons / spaces; lowercase, dedupe, clamp to 5 tags
+  // (the API doesn't document a hard cap, but >5 narrows aggressively to no
+  // results on most slices and makes the cache key explode).
+  const parts = tag
+    .split(/[,;\s]+/)
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean);
+  const seen = new Set<string>();
+  const uniq: string[] = [];
+  for (const p of parts) {
+    if (!seen.has(p)) {
+      seen.add(p);
+      uniq.push(p);
+    }
+    if (uniq.length === 5) break;
+  }
+  return uniq;
+}
+
+function endpointFor(
+  mode: DevtoMode,
+  tags: string[],
+  perPage: number,
+  page: number,
+): string {
+  const params = new URLSearchParams();
+  params.set("per_page", String(Math.min(Math.max(perPage, 1), 100)));
+  params.set("page", String(Math.max(page, 0) + 1));
+
+  switch (mode) {
+    case "top":
+      // Reactions over the last 7 days. The DEV.to UI's "Top → Week" tab.
+      params.set("top", "7");
+      break;
+    case "latest":
+      // No `top=` param + state=fresh sorts by published_at desc.
+      params.set("state", "fresh");
+      break;
+    case "rising":
+      // Reactions in the last 24h — the "Top → Day" slice. Tighter than top
+      // and biased toward posts still climbing rather than already viral.
+      params.set("top", "1");
+      break;
+  }
+
+  if (tags.length === 1) {
+    params.set("tag", tags[0]);
+  } else if (tags.length > 1) {
+    // The API documents `tags` (plural) as a comma-separated AND filter.
+    params.set("tags", tags.join(","));
+  }
+
+  return `${BASE}/articles?${params}`;
+}
+
+function tagListOf(a: DevtoArticle): string[] {
+  // The API has shipped both `tag_list` (array) and `tags` (comma string) over
+  // the years; some endpoints return one, some return both. Accept either,
+  // normalise to a deduped array, drop empties.
+  const fromList = Array.isArray(a.tag_list) ? a.tag_list : [];
+  const fromString =
+    typeof a.tag_list === "string"
+      ? a.tag_list.split(",")
+      : typeof a.tags === "string"
+        ? a.tags.split(",")
+        : [];
+  const all = [...fromList, ...fromString]
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean);
+  return Array.from(new Set(all));
+}
+
+function authorOf(a: DevtoArticle): {
+  name: string;
+  handle: string;
+  avatarUrl?: string;
+} {
+  const u = a.user;
+  const handle = u?.username?.trim() || "anonymous";
+  const name = u?.name?.trim() || handle;
+  // profile_image_90 is the smaller variant; fall back to the larger profile_image
+  // when the 90px one isn't returned. Both are absolute URLs on the dev.to CDN.
+  const avatarUrl = u?.profile_image_90 || u?.profile_image;
+  return { name, handle, avatarUrl };
+}
+
+function organizationOf(a: DevtoArticle): DevtoMeta["organization"] {
+  const o = a.organization;
+  if (!o) return undefined;
+  const name = o.name?.trim();
+  const slug = o.slug?.trim() || o.username?.trim();
+  if (!name || !slug) return undefined;
+  return { name, slug, avatarUrl: o.profile_image };
+}
+
+function mapArticle(a: DevtoArticle): FeedItem<DevtoMeta> | null {
+  // Schema-drift safe: an article without an id, title, or url has nothing to
+  // render or link to, so drop rather than emit a dead row.
+  if (!a.id || !a.title || !a.url) return null;
+
+  const author = authorOf(a);
+  const reactions =
+    a.public_reactions_count ?? a.positive_reactions_count ?? 0;
+  const comments = a.comments_count ?? 0;
+  const readingTimeMinutes = a.reading_time_minutes ?? 0;
+  const tags = tagListOf(a);
+  const createdMs = a.published_at ? Date.parse(a.published_at) : Date.now();
+  const description = a.description?.trim() || "";
+  const content = description ? `${a.title}\n\n${description}` : a.title;
+
+  return {
+    id: String(a.id),
+    author,
+    content,
+    url: a.url,
+    createdAt: new Date(createdMs).toISOString(),
+    meta: {
+      reactions,
+      comments,
+      readingTimeMinutes,
+      tags,
+      organization: organizationOf(a),
+      coverImage: a.cover_image || a.social_image,
+    },
+  };
+}
+
+export async function fetchDevtoPage(
+  mode: DevtoMode,
+  tag: string,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<DevtoMeta>[]; hasMore: boolean }> {
+  const tags = normaliseTagFilter(tag);
+  const url = endpointFor(mode, tags, Math.max(limit, 30), page);
+  const res = await fetch(url, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `DEV.to ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+
+  const json = (await res.json()) as DevtoArticle[] | { error?: string };
+  if (!Array.isArray(json)) {
+    // Some upstream errors come back as `{ error: "..." }` with a 200; treat
+    // them as empty rather than throw, so the column renders an empty state
+    // instead of a generic crash.
+    return { items: [], hasMore: false };
+  }
+
+  const mapped = json
+    .map(mapArticle)
+    .filter((a): a is FeedItem<DevtoMeta> => a !== null);
+
+  // The /articles endpoint returns `per_page` items on a full page; fewer
+  // means we've hit the tail of the slice. Per_page is requested at >= limit
+  // so the trim is independent of upstream page size.
+  const hasMore = json.length >= Math.max(limit, 30);
+  return { items: mapped.slice(0, limit), hasMore };
+}


### PR DESCRIPTION
## What
39th column type — fills the long-form-developer gap in the news cluster. HN + Lobsters cover link aggregation and dev discussion; DEV.to is where practitioners write tutorials, walkthroughs, and opinionated engineering posts — content HN links to but doesn't host.

Public REST API at \`dev.to/api/articles\`, fully keyless for read endpoints. Three modes:
- **top** — past week by reactions (DEV's "Top → Week" tab; \`top=7\`)
- **rising** — past 24h by reactions, biased toward posts still climbing rather than already viral (\`top=1\`)
- **latest** — newest by \`published_at\` (\`state=fresh\`)

Optional 1–5 tag AND-filter — comma/semicolon/space-separated input, normalised to lowercase, deduped, clamped to 5. Single tag uses \`tag=\`; multi-tag uses \`tags=\`.

\`#3b49df\` DEV indigo accent (the navbar / \`</>\` mark colour from dev.to/about), distinct from substack \`#ff7b30\`, lobsters \`#ac130d\`, stack-overflow \`#F48024\`. \`Code2\` lucide icon. Renderer matches Lobsters' serif-title-with-description treatment, plus a "for {org}" line when an article was published under a Forem organization, and a reading-time footer next to reactions and comments.

## Why
Yesterday's PR #31 (arXiv) closed the academic gap for the AI/research audience. Today's PR closes the long-form-developer gap. Together with HN, Lobsters, and Stack Overflow, the news cluster now covers four distinct developer content modes — link aggregation (HN), curated dev links (Lobsters), Q&A (SO), and tutorials/blogs (DEV.to). Picked from the [2026-05-08 repo-actions brief](https://github.com/aaronjmars/aeon-agent/blob/main/articles/repo-actions-2026-05-08.md) idea #2; companion to yesterday's arXiv column (idea #1).

## Changes
- \`lib/integrations/devto.ts\`: keyless \`fetch\` against \`dev.to/api/articles\` with mode/tag/page params, schema-drift-safe parsing (accepts both \`tag_list\` array and \`tags\` CSV — the API has shipped both over the years), title/description/reactions/comments/reading-time mapping, organization metadata, identicon-via-DEV-CDN avatars
- \`lib/columns/plugins/devto/plugin.ts\`: Zod schema \`{ mode, tag }\`, \`Code2\` icon, \`#3b49df\` accent, news category, \`paginated: true\`
- \`lib/columns/plugins/devto/server.ts\`: standard \`defineColumnServer\` with \`PAGE_SIZE\`-based pagination
- \`lib/columns/plugins/devto/client.tsx\`: ConfigForm (mode select + tag input + dev.to/tags link) + ItemRenderer (DEV badge + author + org + relative time + serif title + description + tag pills + Heart/MessageSquareText/Timer footer)
- \`lib/columns/plugins/manifest.ts\`: import + \`PLUGIN_METAS\` registration
- \`lib/columns/registry.ts\`: client UI registration
- \`lib/columns/server-registry.ts\`: server fetcher registration (parity check stays clean)
- \`README.md\`: hero column-list picks up DEV.to, count 38 → 39, News & web cluster 6 → 7, keyless-columns line picks up DEV.to

## Quirks documented inline
1. **Tag-field schema drift.** \`tag_list\` ships as both an array and a CSV string across endpoints; the parser accepts either, normalises to a deduped lowercase array.
2. **Per_page = max(limit, 30).** Requesting \`per_page\` ≥ 30 makes the \`hasMore\` signal independent of how many items the column trims to. Slice happens after fetch.
3. **Tag count cap = 5.** API doesn't document a hard cap, but >5 tags narrows aggressively to no results on most slices and explodes the cache key. Five matches the \`stack-overflow\` plugin's discipline.

## Test plan
- [ ] \`pnpm dev\` (or \`./minitor\`), add a DEV.to column with mode = top, no tag — top-of-week articles render
- [ ] Change tag to \`ai\` — only \`ai\`-tagged articles
- [ ] Add a second tag \`llm\` (comma-separated) — AND filter returns only articles tagged with both
- [ ] Switch to "Rising — past 24h" — different slice, fresher posts
- [ ] Click "Load more" — page 2 appends without duplicates
- [ ] Watch the parity check on server boot — passes (no manifest/server-registry mismatch)
- [ ] Article with an organization (e.g. a Vercel post) shows the "for Vercel" line; article without org does not

---
*Built autonomously by Aeon — sourced from 2026-05-08 repo-actions idea #2.*