### PR TITLE
feat: github-actions column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 39 column types out of the box — social feeds, news, GitHub, Hugging Face, arXiv, DEV.to, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
+- 40 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -59,7 +59,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 | Category | Columns |
 |----------|---------|
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
-| **GitHub** (8) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks` |
+| **GitHub** (9) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks`, `github-actions` |
 | **News & web** (7) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto` |
 | **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |

--- a/lib/columns/plugins/github-actions/client.tsx
+++ b/lib/columns/plugins/github-actions/client.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import {
+  CheckCircle2,
+  XCircle,
+  CircleSlash,
+  Loader2,
+  AlertTriangle,
+  Clock,
+  GitBranch,
+  Hash,
+} from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type GHActionsConfig, type GHActionsMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<GHActionsConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="gha-repo">Repository</Label>
+        <Input
+          id="gha-repo"
+          placeholder="vercel/next.js"
+          value={value.repo}
+          onChange={(e) => onChange({ ...value, repo: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          <code>owner/repo</code> or full GitHub URL.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="gha-workflow">Workflow (optional)</Label>
+        <Input
+          id="gha-workflow"
+          placeholder="CI · or ci.yml"
+          value={value.workflow}
+          onChange={(e) => onChange({ ...value, workflow: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Match by workflow display name (e.g. <code>CI</code>) or the file
+          inside <code>.github/workflows/</code> (e.g. <code>ci.yml</code>).
+          Empty = every workflow.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="gha-branch">Branch (optional)</Label>
+        <Input
+          id="gha-branch"
+          placeholder="main"
+          value={value.branch}
+          onChange={(e) => onChange({ ...value, branch: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Exact branch match only — the API doesn&apos;t support partials.
+          Empty = every branch.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+interface ConclusionStyle {
+  Icon: typeof CheckCircle2;
+  iconColor: string;
+  ringBg: string;
+  label: string;
+}
+
+// One pill per terminal conclusion. Pending / in-flight runs are rendered
+// separately so the colour pop is reserved for finished outcomes — that's
+// what the user actually scans for ("did it break?").
+const CONCLUSION_STYLES: Record<
+  NonNullable<GHActionsMeta["conclusion"]>,
+  ConclusionStyle
+> = {
+  success: {
+    Icon: CheckCircle2,
+    iconColor: "#10b981",
+    ringBg: "rgba(16, 185, 129, 0.18)",
+    label: "success",
+  },
+  failure: {
+    Icon: XCircle,
+    iconColor: "#ef4444",
+    ringBg: "rgba(239, 68, 68, 0.20)",
+    label: "failure",
+  },
+  cancelled: {
+    Icon: CircleSlash,
+    iconColor: "#9ca3af",
+    ringBg: "rgba(156, 163, 175, 0.18)",
+    label: "cancelled",
+  },
+  neutral: {
+    Icon: CircleSlash,
+    iconColor: "#9ca3af",
+    ringBg: "rgba(156, 163, 175, 0.18)",
+    label: "neutral",
+  },
+  skipped: {
+    Icon: CircleSlash,
+    iconColor: "#9ca3af",
+    ringBg: "rgba(156, 163, 175, 0.14)",
+    label: "skipped",
+  },
+  timed_out: {
+    Icon: AlertTriangle,
+    iconColor: "#f59e0b",
+    ringBg: "rgba(245, 158, 11, 0.18)",
+    label: "timed out",
+  },
+  action_required: {
+    Icon: AlertTriangle,
+    iconColor: "#f59e0b",
+    ringBg: "rgba(245, 158, 11, 0.22)",
+    label: "action required",
+  },
+  stale: {
+    Icon: CircleSlash,
+    iconColor: "#9ca3af",
+    ringBg: "rgba(156, 163, 175, 0.14)",
+    label: "stale",
+  },
+  startup_failure: {
+    Icon: XCircle,
+    iconColor: "#ef4444",
+    ringBg: "rgba(239, 68, 68, 0.20)",
+    label: "startup failure",
+  },
+};
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) {
+    return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remM = minutes % 60;
+  return remM === 0 ? `${hours}h` : `${hours}h ${remM}m`;
+}
+
+function StatusPill({ meta: m }: { meta: GHActionsMeta }) {
+  // Pending / queued / in-flight take precedence over conclusion — a completed
+  // run always has a conclusion, but the reverse isn't guaranteed.
+  if (m.status === "in_progress") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px] font-medium"
+        style={{ backgroundColor: "rgba(32, 136, 255, 0.18)", color: "#2088FF" }}
+      >
+        <Loader2 className="size-3 animate-spin" />
+        running
+      </span>
+    );
+  }
+  if (m.status === "queued" || m.status === "waiting" || m.status === "pending" || m.status === "requested") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px] font-medium"
+        style={{ backgroundColor: "rgba(245, 158, 11, 0.18)", color: "#b45309" }}
+      >
+        <Clock className="size-3" />
+        {m.status === "queued" ? "queued" : m.status}
+      </span>
+    );
+  }
+  const conclusion = m.conclusion ?? "neutral";
+  const s = CONCLUSION_STYLES[conclusion] ?? CONCLUSION_STYLES.neutral;
+  const Icon = s.Icon;
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px] font-medium text-foreground/90"
+      style={{ backgroundColor: s.ringBg }}
+    >
+      <Icon className="size-3" style={{ color: s.iconColor }} />
+      {s.label}
+    </span>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<GHActionsMeta>) {
+  const m = item.meta;
+  if (!m) return null;
+  const title = item.content || `Run #${m.runNumber}`;
+  const branch = m.branch ?? "";
+  const sha = m.shortSha ?? "";
+  const duration = m.durationMs != null ? formatDuration(m.durationMs) : "";
+  // event=push / pull_request / schedule / workflow_dispatch — short label
+  // useful when scanning whether a run came from a cron or a code push.
+  const event = m.event ?? "";
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <StatusPill meta={m} />
+        <span className="truncate font-medium text-foreground/80">
+          {m.workflowName}
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="truncate text-foreground/70">{m.fullRepo}</span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">#{m.runNumber}</span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {title}
+      </h3>
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11.5px] text-muted-foreground">
+        {branch && (
+          <span className="flex items-center gap-1">
+            <GitBranch className="size-3.5" />
+            <span className="truncate">{branch}</span>
+          </span>
+        )}
+        {sha && (
+          <span className="flex items-center gap-1">
+            <Hash className="size-3.5" />
+            <span className="font-mono text-[11px]">{sha}</span>
+          </span>
+        )}
+        {duration && (
+          <span className="flex items-center gap-1">
+            <Clock className="size-3.5" />
+            <span className="tabular-nums">{duration}</span>
+          </span>
+        )}
+        {event && (
+          <span className="rounded-sm px-1 py-0.5 text-[10px] text-muted-foreground ring-1 ring-border/60">
+            {event}
+          </span>
+        )}
+      </div>
+    </a>
+  );
+}
+
+export const column = defineColumnUI<GHActionsConfig, GHActionsMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-actions/plugin.ts
+++ b/lib/columns/plugins/github-actions/plugin.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import { Workflow } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  repo: z.string().default(""),
+  // Optional workflow filter. Match by display name (e.g. "CI") OR by the
+  // filename of `.github/workflows/<file>.yml` — whichever the user pastes.
+  // Empty = show every workflow on the repo.
+  workflow: z.string().default(""),
+  // Optional branch filter, passed to the Actions API as `?branch=`. Exact
+  // match only; the API rejects partials.
+  branch: z.string().default(""),
+});
+
+export type GHActionsConfig = z.infer<typeof schema>;
+
+export interface GHActionsMeta {
+  kind: "run";
+  repo: string;
+  runId: number;
+  runNumber: number;
+  workflowName: string;
+  workflowPath?: string;
+  status:
+    | "queued"
+    | "in_progress"
+    | "completed"
+    | "waiting"
+    | "pending"
+    | "requested";
+  conclusion?:
+    | "success"
+    | "failure"
+    | "cancelled"
+    | "neutral"
+    | "skipped"
+    | "timed_out"
+    | "action_required"
+    | "stale"
+    | "startup_failure";
+  branch?: string;
+  event?: string;
+  sha?: string;
+  shortSha?: string;
+  fullRepo: string;
+  startedAt?: string;
+  durationMs?: number;
+  commitMessage?: string;
+}
+
+export const meta: PluginMeta<GHActionsConfig, GHActionsMeta> = {
+  id: "github-actions",
+  label: "GitHub Actions",
+  description:
+    "Live workflow runs for a GitHub repository — status, conclusion, branch, commit, and duration. Optional workflow + branch filters.",
+  icon: Workflow,
+  // GitHub Actions brand blue — the swatch used on the Actions tab badge.
+  accent: "#2088FF",
+  // Sits alongside the other github-* plugins. The wider GitHub cluster uses
+  // "social" by convention; we follow it here so the "Add column" picker
+  // groups Actions next to PRs / Releases / Issues rather than orphaning it.
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const repo = c.repo.trim();
+    const wf = c.workflow.trim();
+    const branch = c.branch.trim();
+    if (!repo) return "GitHub · Actions";
+    const head = wf ? `Actions · ${repo} · ${wf}` : `Actions · ${repo}`;
+    return branch ? `${head} (${branch})` : head;
+  },
+  capabilities: {
+    paginated: true,
+    rateLimitHint: "60 req/hr without GITHUB_TOKEN, 5000 with.",
+  },
+};

