### PR TITLE
fix(substack): accept custom-domain Substacks (pluralistic.net, astralcodexten.com)

### DIFF
--- a/lib/columns/plugins/substack/client.tsx
+++ b/lib/columns/plugins/substack/client.tsx
@@ -18,16 +18,18 @@ function ConfigForm({ value, onChange }: ConfigFormProps<SubstackConfig>) {
         <Label htmlFor="sub-handles">Publications (optional)</Label>
         <Textarea
           id="sub-handles"
-          placeholder={"mattyglesias\nslowboring\nstratechery.com"}
+          placeholder={"mattyglesias\nslowboring\npluralistic.net"}
           value={value.handles}
           onChange={(e) => onChange({ ...value, handles: e.target.value })}
           rows={3}
         />
         <p className="text-xs text-muted-foreground">
           One per line, or comma-separated. Use the handle (
-          <code>mattyglesias</code>) or full URL (
-          <code>slowboring.substack.com</code>). Per-publication RSS is keyless.
-          Leave empty to search all of Substack via xAI web search.
+          <code>mattyglesias</code>), the full Substack URL (
+          <code>slowboring.substack.com</code>), or a custom-domain Substack (
+          <code>pluralistic.net</code>, <code>astralcodexten.com</code>) —
+          anything that exposes <code>/feed</code>. Per-publication RSS is
+          keyless. Leave empty to search all of Substack via xAI web search.
         </p>
       </div>
       <div className="grid gap-1.5">

--- a/lib/integrations/substack.ts
+++ b/lib/integrations/substack.ts
@@ -21,7 +21,11 @@ import { identiconUrl } from "@/lib/utils";
 export type { SubstackMeta };
 
 export interface ParsedHandle {
+  // Display label — bare handle for `.substack.com` subdomains, full host for
+  // custom domains (e.g. `pluralistic.net`, `astralcodexten.com`).
   handle: string;
+  // Canonical hostname used for the feed URL and for `publication` in meta.
+  host: string;
   feedUrl: string;
 }
 
@@ -31,23 +35,45 @@ export function parseHandles(input: string): ParsedHandle[] {
   for (const raw of input.split(/[\s,]+/)) {
     const piece = raw.trim();
     if (!piece) continue;
-    const handle = handleFromInput(piece);
-    if (!handle || seen.has(handle)) continue;
-    seen.add(handle);
-    out.push({ handle, feedUrl: `https://${handle}.substack.com/feed` });
+    const parsed = handleFromInput(piece);
+    if (!parsed || seen.has(parsed.host)) continue;
+    seen.add(parsed.host);
+    out.push({ ...parsed, feedUrl: `https://${parsed.host}/feed` });
   }
   return out;
 }
 
-function handleFromInput(s: string): string | null {
+function handleFromInput(
+  s: string,
+): { handle: string; host: string } | null {
   const lower = s.toLowerCase();
-  // Full URL or bare host: extract the subdomain before .substack.com.
-  const urlMatch = lower.match(
+  // Full URL or bare host on .substack.com → bare handle, canonical host.
+  const subMatch = lower.match(
     /^(?:https?:\/\/)?([a-z0-9-]+)\.substack\.com\b/,
   );
-  if (urlMatch) return urlMatch[1];
+  if (subMatch) {
+    const handle = subMatch[1];
+    return { handle, host: `${handle}.substack.com` };
+  }
+  // Custom domain — many popular Substacks (astralcodexten.com,
+  // pluralistic.net, noahpinion.blog, every.to) live on their own
+  // hostname. They still expose `/feed` so the same fetch path works.
+  // Accept any URL or bare host with at least one dot in the body of the
+  // hostname; strip a leading `www.` for canonicalisation.
+  const urlMatch = lower.match(
+    /^(?:https?:\/\/)?(?:www\.)?([a-z0-9-]+(?:\.[a-z0-9-]+)+)(?:[\/?#]|$)/,
+  );
+  if (urlMatch) {
+    const host = urlMatch[1];
+    // Defensive: reject `substack.com` bare (no publication) and anything
+    // ending in a leading `.` from the regex.
+    if (host === "substack.com" || host.startsWith(".")) return null;
+    return { handle: host, host };
+  }
   // Plain handle. Allow alphanumerics and hyphens; reject anything else.
-  if (/^[a-z0-9][a-z0-9-]*$/.test(lower)) return lower;
+  if (/^[a-z0-9][a-z0-9-]*$/.test(lower)) {
+    return { handle: lower, host: `${lower}.substack.com` };
+  }
   return null;
 }
 
@@ -91,11 +117,9 @@ export async function searchSubstackPublications(
   if (handles.length === 0) return [];
 
   const results = await Promise.allSettled(
-    handles.map(async ({ handle, feedUrl }) => {
+    handles.map(async ({ host, feedUrl }) => {
       const items = await fetchFeed(feedUrl, perFeed);
-      return items.map((item) =>
-        tagWithPublication(item, handle, feedUrl),
-      );
+      return items.map((item) => tagWithPublication(item, host, feedUrl));
     }),
   );
 
@@ -167,10 +191,10 @@ export async function searchSubstackByKeyword(
 
 function tagWithPublication(
   item: FeedItem,
-  handle: string,
+  host: string,
   feedUrl: string,
 ): FeedItem<SubstackMeta> {
-  const publication = `${handle}.substack.com`;
+  const publication = host;
   const prevMeta = item.meta as { source?: string; feedTitle?: string } | undefined;
   const feedTitle = prevMeta?.feedTitle ?? publication;
   const source = prevMeta?.source ?? feedTitle;


### PR DESCRIPTION
## Summary
The Substack column dropped custom-domain Substacks silently — pasting `pluralistic.net`, `astralcodexten.com`, or `noahpinion.blog` parsed as `null` and produced no feed. The placeholder hint even suggested `stratechery.com`, which (a) isn't on Substack and (b) would have been rejected anyway.

Custom-domain Substacks expose the same `/feed` RSS endpoint, so the fetch path already worked — only the input parser and dedup were limited to `*.substack.com`.

## Changes
- `lib/integrations/substack.ts`
  - `ParsedHandle` carries `host` (canonical hostname for the feed) in addition to `handle` (display label). Substack subdomains keep the bare slug as handle; custom domains use the host as both.
  - `handleFromInput` accepts any URL/host with a valid hostname, strips a leading `www.`, and defensively rejects bare `substack.com`.
  - `parseHandles` dedups by host so `mattyglesias` and `mattyglesias.substack.com` collapse to one feed.
  - `tagWithPublication` uses the real host for `publication` / author `handle`, so meta and the renderer reflect the actual publication.
- `lib/columns/plugins/substack/client.tsx`
  - Placeholder swapped from non-Substack `stratechery.com` → `pluralistic.net` (real custom-domain Substack).
  - Help text documents the custom-domain case alongside handle + URL.

## Context
Spotted while reading the Substack plugin end-to-end against the README's promise of "Substack publications you trust." Two of the most-cited Substacks in the wild (Cory Doctorow's Pluralistic, Scott Alexander's ACX) use custom domains; the column silently refusing them is a real footgun. Behaviour for existing `.substack.com` inputs is unchanged.

## Verification
- `npx tsc --noEmit -p tsconfig.json` clean.
- Out-of-tree node script ran the parser against 14 cases (bare handle, full subdomain URL, custom domain bare, custom domain w/ `https://`, `www.` prefix, URL with path, dedup of handle + URL across the same publication, rejection of bare `substack.com` / empty / junk) — all green.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)