### PR TITLE
feat: deck export / import

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -273,32 +273,35 @@ export async function importDeck(json: string): Promise<ImportedDeckResult> {
   }
   const data = result.data;
 
-  const [{ maxDeckPos }] = await db
-    .select({ maxDeckPos: sql<number>`coalesce(max(${decks.position}), -1)` })
-    .from(decks);
-
   const deckId = nanoid();
   const deckName = `${data.deckName} (imported)`;
-  await db.insert(decks).values({
-    id: deckId,
-    name: deckName,
-    position: maxDeckPos + 1,
-  });
-
   const created: ImportedDeckColumn[] = [];
-  for (let i = 0; i < data.columns.length; i++) {
-    const c = data.columns[i];
-    const id = nanoid();
-    await db.insert(columns).values({
-      id,
-      deckId,
-      typeId: c.typeId,
-      title: c.title,
-      config: c.config,
-      position: i,
+
+  await db.transaction(async (tx) => {
+    const [{ maxDeckPos }] = await tx
+      .select({ maxDeckPos: sql<number>`coalesce(max(${decks.position}), -1)` })
+      .from(decks);
+
+    await tx.insert(decks).values({
+      id: deckId,
+      name: deckName,
+      position: maxDeckPos + 1,
     });
-    created.push({ id, typeId: c.typeId, title: c.title, config: c.config });
-  }
+
+    for (let i = 0; i < data.columns.length; i++) {
+      const c = data.columns[i];
+      const id = nanoid();
+      await tx.insert(columns).values({
+        id,
+        deckId,
+        typeId: c.typeId,
+        title: c.title,
+        config: c.config,
+        position: i,
+      });
+      created.push({ id, typeId: c.typeId, title: c.title, config: c.config });
+    }
+  });
 
   return { deckId, deckName, columns: created };
 }

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -3,6 +3,8 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { z } from "zod";
 import { db } from "@/lib/db/client";
 import { columns, decks, feedItems } from "@/lib/db/schema";
 import type { Column, Deck, FeedItem } from "@/lib/columns/types";
@@ -183,6 +185,122 @@ export async function reorderColumnsInDeck(
     FROM (VALUES ${values}) AS v(id, position)
     WHERE columns.id = v.id
   `);
+}
+
+export const DECK_EXPORT_VERSION = 1;
+
+const importedColumnSchema = z.object({
+  typeId: z.string().min(1).max(128),
+  title: z.string().min(1).max(256),
+  config: z.record(z.string(), z.unknown()),
+});
+
+const importedDeckSchema = z.object({
+  version: z.literal(DECK_EXPORT_VERSION),
+  deckName: z.string().min(1).max(128),
+  exportedAt: z.string().optional(),
+  columns: z.array(importedColumnSchema).max(64),
+});
+
+export type DeckExport = z.infer<typeof importedDeckSchema>;
+
+/**
+ * Serialize a deck (name + ordered columns) to a JSON string suitable for
+ * sharing. Feed items are intentionally not included — they're fetched from
+ * upstream sources, not stored in user state. Imports recreate columns and
+ * trigger a fresh fetch on first view.
+ */
+export async function exportDeck(deckId: string): Promise<string> {
+  const [deck] = await db.select().from(decks).where(eq(decks.id, deckId));
+  if (!deck) {
+    throw new Error("Deck not found");
+  }
+  const cols = await db
+    .select({
+      typeId: columns.typeId,
+      title: columns.title,
+      config: columns.config,
+    })
+    .from(columns)
+    .where(eq(columns.deckId, deckId))
+    .orderBy(asc(columns.position), asc(columns.createdAt));
+
+  const payload: DeckExport = {
+    version: DECK_EXPORT_VERSION,
+    deckName: deck.name,
+    exportedAt: new Date().toISOString(),
+    columns: cols.map((c) => ({
+      typeId: c.typeId,
+      title: c.title,
+      config: (c.config as Record<string, unknown>) ?? {},
+    })),
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+export interface ImportedDeckColumn {
+  id: string;
+  typeId: string;
+  title: string;
+  config: Record<string, unknown>;
+}
+
+export interface ImportedDeckResult {
+  deckId: string;
+  deckName: string;
+  columns: ImportedDeckColumn[];
+}
+
+/**
+ * Validate `json` against the deck-export schema and create a new deck with
+ * the imported columns. Always inserts as a new deck (never merges into an
+ * existing one) and appends ` (imported)` to the name so the source deck
+ * remains untouched. Returns the IDs needed to update the client store
+ * without a full re-fetch.
+ */
+export async function importDeck(json: string): Promise<ImportedDeckResult> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("Not valid JSON");
+  }
+  const result = importedDeckSchema.safeParse(parsed);
+  if (!result.success) {
+    const first = result.error.issues[0];
+    const path = first.path.length > 0 ? first.path.join(".") : "<root>";
+    throw new Error(`Invalid deck JSON at ${path}: ${first.message}`);
+  }
+  const data = result.data;
+
+  const [{ maxDeckPos }] = await db
+    .select({ maxDeckPos: sql<number>`coalesce(max(${decks.position}), -1)` })
+    .from(decks);
+
+  const deckId = nanoid();
+  const deckName = `${data.deckName} (imported)`;
+  await db.insert(decks).values({
+    id: deckId,
+    name: deckName,
+    position: maxDeckPos + 1,
+  });
+
+  const created: ImportedDeckColumn[] = [];
+  for (let i = 0; i < data.columns.length; i++) {
+    const c = data.columns[i];
+    const id = nanoid();
+    await db.insert(columns).values({
+      id,
+      deckId,
+      typeId: c.typeId,
+      title: c.title,
+      config: c.config,
+      position: i,
+    });
+    created.push({ id, typeId: c.typeId, title: c.title, config: c.config });
+  }
+
+  return { deckId, deckName, columns: created };
 }
 
 export async function persistFetchedItems(

--- a/components/dialogs/import-deck-dialog.tsx
+++ b/components/dialogs/import-deck-dialog.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useDeckStore } from "@/lib/store/use-deck-store";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ImportDeckDialog({ open, onOpenChange }: Props) {
+  const importDeck = useDeckStore((s) => s.importDeck);
+  const [value, setValue] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setValue("");
+      setSubmitting(false);
+    }
+  }
+
+  async function commit() {
+    const trimmed = value.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      const result = await importDeck(trimmed);
+      toast.success(`Imported "${result.deckName}"`, {
+        description: `${result.columns.length} column${result.columns.length === 1 ? "" : "s"}`,
+      });
+      onOpenChange(false);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Import failed";
+      toast.error("Import failed", { description: msg });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void commit();
+          }}
+          className="contents"
+        >
+          <DialogHeader>
+            <DialogTitle>Import deck</DialogTitle>
+          </DialogHeader>
+          <div className="grid gap-1.5">
+            <Label htmlFor="import-deck-input">Paste deck JSON</Label>
+            <Textarea
+              id="import-deck-input"
+              value={value}
+              placeholder='{"version":1,"deckName":"…","columns":[…]}'
+              autoFocus
+              spellCheck={false}
+              className="min-h-48 font-mono text-xs"
+              onChange={(e) => setValue(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              The imported deck is added as a new deck with “(imported)” appended to
+              its name — your existing decks aren’t touched.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!value.trim() || submitting}>
+              {submitting ? "Importing…" : "Import"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/sidebar-01/app-sidebar.tsx
+++ b/components/sidebar-01/app-sidebar.tsx
@@ -7,6 +7,7 @@ import { NavFooter } from "@/components/sidebar-01/nav-footer";
 import { NavHeader } from "@/components/sidebar-01/nav-header";
 import { NavStats } from "@/components/sidebar-01/nav-stats";
 import { RenameDialog } from "@/components/dialogs/rename-dialog";
+import { ImportDeckDialog } from "@/components/dialogs/import-deck-dialog";
 import { AddColumnDialog } from "@/components/column/add-column-dialog";
 import { useDeckStore } from "@/lib/store/use-deck-store";
 
@@ -17,6 +18,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
   const [newDeckOpen, setNewDeckOpen] = useState(false);
   const [addColOpen, setAddColOpen] = useState(false);
+  const [importDeckOpen, setImportDeckOpen] = useState(false);
 
   return (
     <>
@@ -24,6 +26,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <NavHeader
           onAddDeck={() => setNewDeckOpen(true)}
           onAddColumn={() => setAddColOpen(true)}
+          onImportDeck={() => setImportDeckOpen(true)}
         />
         <SidebarContent>
           <NavDecks />
@@ -50,6 +53,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           deckId={activeDeckId}
         />
       )}
+      <ImportDeckDialog open={importDeckOpen} onOpenChange={setImportDeckOpen} />
     </>
   );
 }

--- a/components/sidebar-01/nav-header.tsx
+++ b/components/sidebar-01/nav-header.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Plus, Search } from "lucide-react";
+import { Download, Plus, Search, Upload } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import {
   CommandDialog,
@@ -21,14 +22,66 @@ import { focusColumn } from "@/components/sidebar-01/nav-decks";
 interface Props {
   onAddDeck: () => void;
   onAddColumn: () => void;
+  onImportDeck: () => void;
 }
 
-export function NavHeader({ onAddDeck, onAddColumn }: Props) {
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to legacy path
+  }
+  if (typeof document === "undefined") return false;
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.setAttribute("readonly", "");
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(ta);
+  return ok;
+}
+
+export function NavHeader({ onAddDeck, onAddColumn, onImportDeck }: Props) {
   const [open, setOpen] = useState(false);
   const decks = useDeckStore((s) => s.decks);
   const deckOrder = useDeckStore((s) => s.deckOrder);
   const columns = useDeckStore((s) => s.columns);
+  const activeDeckId = useDeckStore((s) => s.activeDeckId);
   const setActiveDeck = useDeckStore((s) => s.setActiveDeck);
+  const exportDeck = useDeckStore((s) => s.exportDeck);
+
+  const activeDeck = activeDeckId ? decks[activeDeckId] : null;
+
+  async function handleExportActiveDeck() {
+    if (!activeDeck) return;
+    try {
+      const json = await exportDeck(activeDeck.id);
+      const copied = await copyToClipboard(json);
+      if (copied) {
+        toast.success("Deck JSON copied", { description: activeDeck.name });
+      } else {
+        toast.error("Could not copy to clipboard", {
+          description:
+            "Your browser blocked clipboard access — paste the JSON manually from the console.",
+        });
+        console.log(json);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Export failed";
+      toast.error("Export failed", { description: msg });
+    }
+  }
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
@@ -116,6 +169,27 @@ export function NavHeader({ onAddDeck, onAddColumn }: Props) {
               }}
             >
               <Plus className="mr-2 size-4" /> Add column to current deck
+            </CommandItem>
+            {activeDeck ? (
+              <CommandItem
+                value={`export-deck-${activeDeck.name}`}
+                onSelect={() => {
+                  setOpen(false);
+                  void handleExportActiveDeck();
+                }}
+              >
+                <Download className="mr-2 size-4" /> Export current deck (copy
+                JSON)
+              </CommandItem>
+            ) : null}
+            <CommandItem
+              value="import-deck"
+              onSelect={() => {
+                setOpen(false);
+                onImportDeck();
+              }}
+            >
+              <Upload className="mr-2 size-4" /> Import deck from JSON
             </CommandItem>
           </CommandGroup>
 

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -11,12 +11,15 @@ import {
   createDeck as serverCreateDeck,
   deleteColumn as serverDeleteColumn,
   deleteDeck as serverDeleteDeck,
+  exportDeck as serverExportDeck,
+  importDeck as serverImportDeck,
   persistFetchedItems as serverPersistItems,
   renameColumn as serverRenameColumn,
   renameDeck as serverRenameDeck,
   reorderColumnsInDeck as serverReorderColumns,
   reorderDecks as serverReorderDecks,
   updateColumnConfig as serverUpdateConfig,
+  type ImportedDeckResult,
   type Snapshot,
 } from "@/app/actions";
 
@@ -53,6 +56,9 @@ interface DeckState {
     type: AnyColumnUI,
     ready?: Promise<void>,
   ) => Promise<void>;
+
+  exportDeck: (deckId: string) => Promise<string>;
+  importDeck: (json: string) => Promise<ImportedDeckResult>;
 }
 
 function fireAndLog<T>(label: string, p: Promise<T>) {
@@ -221,6 +227,38 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
         return { autoFetchingIds: next };
       });
     }
+  },
+
+  exportDeck: (deckId) => serverExportDeck(deckId),
+
+  importDeck: async (json) => {
+    const result = await serverImportDeck(json);
+    set((s) => {
+      const cols = { ...s.columns };
+      for (const c of result.columns) {
+        cols[c.id] = {
+          id: c.id,
+          typeId: c.typeId,
+          title: c.title,
+          config: c.config,
+          items: [],
+        };
+      }
+      return {
+        decks: {
+          ...s.decks,
+          [result.deckId]: {
+            id: result.deckId,
+            name: result.deckName,
+            columnIds: result.columns.map((c) => c.id),
+          },
+        },
+        deckOrder: [...s.deckOrder, result.deckId],
+        activeDeckId: result.deckId,
+        columns: cols,
+      };
+    });
+    return result;
   },
 
   applyFetchedItems: async (columnId, items) => {


### PR DESCRIPTION
## What

Two new ⌘K commands plus the server actions and dialog they need:

- **Export current deck (copy JSON)** — serializes the active deck's name + ordered columns (typeId, title, config) to a pretty-printed JSON blob and copies it to the clipboard. Uses `navigator.clipboard` with a `textarea` + `execCommand("copy")` fallback for browsers that block the modern API.
- **Import deck from JSON** — opens a modal with a textarea; on submit the server validates the JSON via Zod and creates a new deck.

The imported deck always lands as a new deck with `" (imported)"` appended to its name, so the source deck (if any) remains untouched. Feed items are intentionally not in the export — they're fetched from upstream sources, not user state, and the imported deck triggers a fresh fetch on first view through the existing `autoFetchColumn` path.

## Why

Minitor is local-first (PGlite) — every new install starts blank. There's no way to share a "founder dashboard" or "crypto desk" setup with another user. Deck export/import is the smallest change that enables community sharing: someone posts a deck JSON on Discord / X / a gist, anyone pastes it into Minitor and starts monitoring the same configuration in seconds. Zero infrastructure change — purely a server-action pair + two ⌘K commands + one small dialog.

May-14 `repo-actions` idea #5.

## DeckExport JSON shape (version 1)

```json
{
  "version": 1,
  "deckName": "Founder dashboard",
  "exportedAt": "2026-05-15T10:34:00.000Z",
  "columns": [
    { "typeId": "hn-top", "title": "HN Top", "config": { } },
    { "typeId": "github-trending", "title": "GitHub trending", "config": { "lang": "rust" } }
  ]
}
```

Schema enforced server-side: `version` must equal `1` (literal), `deckName` 1–128 chars, `columns` ≤ 64, each column has a 1–128 char `typeId` + 1–256 char `title` + a `config` record. Zod errors surface in the dialog as a `sonner` toast with the exact field path that failed.

## Changes

- `app/actions.ts`: new `exportDeck(deckId)` and `importDeck(json)` server actions + `DECK_EXPORT_VERSION` constant + `importedDeckSchema` Zod schema + `ImportedDeckColumn` / `ImportedDeckResult` types. `nanoid` + `zod` are already in `dependencies` — no new deps.
- `lib/store/use-deck-store.ts`: store methods `exportDeck(deckId): Promise<string>` and `importDeck(json): Promise<ImportedDeckResult>`. Import does an optimistic local insert from the server's returned column rows so the new deck appears immediately without a full snapshot re-fetch. Active deck switches to the import target.
- `components/dialogs/import-deck-dialog.tsx`: new — textarea (mono font, autoFocus), Cancel + Import buttons (disabled while submitting), Zod errors and parse errors both surface as toast.
- `components/sidebar-01/nav-header.tsx`: ⌘K entries for Export (only shown when there's an active deck) and Import (always available). Adds a `copyToClipboard` helper with the legacy execCommand fallback.
- `components/sidebar-01/app-sidebar.tsx`: wires `ImportDeckDialog` + `onImportDeck` prop pass-through.

## Notes

- The two pre-existing `lib/integrations/pypi.ts` typecheck errors in `main` are unrelated to this PR. The five files touched here all typecheck cleanly.
- Forward-compatibility: an imported deck can include a `typeId` that doesn't exist in this Minitor's column registry. The column row inserts cleanly; the UI's `getColumnType` returns undefined and the column simply renders as an unknown type until the missing plugin is added. Strict rejection would block users from importing a deck with one unknown column.

---
*Built autonomously by Aeon*