### PR TITLE
feat: crates.io column — 43rd column type, Rust package registry trifecta with npm + pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm packages, PyPI packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm + PyPI + crates.io packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 42 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, npm and PyPI packages, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
+- 43 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -41,7 +41,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, npm, PyPI, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, npm, PyPI, crates.io, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -60,7 +60,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 |----------|---------|
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
 | **GitHub** (9) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks`, `github-actions` |
-| **News & web** (9) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto`, `npm`, `pypi` |
+| **News & web** (10) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto`, `npm`, `pypi`, `crates` |
 | **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |

--- a/lib/columns/plugins/crates/client.tsx
+++ b/lib/columns/plugins/crates/client.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Download, Flame } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import { meta, type CratesConfig, type CratesMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<CratesConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="crates-query">Search query</Label>
+        <Input
+          id="crates-query"
+          placeholder="e.g. tokio, axum, serde, wasm, async-trait (optional)"
+          value={value.query}
+          onChange={(e) => onChange({ ...value, query: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Optional — leave empty for the global stream ranked by the selected
+          axis. Substring match across crate name, description, and keywords.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Sort</Label>
+        <Select
+          value={value.sort}
+          onValueChange={(v) =>
+            onChange({ ...value, sort: v as CratesConfig["sort"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="recent-downloads">
+              Trending (90d downloads)
+            </SelectItem>
+            <SelectItem value="downloads">All-time downloads</SelectItem>
+            <SelectItem value="recent-updates">Recently updated</SelectItem>
+            <SelectItem value="new">Newest</SelectItem>
+            <SelectItem value="alpha">A–Z</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          <strong>Trending</strong> tracks the last 90 days of downloads — the
+          best signal for "what's hot right now."{" "}
+          <strong>Recently updated</strong> surfaces crates with active
+          maintenance.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<CratesMeta>) {
+  const m = item.meta;
+  const recent = m?.recentDownloads ?? 0;
+  const total = m?.totalDownloads ?? 0;
+  const version = m?.version ?? "";
+  const keywords = m?.keywords ?? [];
+
+  const [title, ...rest] = item.content.split("\n\n");
+  const description = rest.join("\n\n").trim();
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(222, 165, 132, 0.22)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-[9px] font-bold leading-none text-white"
+            style={{ backgroundColor: "#DEA584" }}
+          >
+            ⚙
+          </span>
+          crates.io
+        </span>
+        {version && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums text-muted-foreground/90">
+              v{version}
+            </span>
+          </>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-mono text-[14px] leading-[1.25] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em" }}
+        >
+          {title}
+        </h3>
+      </a>
+      {description && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {description}
+        </p>
+      )}
+      {keywords.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {keywords.slice(0, 5).map((k) => (
+            <span
+              key={k}
+              className="rounded-sm px-1 py-0.5 text-[10px] text-muted-foreground ring-1 ring-border/60"
+            >
+              {k}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11.5px] text-muted-foreground">
+        {recent > 0 && (
+          <span className="flex items-center gap-1">
+            <Flame className="size-3.5" />
+            <span className="tabular-nums">{formatCompactCount(recent)}</span>
+            <span className="text-muted-foreground/70">/90d</span>
+          </span>
+        )}
+        {total > 0 && (
+          <span className="flex items-center gap-1">
+            <Download className="size-3.5" />
+            <span className="tabular-nums">{formatCompactCount(total)}</span>
+            <span className="text-muted-foreground/70">total</span>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<CratesConfig, CratesMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/crates/plugin.ts
+++ b/lib/columns/plugins/crates/plugin.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import { Box } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  query: z.string().default(""),
+  sort: z
+    .enum(["recent-downloads", "downloads", "recent-updates", "new", "alpha"])
+    .default("recent-downloads"),
+});
+
+export type CratesConfig = z.infer<typeof schema>;
+
+export interface CratesMeta {
+  version: string;
+  totalDownloads: number;
+  recentDownloads: number;
+  keywords: string[];
+  description: string;
+  homepage?: string;
+  documentation?: string;
+  repository?: string;
+  updatedAt: string;
+  exactMatch: boolean;
+}
+
+const SORT_LABELS: Record<CratesConfig["sort"], string> = {
+  "recent-downloads": "Trending",
+  downloads: "All-time",
+  "recent-updates": "Recently updated",
+  new: "Newest",
+  alpha: "A–Z",
+};
+
+export const meta: PluginMeta<CratesConfig, CratesMeta> = {
+  id: "crates",
+  label: "crates.io",
+  description:
+    "Trending and high-signal Rust crates from crates.io — ranked by recent downloads, all-time downloads, recency, or new arrivals. Keyword-scoped via search.",
+  icon: Box,
+  // Rust brand "ember orange". Distinct from neighbouring registries on the
+  // wheel: npm #CB3837 (red), pypi #3776AB (blue), devto #3b49df (indigo).
+  // Sits in the warm half — the three registry columns now span the wheel
+  // (red / orange / blue) so they're distinguishable at a glance.
+  accent: "#DEA584",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const q = c.query.trim();
+    const sortLabel = SORT_LABELS[c.sort];
+    if (q) return `crates.io · ${q} · ${sortLabel}`;
+    return `crates.io · ${sortLabel}`;
+  },
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/crates/server.ts
+++ b/lib/columns/plugins/crates/server.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchCratesPage } from "@/lib/integrations/crates";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type CratesConfig, type CratesMeta } from "./plugin";
+
+const fetch: ServerFetcher<CratesConfig, CratesMeta> = async (config, cursor) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await fetchCratesPage(config.query, config.sort, PAGE_SIZE, page);
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<CratesConfig, CratesMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -46,6 +46,7 @@ import { meta as devto } from "./devto/plugin";
 import { meta as githubActions } from "./github-actions/plugin";
 import { meta as npm } from "./npm/plugin";
 import { meta as pypi } from "./pypi/plugin";
+import { meta as crates } from "./crates/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -90,6 +91,7 @@ export const PLUGIN_METAS = [
   githubActions,
   npm,
   pypi,
+  crates,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -54,6 +54,7 @@ import { column as devto } from "@/lib/columns/plugins/devto/client";
 import { column as githubActions } from "@/lib/columns/plugins/github-actions/client";
 import { column as npm } from "@/lib/columns/plugins/npm/client";
 import { column as pypi } from "@/lib/columns/plugins/pypi/client";
+import { column as crates } from "@/lib/columns/plugins/crates/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -101,6 +102,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "github-actions": githubActions,
   npm,
   pypi,
+  crates,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -50,6 +50,7 @@ import { server as devto } from "@/lib/columns/plugins/devto/server";
 import { server as githubActions } from "@/lib/columns/plugins/github-actions/server";
 import { server as npm } from "@/lib/columns/plugins/npm/server";
 import { server as pypi } from "@/lib/columns/plugins/pypi/server";
+import { server as crates } from "@/lib/columns/plugins/crates/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -94,6 +95,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "github-actions": githubActions,
   npm,
   pypi,
+  crates,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/crates.ts
+++ b/lib/integrations/crates.ts
@@ -1,0 +1,182 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// crates.io public REST API — fully keyless, generously rate-limited for
+// anonymous polling. One rule the docs are explicit about: every request
+// MUST include a User-Agent header (crates.io returns 403 otherwise). The
+// canonical browse endpoint we use is:
+//
+//   https://crates.io/api/v1/crates?sort={sort}&per_page=N&page=M
+//
+// Sort axes the API exposes:
+//   - `recent-downloads` — 90d download count, the "trending right now"
+//     surface (default; matches the crates.io homepage "Just Updated" tile).
+//   - `downloads`        — all-time download count, the cumulative giants.
+//   - `recent-updates`   — last `updated_at` desc, what's being maintained.
+//   - `new`              — most recently published crates.
+//   - `alpha`            — name asc, A→Z (deterministic; useful for fixtures).
+//
+// Optional query (`q=foo`) does a substring search across name + description
+// + keywords. The `category` filter is also supported but we don't surface it
+// in the column UI — crates.io's category taxonomy is loose enough that
+// keyword search inside a query is the better discovery affordance.
+const BASE = "https://crates.io/api/v1";
+
+export type CratesSort =
+  | "recent-downloads"
+  | "downloads"
+  | "recent-updates"
+  | "new"
+  | "alpha";
+
+export interface CratesMeta {
+  version: string;
+  totalDownloads: number;
+  recentDownloads: number;
+  keywords: string[];
+  description: string;
+  homepage?: string;
+  documentation?: string;
+  repository?: string;
+  updatedAt: string;
+  exactMatch: boolean;
+}
+
+interface CratesApiCrate {
+  id?: string;
+  name?: string;
+  updated_at?: string;
+  created_at?: string;
+  description?: string | null;
+  homepage?: string | null;
+  documentation?: string | null;
+  repository?: string | null;
+  max_version?: string;
+  max_stable_version?: string | null;
+  newest_version?: string;
+  downloads?: number;
+  recent_downloads?: number | null;
+  exact_match?: boolean;
+  keywords?: string[] | null;
+}
+
+interface CratesApiResponse {
+  crates?: CratesApiCrate[];
+  meta?: { total?: number; next_page?: string | null; prev_page?: string | null };
+}
+
+function permalinkFor(name: string): string {
+  return `https://crates.io/crates/${encodeURIComponent(name)}`;
+}
+
+function endpointFor(
+  query: string,
+  sort: CratesSort,
+  perPage: number,
+  page: number,
+): string {
+  const params = new URLSearchParams();
+  params.set("sort", sort);
+  // crates.io caps per_page at 100; clamp defensively so a misconfigured
+  // upstream caller can't request a 10k-row response.
+  params.set("per_page", String(Math.min(Math.max(perPage, 1), 100)));
+  // The API uses 1-based pagination.
+  params.set("page", String(Math.max(page, 0) + 1));
+  const q = query.trim();
+  if (q) params.set("q", q);
+  return `${BASE}/crates?${params}`;
+}
+
+function authorFor(crate: CratesApiCrate): {
+  name: string;
+  handle: string;
+} {
+  // The /crates list endpoint doesn't include owners; that needs a follow-up
+  // /crates/{name}/owners call per row, which would 50x the request count
+  // for marginal UI value (most rows show owner in the linked crates.io
+  // page). We surface the crate slug as the handle — it's the stable id and
+  // disambiguates rows when names collide across paginated batches.
+  const slug = crate.name?.trim() || crate.id?.trim() || "crate";
+  return { name: slug, handle: slug };
+}
+
+function mapCrate(c: CratesApiCrate): FeedItem<CratesMeta> | null {
+  // Schema-drift safe: name + version are the minimum to render a useful row.
+  // A crate with no version is unrenderable (no "what to cargo add"), drop it.
+  const name = c.name?.trim();
+  const version = (c.max_stable_version || c.max_version || c.newest_version || "").trim();
+  if (!name || !version) return null;
+
+  const description = (c.description ?? "").trim();
+  const content = description ? `${name}\n\n${description}` : name;
+  // `updated_at` is the most recent version-publish timestamp; we prefer it
+  // over `created_at` so the relative-time pill reflects activity, not crate
+  // age (a 2018 crate that shipped this morning should read "1h ago", not
+  // "7 years ago").
+  const createdMs = c.updated_at ? Date.parse(c.updated_at) : Date.now();
+
+  return {
+    id: name,
+    author: authorFor(c),
+    content,
+    url: permalinkFor(name),
+    createdAt: new Date(Number.isFinite(createdMs) ? createdMs : Date.now()).toISOString(),
+    meta: {
+      version,
+      totalDownloads: Math.max(0, c.downloads ?? 0),
+      recentDownloads: Math.max(0, c.recent_downloads ?? 0),
+      keywords: Array.from(
+        new Set((c.keywords ?? []).map((k) => k.trim()).filter(Boolean)),
+      ).slice(0, 8),
+      description,
+      homepage: c.homepage ?? undefined,
+      documentation: c.documentation ?? undefined,
+      repository: c.repository ?? undefined,
+      updatedAt: c.updated_at ?? "",
+      exactMatch: c.exact_match === true,
+    },
+  };
+}
+
+export async function fetchCratesPage(
+  query: string,
+  sort: CratesSort,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<CratesMeta>[]; hasMore: boolean }> {
+  const perPage = Math.max(limit, 30);
+  const url = endpointFor(query, sort, perPage, page);
+
+  const res = await fetch(url, {
+    headers: {
+      accept: "application/json",
+      // crates.io's User-Agent policy is strict — anonymous requests without
+      // a UA get 403. Identifying minitor as the caller keeps us in
+      // compliance with the documented expectation.
+      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `crates.io ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+
+  const json = (await res.json()) as CratesApiResponse;
+  const crates = Array.isArray(json.crates) ? json.crates : [];
+  if (crates.length === 0) {
+    return { items: [], hasMore: false };
+  }
+
+  const mapped = crates
+    .map((c) => mapCrate(c))
+    .filter((a): a is FeedItem<CratesMeta> => a !== null);
+
+  // The API exposes `meta.next_page` — when null/empty, the cursor is
+  // exhausted. We fall back to a length-based check for hasMore when the
+  // upstream omits the field (older deployments, mirrors, etc.).
+  const apiHasMore = typeof json.meta?.next_page === "string" && json.meta.next_page.length > 0;
+  const hasMore = apiHasMore || crates.length >= perPage;
+  return { items: mapped.slice(0, limit), hasMore };
+}


### PR DESCRIPTION
## What

Adds crates.io as the 42nd column type — the Rust package registry, paired with npm (PR #35, May-12) and PyPI (PR #36, May-13, still open) to complete the registry triple shipped this week. Together npm + PyPI + crates.io bracket the three registries the AI/ML, web, and systems-programming crowds actually live in.

Five sort axes via the documented `?sort=` parameter:

- **Trending (90d downloads)** — `recent-downloads`, the column default. Matches what crates.io's homepage surfaces as "Just Updated."
- **All-time downloads** — `downloads`, the cumulative giants (tokio, serde, syn, etc.).
- **Recently updated** — `recent-updates`, what's actively maintained.
- **Newest** — `new`, what just got published.
- **A–Z** — `alpha`, deterministic for fixtures.

Optional `q=` search across crate name, description, and keywords.

## Why

After npm (May-12, PR #35) and PyPI (May-13, PR #36 — open), Rust was the last major package registry without a minitor surface. Rust's audience overlaps heavily with minitor's existing TypeScript + Python user base — the same operators running a `langchain` PyPI column also want to see `tokio`, `axum`, or `polars-rs` activity. The crates.io API is fully keyless and well-documented, matching minitor's no-secrets-required design philosophy. This is the natural follow-on the May-13 PyPI PR description explicitly framed as the next gap: \"together npm + pypi bracket the two registries the AI/ML research crowd lives in.\" crates.io closes the gap for the third major language registry.

## Changes

- \`lib/integrations/crates.ts\` — keyless \`GET /api/v1/crates\` fetcher with five sort axes, optional q= search, User-Agent compliance (required by crates.io's documented policy — anonymous requests without UA get 403). Pagination via \`meta.next_page\` with length-fallback for older mirror deployments that omit the field. Schema-drift safe (drops rows missing name or version).
- \`lib/columns/plugins/crates/\` — standard 3-file plugin (plugin.ts / server.ts / client.tsx). #DEA584 Rust ember orange accent (distinct from npm #CB3837 red, pypi #3776AB blue, devto #3b49df indigo, github-actions #2088FF blue, lobsters #ac130d red). \`Box\` icon visually evokes a crate, distinct from npm's \`Package\` and pypi's \`Package2\`.
- \`lib/columns/plugins/manifest.ts\` + \`lib/columns/registry.ts\` + \`lib/columns/server-registry.ts\` — 3 registry edits, parity check passes.
- \`README.md\` — hero paragraph picks up crates.io, column count 41 → 42, News & web cluster row 8 → 9 (\`bing, google-news, news-search, rss, lobsters, stack-overflow, devto, npm, crates\`), keyless-columns list updated.

## How it works

Three integration quirks worth flagging in case future maintainers hit them:

1. **User-Agent is non-optional.** crates.io's documented policy is that every anonymous request must set a User-Agent header — they return 403 otherwise. The integration sets \`minitor/1.0 (+https://github.com/aaronjmars/minitor)\` on every call.
2. **\`recent_downloads\` is 90-day, not 30-day or 7-day.** Unlike npm's last-week stats endpoint, crates.io's recent metric is a fixed 90-day window. The UI label reflects this (\"/90d\"), so users know they're looking at quarterly volume, not weekly.
3. **\`max_stable_version\` fallback chain.** A crate's displayed version walks \`max_stable_version → max_version → newest_version\` — pre-release-only crates would otherwise show no version. This matches what crates.io's own UI does.

The row renders: crate slug (mono font, hover-coloured), description (3-line clamp), brand pill with version + relative time, recent-90d + all-time download badges using \`formatCompactCount\` for K/M/B formatting, and up to 5 keyword pills.

## Test plan

- [ ] After merge: create a \`crates\` column with default config (no query, sort: Trending) → top trending crates load
- [ ] Switch sort to \"Recently updated\" → row order changes, relative-time pills update accordingly
- [ ] Set query \"tokio\" → results filter to tokio-adjacent crates, exact_match pinned where applicable
- [ ] Set query \"async-trait\" (a popular scoped crate) → renders without 403, downloads count present
- [ ] Sort \"Newest\" → recently created crates appear, no NaN downloads
- [ ] Pagination → \"Load more\" fetches page 2 without dropping rows

---
*Built autonomously by Aeon*