### PR TITLE
feat: add npm column type (41st)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 40 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
+- 41 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, npm packages, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -41,7 +41,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, npm, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -60,7 +60,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 |----------|---------|
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
 | **GitHub** (9) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks`, `github-actions` |
-| **News & web** (7) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto` |
+| **News & web** (8) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto`, `npm` |
 | **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -44,6 +44,7 @@ import { meta as huggingface } from "./huggingface/plugin";
 import { meta as arxiv } from "./arxiv/plugin";
 import { meta as devto } from "./devto/plugin";
 import { meta as githubActions } from "./github-actions/plugin";
+import { meta as npm } from "./npm/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -86,6 +87,7 @@ export const PLUGIN_METAS = [
   arxiv,
   devto,
   githubActions,
+  npm,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/plugins/npm/client.tsx
+++ b/lib/columns/plugins/npm/client.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { AlertTriangle, Download, Sparkles } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import { meta, type NpmConfig, type NpmMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<NpmConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="npm-query">Search query</Label>
+        <Input
+          id="npm-query"
+          placeholder="e.g. react, llm, cli, agent, vite-plugin"
+          value={value.query}
+          onChange={(e) => onChange({ ...value, query: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          npm's search endpoint requires a query; leave as <code>javascript</code>
+          {" "}for a broad popularity stream, or scope to a keyword (single word
+          for substring match across name/description/keywords).
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Sort</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as NpmConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="popularity">Popularity</SelectItem>
+            <SelectItem value="quality">Quality</SelectItem>
+            <SelectItem value="maintenance">Maintenance</SelectItem>
+            <SelectItem value="combined">Combined (balanced)</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          Heavy-weights the chosen axis to 0.8; <strong>Combined</strong>{" "}
+          mirrors npm's default ranking blend.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ScorePill({
+  label,
+  value,
+}: {
+  label: string;
+  value: number;
+}) {
+  // Score values are in [0, 1]; render as integer percent. Round to nearest,
+  // floor at 0, cap at 100 — npm sometimes returns 1.0000000002 from the
+  // ranking model, which would round to 100 anyway but the cap is defensive.
+  const pct = Math.max(0, Math.min(100, Math.round(value * 100)));
+  return (
+    <span className="inline-flex items-center gap-1 text-[10.5px] text-muted-foreground">
+      <span className="font-medium uppercase tracking-wide">{label}</span>
+      <span className="tabular-nums text-foreground/90">{pct}</span>
+    </span>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<NpmMeta>) {
+  const m = item.meta;
+  const weeklyDownloads = m?.weeklyDownloads ?? 0;
+  const version = m?.version ?? "";
+  const keywords = m?.keywords ?? [];
+  const deprecated = m?.deprecated ?? false;
+  const score = m?.score ?? 0;
+  const detail = m?.scoreDetail;
+
+  const [title, ...rest] = item.content.split("\n\n");
+  const description = rest.join("\n\n").trim();
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(203, 56, 55, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[9px] font-bold leading-none text-white"
+            style={{ backgroundColor: "#CB3837" }}
+          >
+            n
+          </span>
+          npm
+        </span>
+        {version && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums text-muted-foreground/90">
+              v{version}
+            </span>
+          </>
+        )}
+        {deprecated && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="inline-flex items-center gap-1 rounded-sm px-1 py-0.5 text-[10px] font-medium text-amber-600 ring-1 ring-amber-500/40">
+              <AlertTriangle className="size-3" />
+              deprecated
+            </span>
+          </>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-mono text-[14px] leading-[1.25] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em" }}
+        >
+          {title}
+        </h3>
+      </a>
+      {description && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {description}
+        </p>
+      )}
+      {keywords.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {keywords.slice(0, 5).map((k) => (
+            <span
+              key={k}
+              className="rounded-sm px-1 py-0.5 text-[10px] text-muted-foreground ring-1 ring-border/60"
+            >
+              {k}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11.5px] text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <Download className="size-3.5" />
+          <span className="tabular-nums">
+            {formatCompactCount(weeklyDownloads)}
+          </span>
+          <span className="text-muted-foreground/70">/wk</span>
+        </span>
+        {score > 0 && (
+          <span className="flex items-center gap-1">
+            <Sparkles className="size-3.5" />
+            <span className="tabular-nums text-foreground/90">
+              {Math.round(score * 100)}
+            </span>
+          </span>
+        )}
+        {detail && (
+          <span className="flex items-center gap-2 text-muted-foreground/80">
+            <ScorePill label="Q" value={detail.quality} />
+            <ScorePill label="P" value={detail.popularity} />
+            <ScorePill label="M" value={detail.maintenance} />
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<NpmConfig, NpmMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/npm/plugin.ts
+++ b/lib/columns/plugins/npm/plugin.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import { Package } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default("javascript"),
+  mode: z
+    .enum(["popularity", "quality", "maintenance", "combined"])
+    .default("popularity"),
+});
+
+export type NpmConfig = z.infer<typeof schema>;
+
+export interface NpmMeta {
+  version: string;
+  weeklyDownloads: number;
+  keywords: string[];
+  score: number;
+  scoreDetail: {
+    quality: number;
+    popularity: number;
+    maintenance: number;
+  };
+  publisher?: { username?: string; email?: string };
+  homepage?: string;
+  repository?: string;
+  license?: string;
+  deprecated: boolean;
+}
+
+const MODE_LABELS: Record<NpmConfig["mode"], string> = {
+  popularity: "Popular",
+  quality: "Quality",
+  maintenance: "Maintained",
+  combined: "Combined",
+};
+
+export const meta: PluginMeta<NpmConfig, NpmMeta> = {
+  id: "npm",
+  label: "npm",
+  description:
+    "Trending and high-signal npm packages — ranked by popularity, quality, maintenance, or combined score. Keyword-scoped via search.",
+  icon: Package,
+  // npm's brand red — the colour on the npmjs.com nav and the `npm` wordmark.
+  // Distinct from the existing palette: lobsters #ac130d, github-actions
+  // blue #2088FF, devto indigo #3b49df, hacker-news orange. The closest
+  // adjacent accent in Tools/Dev is stack-overflow #F48024 (yellow-orange),
+  // so the red sits comfortably on the wheel.
+  accent: "#CB3837",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const q = c.query.trim();
+    if (q && q !== "javascript") return `npm · ${q} · ${MODE_LABELS[c.mode]}`;
+    return `npm · ${MODE_LABELS[c.mode]}`;
+  },
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/npm/server.ts
+++ b/lib/columns/plugins/npm/server.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchNpmPage } from "@/lib/integrations/npm";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type NpmConfig, type NpmMeta } from "./plugin";
+
+const fetch: ServerFetcher<NpmConfig, NpmMeta> = async (config, cursor) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await fetchNpmPage(config.query, config.mode, PAGE_SIZE, page);
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<NpmConfig, NpmMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -52,6 +52,7 @@ import { column as huggingface } from "@/lib/columns/plugins/huggingface/client"
 import { column as arxiv } from "@/lib/columns/plugins/arxiv/client";
 import { column as devto } from "@/lib/columns/plugins/devto/client";
 import { column as githubActions } from "@/lib/columns/plugins/github-actions/client";
+import { column as npm } from "@/lib/columns/plugins/npm/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -97,6 +98,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   arxiv,
   devto,
   "github-actions": githubActions,
+  npm,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -48,6 +48,7 @@ import { server as huggingface } from "@/lib/columns/plugins/huggingface/server"
 import { server as arxiv } from "@/lib/columns/plugins/arxiv/server";
 import { server as devto } from "@/lib/columns/plugins/devto/server";
 import { server as githubActions } from "@/lib/columns/plugins/github-actions/server";
+import { server as npm } from "@/lib/columns/plugins/npm/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -90,6 +91,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   arxiv,
   devto,
   "github-actions": githubActions,
+  npm,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/npm.ts
+++ b/lib/integrations/npm.ts
@@ -1,0 +1,274 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// npm public registry + downloads API — both keyless, both rate-limited
+// generously enough for anonymous polling. The two surfaces:
+//   - https://registry.npmjs.org/-/v1/search?text=...&size=N
+//       Returns ranked package metadata (name, version, description,
+//       maintainers, keywords, links, scoreDetail). Used for discovery.
+//   - https://api.npmjs.org/downloads/point/last-week/{package}
+//       Returns { downloads, start, end, package }. Used for the
+//       weekly-downloads badge on each row.
+//
+// The search endpoint exposes a ranking model where the final `score`
+// is a weighted blend of quality / popularity / maintenance. The
+// weights are tunable via `quality=`, `popularity=`, `maintenance=`
+// query params (they must sum to 1.0 — if not, npm normalises silently).
+// "trending" in the column UI maps to popularity-weighted; "quality"
+// maps to quality-weighted; "maintenance" maps to maintenance-weighted;
+// "combined" uses the default balanced weights.
+const REGISTRY_BASE = "https://registry.npmjs.org";
+const DOWNLOADS_BASE = "https://api.npmjs.org";
+
+export type NpmMode = "popularity" | "quality" | "maintenance" | "combined";
+
+export interface NpmMeta {
+  version: string;
+  weeklyDownloads: number;
+  keywords: string[];
+  score: number;
+  scoreDetail: {
+    quality: number;
+    popularity: number;
+    maintenance: number;
+  };
+  publisher?: { username?: string; email?: string };
+  homepage?: string;
+  repository?: string;
+  license?: string;
+  deprecated: boolean;
+}
+
+interface NpmSearchObject {
+  package: {
+    name?: string;
+    scope?: string;
+    version?: string;
+    description?: string;
+    keywords?: string[];
+    date?: string;
+    links?: {
+      npm?: string;
+      homepage?: string;
+      repository?: string;
+      bugs?: string;
+    };
+    publisher?: { username?: string; email?: string };
+    maintainers?: Array<{ username?: string; email?: string }>;
+  };
+  score?: {
+    final?: number;
+    detail?: {
+      quality?: number;
+      popularity?: number;
+      maintenance?: number;
+    };
+  };
+  searchScore?: number;
+  flags?: {
+    insecure?: number;
+    unstable?: boolean;
+    deprecated?: string;
+  };
+}
+
+interface NpmSearchResponse {
+  objects?: NpmSearchObject[];
+  total?: number;
+  time?: string;
+}
+
+interface NpmDownloadsResponse {
+  downloads?: number;
+  start?: string;
+  end?: string;
+  package?: string;
+  error?: string;
+}
+
+function weightsFor(mode: NpmMode): {
+  quality: string;
+  popularity: string;
+  maintenance: string;
+} {
+  // The npm search API requires the three weights to sum to ~1.0. Heavy-
+  // weight the chosen axis to 0.8 and split the remaining 0.2 evenly across
+  // the other two so the resulting ranking is dominated by the intent of
+  // the column without zeroing the other signals (a zeroed axis lets one-
+  // off zombie packages rank highly on the heavy axis).
+  switch (mode) {
+    case "quality":
+      return { quality: "0.8", popularity: "0.1", maintenance: "0.1" };
+    case "maintenance":
+      return { quality: "0.1", popularity: "0.1", maintenance: "0.8" };
+    case "popularity":
+      return { quality: "0.1", popularity: "0.8", maintenance: "0.1" };
+    case "combined":
+    default:
+      // Defaults documented at registry.npmjs.org/-/v1/search — quality 0.65,
+      // popularity 0.98, maintenance 0.5 — which the API renormalises. We
+      // pass them explicitly so the ranking is reproducible across npm's
+      // own weight tweaks.
+      return { quality: "0.65", popularity: "0.98", maintenance: "0.5" };
+  }
+}
+
+function endpointFor(
+  query: string,
+  mode: NpmMode,
+  perPage: number,
+  page: number,
+): string {
+  const params = new URLSearchParams();
+  // npm's search endpoint requires a non-empty `text=` query — there is no
+  // "list all packages" mode. We default the query upstream so the caller
+  // doesn't have to think about it.
+  params.set("text", query.trim() || "javascript");
+  params.set("size", String(Math.min(Math.max(perPage, 1), 250)));
+  params.set("from", String(Math.max(page, 0) * perPage));
+  const w = weightsFor(mode);
+  params.set("quality", w.quality);
+  params.set("popularity", w.popularity);
+  params.set("maintenance", w.maintenance);
+  return `${REGISTRY_BASE}/-/v1/search?${params}`;
+}
+
+function permalinkFor(name: string): string {
+  return `https://www.npmjs.com/package/${name.replace(/^\/+/, "")}`;
+}
+
+function authorOf(obj: NpmSearchObject): {
+  name: string;
+  handle: string;
+  avatarUrl?: string;
+} {
+  // npm exposes `publisher` (the account that pushed the last version) and
+  // `maintainers` (the full ACL list). The publisher is the right "author"
+  // for a feed row — it's whose action produced the version on this page.
+  const publisher = obj.package?.publisher;
+  const handle = publisher?.username?.trim() || "anonymous";
+  const name = handle;
+  // npm exposes gravatar URLs by hashing the publisher email, but the email
+  // field is sometimes withheld. The handle alone is enough — the renderer
+  // builds an identicon fallback when avatarUrl is undefined.
+  return { name, handle };
+}
+
+async function fetchWeeklyDownloads(pkgName: string): Promise<number> {
+  // The downloads endpoint accepts the URL-encoded package name. Scoped
+  // packages (`@scope/name`) need the `/` left raw — encodeURIComponent
+  // turns `/` into `%2F`, which the downloads API rejects with a 404.
+  const url = `${DOWNLOADS_BASE}/downloads/point/last-week/${pkgName}`;
+  try {
+    const res = await fetch(url, {
+      headers: {
+        accept: "application/json",
+        "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      },
+      cache: "no-store",
+    });
+    if (!res.ok) return 0;
+    const json = (await res.json()) as NpmDownloadsResponse;
+    if (json.error) return 0;
+    return Math.max(0, json.downloads ?? 0);
+  } catch {
+    // Network / parse failures degrade silently to 0 — the row still renders
+    // with the rest of the metadata; missing a download count is not a
+    // reason to drop the package from the feed.
+    return 0;
+  }
+}
+
+function mapObject(
+  obj: NpmSearchObject,
+  weeklyDownloads: number,
+): FeedItem<NpmMeta> | null {
+  const pkg = obj.package;
+  // Schema-drift safe: a search result without a name, version, or registry
+  // link is unrenderable, drop it rather than emit a dead row.
+  if (!pkg?.name || !pkg.version) return null;
+
+  const detail = obj.score?.detail ?? {};
+  const description = pkg.description?.trim() || "";
+  const content = description ? `${pkg.name}\n\n${description}` : pkg.name;
+  const createdMs = pkg.date ? Date.parse(pkg.date) : Date.now();
+
+  return {
+    id: pkg.name,
+    author: authorOf(obj),
+    content,
+    url: pkg.links?.npm || permalinkFor(pkg.name),
+    createdAt: new Date(createdMs).toISOString(),
+    meta: {
+      version: pkg.version,
+      weeklyDownloads,
+      keywords: Array.from(
+        new Set((pkg.keywords ?? []).map((k) => k.trim()).filter(Boolean)),
+      ).slice(0, 8),
+      score: obj.score?.final ?? 0,
+      scoreDetail: {
+        quality: detail.quality ?? 0,
+        popularity: detail.popularity ?? 0,
+        maintenance: detail.maintenance ?? 0,
+      },
+      publisher: pkg.publisher
+        ? {
+            username: pkg.publisher.username,
+            email: pkg.publisher.email,
+          }
+        : undefined,
+      homepage: pkg.links?.homepage,
+      repository: pkg.links?.repository,
+      license: undefined,
+      deprecated: typeof obj.flags?.deprecated === "string",
+    },
+  };
+}
+
+export async function fetchNpmPage(
+  query: string,
+  mode: NpmMode,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<NpmMeta>[]; hasMore: boolean }> {
+  const perPage = Math.max(limit, 30);
+  const url = endpointFor(query, mode, perPage, page);
+  const res = await fetch(url, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `npm registry ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+
+  const json = (await res.json()) as NpmSearchResponse;
+  const objects = Array.isArray(json.objects) ? json.objects : [];
+  if (objects.length === 0) {
+    return { items: [], hasMore: false };
+  }
+
+  // Resolve weekly downloads in parallel. A 30-item page = 30 cheap GET
+  // requests — npm's downloads API is fine with that cadence per IP and
+  // the failures degrade to `0` rather than failing the page.
+  const downloads = await Promise.all(
+    objects.map((o) =>
+      o.package?.name ? fetchWeeklyDownloads(o.package.name) : Promise.resolve(0),
+    ),
+  );
+
+  const mapped = objects
+    .map((obj, i) => mapObject(obj, downloads[i] ?? 0))
+    .filter((a): a is FeedItem<NpmMeta> => a !== null);
+
+  // The search endpoint returns `total` so we know whether more pages exist
+  // upstream, but `hasMore` also needs to be true when we trimmed the local
+  // batch. Compare raw count to the requested perPage instead of total —
+  // some queries return fewer than `total` due to ranking filtering.
+  const hasMore = objects.length >= perPage;
+  return { items: mapped.slice(0, limit), hasMore };
+}


### PR DESCRIPTION
## What
41st minitor column type. Surfaces trending and high-signal npm packages — ranked by popularity, quality, maintenance, or a combined blend; scoped via search query. Keyless. The package row shows version, weekly downloads, deprecated badge when applicable, keyword pills, and Q/P/M score detail from npm's own ranking model.

## Why
minitor's audience is predominantly TypeScript/JavaScript developers — aeon, minitor itself, and most active forks are all TS repos — and npm is the canonical discovery surface for that audience. The News & web cluster already has `lobsters`, `stack-overflow`, and `devto` for developer content; an `npm` column closes the gap on package-registry discovery. Natural fit alongside `devto` (also developer-content-focused, landed May-10). Sourced from May-10 repo-actions idea #5.

## Changes
- `lib/columns/plugins/npm/plugin.ts`: schema with two fields (query required, mode oneof popularity / quality / maintenance / combined). Icon `Package` from lucide-react. Accent `#CB3837` (npm registry red). Category `news`. Capabilities: paginated.
- `lib/columns/plugins/npm/server.ts`: `ServerFetcher` → `fetchNpmPage` with PAGE_SIZE cursor-pagination.
- `lib/columns/plugins/npm/client.tsx`: ConfigForm (query input + sort select with help text) and ItemRenderer (npm pill, version, deprecated badge with `AlertTriangle` warning, mono-titled package name, keyword pills, weekly-downloads with `Download` icon + `/wk` suffix, overall score + Q/P/M score-detail pills).
- `lib/integrations/npm.ts`: keyless npm REST APIs (`registry.npmjs.org/-/v1/search` for discovery, `api.npmjs.org/downloads/point/last-week` for the `/wk` badge). Three integration quirks: (1) weights for the four sort modes are heavy-weighted `0.8` on the chosen axis with `0.1` split across the other two — preserves cross-axis signal without zombie-package risk; (2) downloads endpoint rejects `%2F`-encoded scoped names, so `/downloads/point/last-week/{name}` is built with the raw `/` preserved; (3) downloads fetched in parallel per page, failures degrade silently to `0` so a single dead row doesn't kill the column.
- Three registry edits (`manifest.ts`, `registry.ts`, `server-registry.ts`).
- `README.md`: column count 40 → 41, News & web cluster row 7 → 8, hero paragraph picks up "npm packages", keyless-columns list adds npm.

---
*Built autonomously by Aeon*