--- a/lib/columns/plugins/github-actions/server.ts
+++ b/lib/columns/plugins/github-actions/server.ts
@@ -1,0 +1,41 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchWorkflowRuns } from "@/lib/integrations/github";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type GHActionsConfig, type GHActionsMeta } from "./plugin";
+
+const fetch: ServerFetcher<GHActionsConfig, GHActionsMeta> = async (
+  config,
+  cursor,
+) => {
+  const repo = config.repo.trim();
+  if (!repo) throw new Error("Repository is required (owner/repo).");
+  const page = cursor ? Number(cursor) || 1 : 1;
+  const { items, hasMore } = await fetchWorkflowRuns(
+    repo,
+    config.workflow,
+    config.branch,
+    PAGE_SIZE,
+    page,
+  );
+  // The integration returns FeedItem<GHActionRunMeta>; that type is structurally
+  // identical to GHActionsMeta (the renderer contract owned by this plugin).
+  // The cast is safe because the two interfaces describe the same shape; we
+  // could re-export the integration type, but a one-line cast keeps the
+  // ownership clear: the plugin owns the renderer contract, the integration
+  // owns the fetch shape.
+  return {
+    items: items as unknown as FeedItem<GHActionsMeta>[],
+    nextCursor: hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<GHActionsConfig, GHActionsMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -43,6 +43,7 @@ import { meta as stackOverflow } from "./stack-overflow/plugin";
 import { meta as huggingface } from "./huggingface/plugin";
 import { meta as arxiv } from "./arxiv/plugin";
 import { meta as devto } from "./devto/plugin";
+import { meta as githubActions } from "./github-actions/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -84,6 +85,7 @@ export const PLUGIN_METAS = [
   huggingface,
   arxiv,
   devto,
+  githubActions,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -51,6 +51,7 @@ import { column as stackOverflow } from "@/lib/columns/plugins/stack-overflow/cl
 import { column as huggingface } from "@/lib/columns/plugins/huggingface/client";
 import { column as arxiv } from "@/lib/columns/plugins/arxiv/client";
 import { column as devto } from "@/lib/columns/plugins/devto/client";
+import { column as githubActions } from "@/lib/columns/plugins/github-actions/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -95,6 +96,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   huggingface,
   arxiv,
   devto,
+  "github-actions": githubActions,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -47,6 +47,7 @@ import { server as stackOverflow } from "@/lib/columns/plugins/stack-overflow/se
 import { server as huggingface } from "@/lib/columns/plugins/huggingface/server";
 import { server as arxiv } from "@/lib/columns/plugins/arxiv/server";
 import { server as devto } from "@/lib/columns/plugins/devto/server";
+import { server as githubActions } from "@/lib/columns/plugins/github-actions/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -88,6 +89,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   huggingface,
   arxiv,
   devto,
+  "github-actions": githubActions,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/github.ts
+++ b/lib/integrations/github.ts
@@ -866,3 +866,186 @@ export async function fetchForks(
     nextCursor: items.length === limit ? String(page + 1) : undefined,
   };
 }
+
+// ---- Actions / workflow runs (used by the github-actions plugin) -----------
+
+export type GHActionStatus =
+  | "queued"
+  | "in_progress"
+  | "completed"
+  | "waiting"
+  | "pending"
+  | "requested";
+
+export type GHActionConclusion =
+  | "success"
+  | "failure"
+  | "cancelled"
+  | "neutral"
+  | "skipped"
+  | "timed_out"
+  | "action_required"
+  | "stale"
+  | "startup_failure";
+
+export interface GHActionRunMeta {
+  kind: "run";
+  repo: string;
+  runId: number;
+  runNumber: number;
+  workflowName: string;
+  workflowPath?: string;
+  status: GHActionStatus;
+  /** undefined while status != "completed" */
+  conclusion?: GHActionConclusion;
+  branch?: string;
+  event?: string;
+  sha?: string;
+  shortSha?: string;
+  /** "<owner>/<repo>" form; useful for the renderer when displaying the row */
+  fullRepo: string;
+  startedAt?: string;
+  /** Duration in ms; undefined when the run hasn't ended yet */
+  durationMs?: number;
+  /** Commit message first-line, when available */
+  commitMessage?: string;
+}
+
+interface GHWorkflowRun {
+  id: number;
+  name: string | null;
+  path?: string;
+  display_title?: string;
+  run_number: number;
+  event: string;
+  status: GHActionStatus;
+  conclusion: GHActionConclusion | null;
+  head_branch: string | null;
+  head_sha: string;
+  html_url: string;
+  run_started_at?: string;
+  created_at: string;
+  updated_at: string;
+  head_commit?: {
+    id?: string;
+    message?: string;
+    author?: { name?: string; email?: string };
+  } | null;
+  actor?: { login: string; avatar_url?: string } | null;
+  triggering_actor?: { login: string; avatar_url?: string } | null;
+}
+
+interface GHWorkflowRunsResponse {
+  total_count?: number;
+  workflow_runs?: GHWorkflowRun[];
+  message?: string;
+}
+
+/**
+ * Fetch recent workflow runs for a repository.
+ *
+ * - `workflow` (optional): filter to runs whose `name` or `path` equals this
+ *   value. Matched case-insensitively after a trim. We can't push the filter
+ *   into the API directly without knowing the numeric workflow_id, so it's
+ *   applied client-side over the requested page. That means a filter narrower
+ *   than the page can return fewer than `limit` rows even when more pages
+ *   exist upstream — the `hasMore` decision still uses raw upstream count so
+ *   "Load more" pages through correctly.
+ * - `branch` (optional): pushed as `branch=` query param. The API supports
+ *   exact branch matches only; partials don't work.
+ */
+export async function fetchWorkflowRuns(
+  repo: string,
+  workflow: string,
+  branch: string,
+  limit: number,
+  page = 1,
+): Promise<{ items: FeedItem<GHActionRunMeta>[]; hasMore: boolean }> {
+  const fullRepo = normalizeGitHubRepo(repo);
+  const params = new URLSearchParams({
+    per_page: String(Math.min(Math.max(limit, 1), 100)),
+    page: String(Math.max(page, 1)),
+  });
+  const trimmedBranch = branch.trim();
+  if (trimmedBranch) params.set("branch", trimmedBranch);
+  const url = `${API}/repos/${fullRepo}/actions/runs?${params}`;
+  const res = await fetch(url, { headers: headers(), cache: "no-store" });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as GHWorkflowRunsResponse;
+  if (json.message) throw new Error(json.message);
+  const raw = json.workflow_runs ?? [];
+  const wf = workflow.trim().toLowerCase();
+  const filtered = wf
+    ? raw.filter((r) => {
+        const name = (r.name ?? "").toLowerCase();
+        const path = (r.path ?? "").toLowerCase();
+        // Match the workflow name exactly, or against the filename portion of
+        // its path (".github/workflows/foo.yml" → "foo.yml"), so users can
+        // copy either the display label or the workflow filename.
+        const file = path.split("/").pop() ?? "";
+        return name === wf || file === wf;
+      })
+    : raw;
+
+  const items: FeedItem<GHActionRunMeta>[] = filtered.map((r) => {
+    const actor =
+      r.actor?.login ?? r.triggering_actor?.login ?? r.head_commit?.author?.name ?? "github";
+    const avatarUrl =
+      r.actor?.avatar_url ??
+      r.triggering_actor?.avatar_url ??
+      identiconUrl(actor);
+    const startedAt = r.run_started_at ?? r.created_at;
+    // The "completed" status carries an `updated_at` that reliably matches the
+    // run-finished moment; for in-flight runs we leave duration undefined
+    // rather than render a misleading partial-duration number.
+    const durationMs =
+      r.status === "completed"
+        ? Math.max(0, Date.parse(r.updated_at) - Date.parse(startedAt))
+        : undefined;
+    const commitMessage = (r.head_commit?.message ?? "").split("\n")[0]?.trim();
+    const title =
+      r.display_title?.trim() ||
+      commitMessage ||
+      r.name?.trim() ||
+      `Run #${r.run_number}`;
+    const sha = r.head_sha ?? "";
+    const shortSha = sha ? sha.slice(0, 7) : undefined;
+    const workflowName = (r.name ?? "").trim() || (r.path?.split("/").pop() ?? "workflow");
+    return {
+      id: `ghact-${r.id}`,
+      author: { name: actor, handle: actor, avatarUrl },
+      content: title,
+      url: r.html_url,
+      // Sort key: when status is "completed" we use updated_at (finished moment),
+      // otherwise we use the started timestamp so in-flight runs surface near
+      // the top of the column.
+      createdAt: r.status === "completed" ? r.updated_at : startedAt,
+      meta: {
+        kind: "run",
+        repo: fullRepo,
+        runId: r.id,
+        runNumber: r.run_number,
+        workflowName,
+        workflowPath: r.path,
+        status: r.status,
+        conclusion: r.conclusion ?? undefined,
+        branch: r.head_branch ?? undefined,
+        event: r.event,
+        sha,
+        shortSha,
+        fullRepo,
+        startedAt,
+        durationMs,
+        commitMessage,
+      },
+    } satisfies FeedItem<GHActionRunMeta>;
+  });
+
+  // Page-completeness uses raw upstream length, NOT the post-filter length,
+  // so workflow-name filtering doesn't prematurely terminate pagination.
+  const hasMore = raw.length >= Math.min(Math.max(limit, 1), 100);
+  return { items: items.slice(0, limit), hasMore };
+}


### PR DESCRIPTION
## What

40th column type: `github-actions`. Live workflow runs for any GitHub repo — status, conclusion, branch, commit SHA, duration, event source. Optional workflow + branch filters.

## Why

minitor's 39 column types cover GitHub stars/issues/PRs/forks/releases/trending/search/backlinks, news, social, AI/ML, on-chain, prediction markets, app reviews, China hot boards — but **no CI visibility**. Engineering teams that already use minitor to monitor their repos have to open a second tab for GitHub Actions. A GitHub Actions column makes minitor the single dashboard for repo health, not just community health.

No API key required for public repos (keyless GitHub REST). Higher rate limits with the optional `GITHUB_TOKEN` env var already used by the rest of the github-* plugins.

May-10 repo-actions idea #2.

## Changes

- `lib/columns/plugins/github-actions/plugin.ts`: meta + Zod schema. Three config fields: `repo` (required), `workflow` (optional name OR filename), `branch` (optional, exact match). Workflow icon, GitHub-Actions-blue (#2088FF) accent, `social` category to sit with the other github-* plugins.
- `lib/columns/plugins/github-actions/server.ts`: thin server fetcher; delegates to the new `fetchWorkflowRuns` in `lib/integrations/github.ts`.
- `lib/columns/plugins/github-actions/client.tsx`: `ConfigForm` with three inputs + inline help text. `ItemRenderer` uses a status pill that distinguishes in-flight (`Loader2` spinner) / queued / 9 terminal conclusions (success/failure/cancelled/neutral/skipped/timed_out/action_required/stale/startup_failure). Row shows workflow name, repo, run #, relative time, branch, short SHA, duration, event source (push/pull_request/schedule/workflow_dispatch).
- `lib/integrations/github.ts`: new `fetchWorkflowRuns(repo, workflow, branch, limit, page)` and supporting types. Three integration quirks documented inline: (1) workflow filter is applied client-side because the API needs a numeric workflow_id, not a name; (2) page-completeness uses raw upstream length, so the workflow filter doesn't break pagination; (3) duration is only computed for `status=completed` — in-flight runs don't render a partial-duration number.
- `lib/columns/plugins/manifest.ts`, `lib/columns/registry.ts`, `lib/columns/server-registry.ts`: three registry edits. Parity check at server module init will throw loudly if any of the three are out of sync (catches typos like the slug not matching).
- `README.md`: column count 39 → 40, GitHub cluster row 8 → 9, mention of "GitHub (including CI runs)" in the top-line bullet.

## How it works

The `/repos/{owner}/{repo}/actions/runs` endpoint is public and keyless for public repos (60 req/hr per IP; 5000/hr with `GITHUB_TOKEN`). The fetcher requests one page at a time with `per_page=PAGE_SIZE`, optionally narrows server-side via `?branch=`, and applies the workflow name/filename filter client-side over the response. Each run is mapped into a `FeedItem<GHActionsMeta>` carrying the status, conclusion, branch, head SHA, duration, event, and commit message first-line. The renderer's status pill uses lucide icons for each conclusion (`CheckCircle2`, `XCircle`, `CircleSlash`, `AlertTriangle`) plus a spinning `Loader2` for in-flight runs. Duration is computed from `updated_at - run_started_at` and only displayed when the run has completed.

## Test plan

- [ ] Add a `github-actions` column with `repo=vercel/next.js`, no workflow/branch filter — verify recent runs render with mixed statuses
- [ ] Add a column with `repo=aaronjmars/minitor, workflow=CI` — verify only CI-named runs render
- [ ] Add a column with `repo=aaronjmars/aeon, branch=main` — verify only main-branch runs render
- [ ] Try an invalid repo (`foo`) — verify the "Use owner/repo" error surfaces in the column
- [ ] Verify Load more pagination through 3 pages (30 runs) without re-fetching

---
*Built autonomously by Aeon*