### PR TITLE
feat: add PyPI column — 42nd column type, Python package registry companion to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm packages, PyPI packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 41 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, npm packages, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
+- 42 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, npm and PyPI packages, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -41,7 +41,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, npm, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, npm, PyPI, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -60,7 +60,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 |----------|---------|
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
 | **GitHub** (9) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks`, `github-actions` |
-| **News & web** (8) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto`, `npm` |
+| **News & web** (9) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto`, `npm`, `pypi` |
 | **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -45,6 +45,7 @@ import { meta as arxiv } from "./arxiv/plugin";
 import { meta as devto } from "./devto/plugin";
 import { meta as githubActions } from "./github-actions/plugin";
 import { meta as npm } from "./npm/plugin";
+import { meta as pypi } from "./pypi/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -88,6 +89,7 @@ export const PLUGIN_METAS = [
   devto,
   githubActions,
   npm,
+  pypi,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/plugins/pypi/client.tsx
+++ b/lib/columns/plugins/pypi/client.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { Download, Calendar } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import { meta, type PypiConfig, type PypiMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<PypiConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Mode</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as PypiConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="updates">Recent updates</SelectItem>
+            <SelectItem value="new-packages">New packages</SelectItem>
+            <SelectItem value="top-30d">Top · 30 days</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          <strong>Updates</strong> and <strong>New packages</strong> read PyPI's
+          public RSS feeds (last ~40 entries, time-ordered).{" "}
+          <strong>Top · 30d</strong> ranks the top 8000 packages by 30-day
+          downloads via the community-maintained mirror — no API key required.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="pypi-keyword">Keyword filter (optional)</Label>
+        <Input
+          id="pypi-keyword"
+          placeholder="e.g. llm, agent, torch, fastapi"
+          value={value.keyword}
+          onChange={(e) => onChange({ ...value, keyword: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Case-insensitive substring match. Updates/new-packages search title
+          and description; Top · 30d searches the project name only.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<PypiMeta>) {
+  const m = item.meta;
+  const version = m?.version ?? "";
+  const weeklyDownloads = m?.weeklyDownloads ?? 0;
+  const monthlyDownloads = m?.monthlyDownloads ?? 0;
+  const author = m?.author ?? "";
+
+  const [title, ...rest] = item.content.split("\n\n");
+  const description = rest.join("\n\n").trim();
+
+  // Top · 30d rows share a synthetic createdAt (the mirror's last_update)
+  // so relative-time on them is misleading. Detect via the absence of a
+  // version and the absence of a description — that's the rank-feed shape.
+  const isRankFeed = !version && !description;
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(55, 118, 171, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[9px] font-bold leading-none text-white"
+            style={{ backgroundColor: "#3776AB" }}
+          >
+            py
+          </span>
+          PyPI
+        </span>
+        {version && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums text-muted-foreground/90">
+              v{version}
+            </span>
+          </>
+        )}
+        {author && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="text-muted-foreground/90">{author}</span>
+          </>
+        )}
+        {!isRankFeed && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums">
+              <RelativeTime date={item.createdAt} addSuffix />
+            </span>
+          </>
+        )}
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-mono text-[14px] leading-[1.25] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em" }}
+        >
+          {title}
+        </h3>
+      </a>
+      {description && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {description}
+        </p>
+      )}
+      <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11.5px] text-muted-foreground">
+        {weeklyDownloads > 0 && (
+          <span className="flex items-center gap-1">
+            <Download className="size-3.5" />
+            <span className="tabular-nums">
+              {formatCompactCount(weeklyDownloads)}
+            </span>
+            <span className="text-muted-foreground/70">/wk</span>
+          </span>
+        )}
+        {monthlyDownloads > 0 && (
+          <span className="flex items-center gap-1">
+            <Calendar className="size-3.5" />
+            <span className="tabular-nums">
+              {formatCompactCount(monthlyDownloads)}
+            </span>
+            <span className="text-muted-foreground/70">/30d</span>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<PypiConfig, PypiMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/pypi/plugin.ts
+++ b/lib/columns/plugins/pypi/plugin.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { Package2 } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  mode: z.enum(["updates", "new-packages", "top-30d"]).default("updates"),
+  keyword: z.string().default(""),
+});
+
+export type PypiConfig = z.infer<typeof schema>;
+
+export interface PypiMeta {
+  version?: string;
+  monthlyDownloads: number;
+  weeklyDownloads: number;
+  author?: string;
+}
+
+const MODE_LABELS: Record<PypiConfig["mode"], string> = {
+  updates: "Recent updates",
+  "new-packages": "New packages",
+  "top-30d": "Top · 30d",
+};
+
+export const meta: PluginMeta<PypiConfig, PypiMeta> = {
+  id: "pypi",
+  label: "PyPI",
+  description:
+    "Recent Python package updates, newly registered packages, or the top 8000 by 30-day downloads. Optional keyword filter.",
+  icon: Package2,
+  // Python brand blue — the colour used on the python.org navbar and the
+  // Python logo's left-half wing. Distinct from the existing palette:
+  // npm registry red #CB3837, devto indigo #3b49df, github-actions blue
+  // #2088FF, lobsters #ac130d, arxiv #B31B1B. PyPI itself uses the same
+  // blue across pypi.org's accent treatment.
+  accent: "#3776AB",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const kw = c.keyword.trim();
+    if (kw) return `PyPI · ${kw} · ${MODE_LABELS[c.mode]}`;
+    return `PyPI · ${MODE_LABELS[c.mode]}`;
+  },
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/pypi/server.ts
+++ b/lib/columns/plugins/pypi/server.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchPypiPage } from "@/lib/integrations/pypi";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type PypiConfig, type PypiMeta } from "./plugin";
+
+const fetch: ServerFetcher<PypiConfig, PypiMeta> = async (config, cursor) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await fetchPypiPage(config.mode, config.keyword, PAGE_SIZE, page);
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<PypiConfig, PypiMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -53,6 +53,7 @@ import { column as arxiv } from "@/lib/columns/plugins/arxiv/client";
 import { column as devto } from "@/lib/columns/plugins/devto/client";
 import { column as githubActions } from "@/lib/columns/plugins/github-actions/client";
 import { column as npm } from "@/lib/columns/plugins/npm/client";
+import { column as pypi } from "@/lib/columns/plugins/pypi/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -99,6 +100,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   devto,
   "github-actions": githubActions,
   npm,
+  pypi,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -49,6 +49,7 @@ import { server as arxiv } from "@/lib/columns/plugins/arxiv/server";
 import { server as devto } from "@/lib/columns/plugins/devto/server";
 import { server as githubActions } from "@/lib/columns/plugins/github-actions/server";
 import { server as npm } from "@/lib/columns/plugins/npm/server";
+import { server as pypi } from "@/lib/columns/plugins/pypi/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -92,6 +93,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   devto,
   "github-actions": githubActions,
   npm,
+  pypi,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/pypi.ts
+++ b/lib/integrations/pypi.ts
@@ -1,0 +1,322 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// PyPI exposes three keyless surfaces this column draws from:
+//
+//   - https://pypi.org/rss/updates.xml
+//       RSS 2.0 feed of the ~40 most-recent package updates. Each item
+//       carries title (`{name} {version}`), description (summary line),
+//       author (PyPI user), link (project page), pubDate. Used for the
+//       `updates` mode.
+//
+//   - https://pypi.org/rss/packages.xml
+//       RSS 2.0 feed of the ~40 most-recently registered packages.
+//       Same shape as updates, but title is `{name}` (no version yet).
+//       Used for the `new-packages` mode.
+//
+//   - https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json
+//       Community-maintained mirror of the BigQuery-backed PyPI download
+//       stats. JSON shape: `{ last_update, query, rows: [{project,
+//       download_count}, ...] }`. Updated daily; the top 8000 packages
+//       are kept. Used for the `top-30d` mode — the only "trending"
+//       surface PyPI itself doesn't expose.
+//
+//   - https://pypistats.org/api/packages/{name}/recent
+//       Keyless weekly/monthly download stats. Used for the weekly-
+//       downloads badge on each row. Failures degrade silently to 0.
+//
+// PyPI's terms-of-use ask consumers to identify themselves with a
+// descriptive User-Agent; we send `minitor/1.0 (+url)`.
+
+const RSS_BASE = "https://pypi.org/rss";
+const TOP_PACKAGES_URL =
+  "https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json";
+const STATS_BASE = "https://pypistats.org/api/packages";
+const PYPI_PROJECT_BASE = "https://pypi.org/project";
+
+const UA = "minitor/1.0 (+https://github.com/aaronjmars/minitor)";
+
+export type PypiMode = "updates" | "new-packages" | "top-30d";
+
+export interface PypiMeta {
+  /** Version string when known (always for updates, never for new-packages). */
+  version?: string;
+  /** 30-day downloads when known (top-30d mode); 0 otherwise. */
+  monthlyDownloads: number;
+  /** Last-week downloads via pypistats.org; 0 on failure. */
+  weeklyDownloads: number;
+  /** PyPI author/maintainer login if surfaced by the feed. */
+  author?: string;
+}
+
+interface RssItem {
+  title: string;
+  link: string;
+  description: string;
+  author: string;
+  pubDate: string;
+}
+
+function stripCdata(s: string): string {
+  return s.replace(/^<!\[CDATA\[([\s\S]*?)\]\]>$/m, "$1").trim();
+}
+
+function decodeEntities(s: string): string {
+  // RSS bodies are HTML-encoded; decode the entities we care about.
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
+function extractTag(block: string, tag: string): string {
+  // PyPI's RSS is well-formed and unnested per tag — a single regex per tag
+  // is enough. We accept either bare text or a CDATA-wrapped body.
+  const re = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, "i");
+  const m = block.match(re);
+  if (!m) return "";
+  return decodeEntities(stripCdata(m[1]));
+}
+
+function parseRss(xml: string): RssItem[] {
+  const out: RssItem[] = [];
+  // Split on item boundaries — the RSS body wraps every entry in `<item>...</item>`.
+  const blocks = xml.split(/<item>/i).slice(1);
+  for (const raw of blocks) {
+    const closeIdx = raw.indexOf("</item>");
+    const block = closeIdx >= 0 ? raw.slice(0, closeIdx) : raw;
+    const title = extractTag(block, "title");
+    const link = extractTag(block, "link");
+    if (!title || !link) continue;
+    out.push({
+      title,
+      link,
+      description: extractTag(block, "description"),
+      author: extractTag(block, "author"),
+      pubDate: extractTag(block, "pubDate"),
+    });
+  }
+  return out;
+}
+
+interface PypiStatsResponse {
+  data?: { last_day?: number; last_week?: number; last_month?: number };
+  package?: string;
+  type?: string;
+}
+
+interface TopPackagesResponse {
+  last_update?: string;
+  query?: { from?: string; to?: string };
+  rows?: Array<{ project?: string; download_count?: number }>;
+}
+
+async function fetchWeeklyDownloads(pkgName: string): Promise<number> {
+  // Pypistats.org is a thin proxy over the BigQuery-backed `pypi-public`
+  // dataset. Public, keyless, polite to call once per row. Failures
+  // degrade silently to 0; the column still renders without the badge.
+  const url = `${STATS_BASE}/${encodeURIComponent(pkgName.toLowerCase())}/recent?period=week`;
+  try {
+    const res = await fetch(url, {
+      headers: { accept: "application/json", "user-agent": UA },
+      cache: "no-store",
+    });
+    if (!res.ok) return 0;
+    const json = (await res.json()) as PypiStatsResponse;
+    return Math.max(0, json.data?.last_week ?? 0);
+  } catch {
+    return 0;
+  }
+}
+
+function permalinkFor(name: string): string {
+  return `${PYPI_PROJECT_BASE}/${name.toLowerCase().replace(/^\/+/, "")}/`;
+}
+
+function parseUpdateTitle(title: string): { name: string; version?: string } {
+  // The updates feed uses `{name} {version}` (whitespace separator). New-
+  // packages feed uses just `{name}`. The package name itself can contain
+  // hyphens and underscores but never spaces, so the first space splits
+  // cleanly.
+  const trimmed = title.trim();
+  const spaceIdx = trimmed.indexOf(" ");
+  if (spaceIdx < 0) return { name: trimmed };
+  const name = trimmed.slice(0, spaceIdx);
+  const version = trimmed.slice(spaceIdx + 1).trim();
+  return { name, version: version || undefined };
+}
+
+function rssItemToFeedItem(
+  item: RssItem,
+  weeklyDownloads: number,
+): FeedItem<PypiMeta> | null {
+  const { name, version } = parseUpdateTitle(item.title);
+  if (!name) return null;
+
+  const summary = item.description.trim();
+  const content = summary ? `${item.title}\n\n${summary}` : item.title;
+  const created = item.pubDate
+    ? new Date(item.pubDate).toISOString()
+    : new Date().toISOString();
+  const author = item.author.trim() || undefined;
+
+  return {
+    id: `${name.toLowerCase()}@${version ?? "new"}@${created}`,
+    author: { name: author ?? name, handle: author },
+    content,
+    url: item.link || permalinkFor(name),
+    createdAt: created,
+    meta: {
+      version,
+      monthlyDownloads: 0,
+      weeklyDownloads,
+      author,
+    },
+  };
+}
+
+async function fetchRssMode(
+  feed: "updates" | "packages",
+  keyword: string,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<PypiMeta>[]; hasMore: boolean }> {
+  const url = `${RSS_BASE}/${feed}.xml`;
+  const res = await fetch(url, {
+    headers: {
+      accept: "application/rss+xml,application/xml;q=0.9,*/*;q=0.5",
+      "user-agent": UA,
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(
+      `PyPI ${feed} feed ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const xml = await res.text();
+  const all = parseRss(xml);
+
+  // Optional keyword filter — substring match on title OR description,
+  // case-insensitive. Applied before pagination so the page count
+  // reflects the filtered slice, not the raw feed.
+  const kw = keyword.trim().toLowerCase();
+  const filtered = kw
+    ? all.filter((i) => {
+        const hay = `${i.title} ${i.description}`.toLowerCase();
+        return hay.includes(kw);
+      })
+    : all;
+
+  // Page through the feed — RSS itself returns at most ~40, so pages
+  // beyond the first are usually empty. We still honour the cursor so
+  // the UI's "Load more" stays consistent across column types.
+  const start = Math.max(page, 0) * limit;
+  const slice = filtered.slice(start, start + limit);
+
+  // Enrich each row with weekly downloads (parallel). Failures degrade
+  // to 0; we don't drop a row for a missing stats response.
+  const downloads = await Promise.all(
+    slice.map((i) => {
+      const { name } = parseUpdateTitle(i.title);
+      return name ? fetchWeeklyDownloads(name) : Promise.resolve(0);
+    }),
+  );
+
+  const items = slice
+    .map((i, idx) => rssItemToFeedItem(i, downloads[idx] ?? 0))
+    .filter((x): x is FeedItem<PypiMeta> => x !== null);
+
+  return { items, hasMore: start + limit < filtered.length };
+}
+
+async function fetchTopMode(
+  keyword: string,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<PypiMeta>[]; hasMore: boolean }> {
+  // Top 8000 packages, ranked by 30-day downloads, updated daily by the
+  // hugovk/top-pypi-packages mirror. Keyless, served via GitHub Pages.
+  // The full JSON is ~250KB; cache aggressively via `cache: "force-cache"`
+  // and rely on Next.js's HTTP cache to dedupe across columns/requests.
+  const res = await fetch(TOP_PACKAGES_URL, {
+    headers: { accept: "application/json", "user-agent": UA },
+    cache: "force-cache",
+    next: { revalidate: 3600 },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `top-pypi-packages ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const json = (await res.json()) as TopPackagesResponse;
+  const rows = Array.isArray(json.rows) ? json.rows : [];
+
+  // Optional keyword filter — substring match on project name, case-
+  // insensitive. Top-mode has no description, only names, so the filter
+  // is name-only.
+  const kw = keyword.trim().toLowerCase();
+  const filtered = kw
+    ? rows.filter((r) => (r.project ?? "").toLowerCase().includes(kw))
+    : rows;
+
+  const start = Math.max(page, 0) * limit;
+  const slice = filtered.slice(start, start + limit);
+
+  // Enrich with weekly downloads in parallel — the badge converts the
+  // monthly number into a more digestible weekly figure that matches
+  // the npm column's badge convention.
+  const downloads = await Promise.all(
+    slice.map((r) =>
+      r.project ? fetchWeeklyDownloads(r.project) : Promise.resolve(0),
+    ),
+  );
+
+  // Generate a synthetic createdAt from the mirror's last_update — every
+  // row in this slice ranks against the same 30-day window, so they
+  // share a timestamp. The renderer hides relative time when the value
+  // is the mirror's mtime (rank-based feeds aren't time-ordered).
+  const updatedAt = json.last_update
+    ? new Date(json.last_update).toISOString()
+    : new Date().toISOString();
+
+  const items: FeedItem<PypiMeta>[] = slice
+    .map((r, idx) => {
+      const name = r.project?.trim();
+      if (!name) return null;
+      return {
+        id: `${name.toLowerCase()}@top-30d`,
+        author: { name },
+        content: name,
+        url: permalinkFor(name),
+        createdAt: updatedAt,
+        meta: {
+          monthlyDownloads: Math.max(0, r.download_count ?? 0),
+          weeklyDownloads: downloads[idx] ?? 0,
+        },
+      } satisfies FeedItem<PypiMeta>;
+    })
+    .filter((x): x is FeedItem<PypiMeta> => x !== null);
+
+  return { items, hasMore: start + limit < filtered.length };
+}
+
+export async function fetchPypiPage(
+  mode: PypiMode,
+  keyword: string,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<PypiMeta>[]; hasMore: boolean }> {
+  switch (mode) {
+    case "new-packages":
+      return fetchRssMode("packages", keyword, limit, page);
+    case "top-30d":
+      return fetchTopMode(keyword, limit, page);
+    case "updates":
+    default:
+      return fetchRssMode("updates", keyword, limit, page);
+  }
+}


### PR DESCRIPTION
## What

42nd column type — a **PyPI** column. Three modes: `updates` (recent package releases via RSS), `new-packages` (newly registered via RSS), `top-30d` (top 8000 packages ranked by 30-day downloads via the community mirror). Optional keyword filter, optional weekly-downloads badge via `pypistats.org`.

## Why

npm shipped May 12 as the 41st column — JavaScript ecosystem covered. PyPI is the natural pair: same package-registry pattern, Python ecosystem audience. Together they bracket the two registries that the AI / ML research crowd already lives in. Both keyless, both polite to anonymous polling.

The May-12 repo-actions article proposed Reddit and Bluesky as the next minitor columns — but **both already exist in the manifest**. The article was wrong about what was missing. PyPI is the actual highest-impact gap given the May-12 npm precedent and the existing AI/ML cluster (huggingface artifacts, arxiv papers — but no Python package registry).

## Changes

### Files added
- **`lib/integrations/pypi.ts`** — three keyless source surfaces:
  - `pypi.org/rss/updates.xml` — RSS 2.0 feed of recent package releases (~40 entries, time-ordered with version bump info).
  - `pypi.org/rss/packages.xml` — RSS 2.0 feed of newly registered packages.
  - `hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json` — community-maintained mirror of the BigQuery-backed download stats, top 8000 packages, updated daily. The only "trending" surface PyPI itself doesn't expose.
  - `pypistats.org/api/packages/{name}/recent?period=week` — keyless weekly-downloads badge enrichment, parallel-fetched per row.
- **`lib/columns/plugins/pypi/plugin.ts`** — metadata (`id`, `label`, `accent #3776AB`, `Package2` icon, `news` category, Zod schema with `mode` + `keyword`).
- **`lib/columns/plugins/pypi/server.ts`** — standard `defineColumnServer` wrapper around `fetchPypiPage`.
- **`lib/columns/plugins/pypi/client.tsx`** — `ConfigForm` (mode select + keyword input) and `ItemRenderer` (PyPI brand pill, version badge, author handle, line-clamped description, weekly + monthly downloads).

### Files modified
- **`lib/columns/plugins/manifest.ts`** — registered `pypi` meta.
- **`lib/columns/registry.ts`** — client-side UI map.
- **`lib/columns/server-registry.ts`** — server-side fetcher map (init-time parity check picks it up).
- **`README.md`** — News & web cluster `(8)` → `(9)`, column count `41` → `42`, hero paragraph mentions PyPI, keyless-columns list includes PyPI.

## How it works

The integration is structured around three mode handlers sharing one set of helpers:

- **RSS modes (`updates`, `new-packages`)** — fetch the XML feed, parse with a small CDATA-aware tag extractor (no XML library dependency added), apply optional keyword filter, slice for pagination, enrich each row with weekly downloads in parallel.
- **`top-30d` mode** — fetch the JSON mirror with `cache: "force-cache"` + `next.revalidate: 3600` (data updates daily, hourly cache is plenty). Apply optional name-only keyword filter, slice for pagination, parallel-enrich weekly downloads.
- **All modes** use a single `User-Agent: minitor/1.0 (+url)` per PyPI's TOS request to identify anonymous clients.

## Integration quirks (documented in source)

1. PyPI's `updates` feed wraps title as `{name} {version}` (space-separated) while `new-packages` uses just `{name}` — `parseUpdateTitle` handles both shapes.
2. The `top-30d` rank-feed's `createdAt` is the mirror's `last_update`, which is misleading as relative-time (every row in the slice shares the same timestamp). The renderer detects rank rows via the absence of version + description and suppresses the time pill.
3. `pypistats.org` weekly-downloads failures degrade silently to 0 — a single dead row never kills the page.

## Visual

PyPI brand blue `#3776AB` (matches python.org navbar and the Python logo's left-half wing). Distinct from the existing palette: npm registry red `#CB3837`, devto indigo `#3b49df`, github-actions blue `#2088FF`, arxiv `#B31B1B`. `Package2` icon — distinct from npm's `Package` so the two columns are differentiated at a glance.

---
*Built autonomously by Aeon*
