### PR TITLE
feat: column-level alert keywords (highlight + badge)

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -79,6 +79,7 @@ export async function loadSnapshot(): Promise<Snapshot> {
       typeId: c.typeId,
       title: c.title,
       config: (c.config as Record<string, unknown>) ?? {},
+      alertKeywords: c.alertKeywords ?? undefined,
       items: [],
       lastFetchedAt: c.lastFetchedAt ? c.lastFetchedAt.toISOString() : undefined,
     };
@@ -162,6 +163,22 @@ export async function updateColumnConfig(
   await db.update(columns).set({ config }).where(eq(columns.id, id));
 }
 
+/**
+ * Persist a column's alert-keyword string. Pass an empty string to clear.
+ * Validated to 512 chars to bound storage; longer inputs are truncated so the
+ * UI never silently rejects a paste.
+ */
+export async function updateColumnAlertKeywords(
+  id: string,
+  alertKeywords: string,
+): Promise<void> {
+  const trimmed = alertKeywords.slice(0, 512);
+  await db
+    .update(columns)
+    .set({ alertKeywords: trimmed.length === 0 ? null : trimmed })
+    .where(eq(columns.id, id));
+}
+
 export async function renameColumn(id: string, title: string): Promise<void> {
   await db.update(columns).set({ title }).where(eq(columns.id, id));
 }
@@ -193,6 +210,7 @@ const importedColumnSchema = z.object({
   typeId: z.string().min(1).max(128),
   title: z.string().min(1).max(256),
   config: z.record(z.string(), z.unknown()),
+  alertKeywords: z.string().max(512).optional(),
 });
 
 const importedDeckSchema = z.object({
@@ -220,6 +238,7 @@ export async function exportDeck(deckId: string): Promise<string> {
       typeId: columns.typeId,
       title: columns.title,
       config: columns.config,
+      alertKeywords: columns.alertKeywords,
     })
     .from(columns)
     .where(eq(columns.deckId, deckId))
@@ -233,6 +252,7 @@ export async function exportDeck(deckId: string): Promise<string> {
       typeId: c.typeId,
       title: c.title,
       config: (c.config as Record<string, unknown>) ?? {},
+      ...(c.alertKeywords ? { alertKeywords: c.alertKeywords } : {}),
     })),
   };
   return JSON.stringify(payload, null, 2);
@@ -243,6 +263,7 @@ export interface ImportedDeckColumn {
   typeId: string;
   title: string;
   config: Record<string, unknown>;
+  alertKeywords?: string;
 }
 
 export interface ImportedDeckResult {
@@ -291,15 +312,24 @@ export async function importDeck(json: string): Promise<ImportedDeckResult> {
     for (let i = 0; i < data.columns.length; i++) {
       const c = data.columns[i];
       const id = nanoid();
+      const alertKeywords =
+        c.alertKeywords && c.alertKeywords.length > 0 ? c.alertKeywords : null;
       await tx.insert(columns).values({
         id,
         deckId,
         typeId: c.typeId,
         title: c.title,
         config: c.config,
+        alertKeywords,
         position: i,
       });
-      created.push({ id, typeId: c.typeId, title: c.title, config: c.config });
+      created.push({
+        id,
+        typeId: c.typeId,
+        title: c.title,
+        config: c.config,
+        ...(alertKeywords ? { alertKeywords } : {}),
+      });
     }
   });
 

--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -3,7 +3,9 @@
 import { useState, type CSSProperties } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { useMemo } from "react";
 import {
+  Bell,
   GripVertical,
   Loader2,
   MoreHorizontal,
@@ -31,6 +33,10 @@ import { callColumnApi } from "@/lib/columns/api-client";
 import { useDeckStore } from "@/lib/store/use-deck-store";
 import { useMinDuration } from "@/hooks/use-min-duration";
 import { BEAM_MIN_DURATION_MS } from "@/lib/columns/constants";
+import {
+  itemMatchesAlertKeywords,
+  parseAlertKeywords,
+} from "@/lib/columns/keyword-match";
 import type { Column } from "@/lib/columns/types";
 import { ConfigureColumnDialog } from "@/components/column/configure-column-dialog";
 import { RenameDialog } from "@/components/dialogs/rename-dialog";
@@ -83,6 +89,20 @@ export function ColumnCard({ column }: { column: Column }) {
   const ItemRenderer = type.ItemRenderer;
 
   const paginated = type?.capabilities?.paginated === true;
+
+  const alertTerms = useMemo(
+    () => parseAlertKeywords(column.alertKeywords),
+    [column.alertKeywords],
+  );
+  const matchedItemIds = useMemo(() => {
+    if (alertTerms.length === 0) return new Set<string>();
+    const out = new Set<string>();
+    for (const it of column.items) {
+      if (itemMatchesAlertKeywords(it, alertTerms)) out.add(it.id);
+    }
+    return out;
+  }, [alertTerms, column.items]);
+  const matchCount = matchedItemIds.size;
 
   async function onRefresh() {
     if (!type) return;
@@ -211,6 +231,20 @@ export function ColumnCard({ column }: { column: Column }) {
               )}
             </div>
           </div>
+          {matchCount > 0 && (
+            <Tooltip>
+              <TooltipTrigger
+                aria-label={`${matchCount} item${matchCount === 1 ? "" : "s"} matched alert keywords`}
+                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-yellow-400/15 px-2 py-0.5 text-[11px] font-medium text-yellow-700 ring-1 ring-yellow-400/40 dark:text-yellow-300"
+              >
+                <Bell className="size-3" strokeWidth={2.5} />
+                <span className="tabular-nums">{matchCount}</span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {matchCount} match{matchCount === 1 ? "" : "es"} for: {alertTerms.join(", ")}
+              </TooltipContent>
+            </Tooltip>
+          )}
           <Tooltip>
             <TooltipTrigger
               onClick={onRefresh}
@@ -261,9 +295,19 @@ export function ColumnCard({ column }: { column: Column }) {
             )
           ) : (
             <div>
-              {column.items.map((item) => (
-                <ItemRenderer key={item.id} item={item} />
-              ))}
+              {column.items.map((item) =>
+                matchedItemIds.has(item.id) ? (
+                  <div
+                    key={item.id}
+                    data-alert-match="true"
+                    className="relative bg-yellow-50/40 ring-1 ring-inset ring-yellow-400/50 dark:bg-yellow-400/[0.06]"
+                  >
+                    <ItemRenderer item={item} />
+                  </div>
+                ) : (
+                  <ItemRenderer key={item.id} item={item} />
+                ),
+              )}
               {paginated && nextCursor !== null && (
                 <button
                   type="button"

--- a/components/column/configure-column-dialog.tsx
+++ b/components/column/configure-column-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Bell } from "lucide-react";
 
 import {
   Dialog,
@@ -11,8 +12,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
 import { getColumnType } from "@/lib/columns/registry";
 import { useDeckStore } from "@/lib/store/use-deck-store";
+import { parseAlertKeywords } from "@/lib/columns/keyword-match";
 import type { Column } from "@/lib/columns/types";
 
 interface Props {
@@ -21,23 +26,39 @@ interface Props {
   column: Column;
 }
 
+const ALERT_KEYWORDS_MAX = 512;
+
 export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
   const type = getColumnType(column.typeId);
   const updateColumnConfig = useDeckStore((s) => s.updateColumnConfig);
+  const updateAlertKeywords = useDeckStore((s) => s.updateAlertKeywords);
 
   const [draft, setDraft] = useState<Record<string, unknown>>(column.config);
+  const [alertDraft, setAlertDraft] = useState<string>(
+    column.alertKeywords ?? "",
+  );
   const [prevOpen, setPrevOpen] = useState(open);
   if (open !== prevOpen) {
     setPrevOpen(open);
-    if (open) setDraft(column.config);
+    if (open) {
+      setDraft(column.config);
+      setAlertDraft(column.alertKeywords ?? "");
+    }
   }
 
   if (!type) return null;
 
   function save() {
     updateColumnConfig(column.id, draft);
+    const next = alertDraft.slice(0, ALERT_KEYWORDS_MAX);
+    if (next !== (column.alertKeywords ?? "")) {
+      updateAlertKeywords(column.id, next);
+    }
     onOpenChange(false);
   }
+
+  const parsedPreview = parseAlertKeywords(alertDraft);
+  const previewCount = parsedPreview.length;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -52,6 +73,35 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
             value={draft as never}
             onChange={(v) => setDraft(v as Record<string, unknown>)}
           />
+
+          <Separator />
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="alert-keywords" className="flex items-center gap-1.5">
+              <Bell className="size-3.5" />
+              Alert keywords
+              <span className="text-[11px] font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </Label>
+            <Input
+              id="alert-keywords"
+              placeholder="aeon, anthropic, claude"
+              value={alertDraft}
+              maxLength={ALERT_KEYWORDS_MAX}
+              onChange={(e) => setAlertDraft(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Comma- or space-separated. Matching items get a highlight ring and
+              the column header shows a badge with the match count.
+              {previewCount > 0 && (
+                <>
+                  {" "}
+                  Parsed {previewCount} term{previewCount === 1 ? "" : "s"}.
+                </>
+              )}
+            </p>
+          </div>
         </div>
 
         <DialogFooter>

--- a/drizzle/0001_alert_keywords.sql
+++ b/drizzle/0001_alert_keywords.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "columns" ADD COLUMN "alert_keywords" text;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,248 @@
+{
+  "id": "9b3e3a7a-1c1f-4a4d-9b89-2f7a7f9a3001",
+  "prevId": "2baea111-3a85-4861-bd24-276797709de1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.columns": {
+      "name": "columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "alert_keywords": {
+          "name": "alert_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "columns_deck_id_decks_id_fk": {
+          "name": "columns_deck_id_decks_id_fk",
+          "tableFrom": "columns",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decks": {
+      "name": "decks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_column_created_idx": {
+          "name": "feed_items_column_created_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_column_id_columns_id_fk": {
+          "name": "feed_items_column_id_columns_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feed_items_column_id_id_pk": {
+          "name": "feed_items_column_id_id_pk",
+          "columns": [
+            "column_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777056814308,
       "tag": "0000_sloppy_joshua_kane",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1779148800000,
+      "tag": "0001_alert_keywords",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/columns/keyword-match.ts
+++ b/lib/columns/keyword-match.ts
@@ -1,0 +1,51 @@
+import type { FeedItem } from "./types";
+
+/**
+ * Parse a comma/semicolon/space-separated alert-keyword string into a normalised
+ * list of lowercase terms. Empty strings and whitespace-only segments are
+ * dropped. Terms longer than 64 characters are dropped (defensive — no operator
+ * intentionally writes a 64-char keyword, and unbounded lengths would slow
+ * substring scans without changing match semantics). At most 16 terms are
+ * retained per column.
+ */
+export function parseAlertKeywords(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const segment of raw.split(/[,;]+/)) {
+    for (const term of segment.split(/\s+/)) {
+      const trimmed = term.trim().toLowerCase();
+      if (trimmed.length === 0) continue;
+      if (trimmed.length > 64) continue;
+      if (seen.has(trimmed)) continue;
+      seen.add(trimmed);
+      out.push(trimmed);
+      if (out.length >= 16) return out;
+    }
+  }
+  return out;
+}
+
+/**
+ * Returns true when any of the parsed `terms` appears as a substring in the
+ * item's author, content, or URL. Comparison is case-insensitive — `terms` is
+ * already lowercased by `parseAlertKeywords`.
+ */
+export function itemMatchesAlertKeywords(
+  item: FeedItem,
+  terms: string[],
+): boolean {
+  if (terms.length === 0) return false;
+  const haystack = [
+    item.content,
+    item.author?.name ?? "",
+    item.author?.handle ?? "",
+    item.url ?? "",
+  ]
+    .join("\n")
+    .toLowerCase();
+  for (const t of terms) {
+    if (haystack.includes(t)) return true;
+  }
+  return false;
+}

--- a/lib/columns/types.ts
+++ b/lib/columns/types.ts
@@ -141,6 +141,13 @@ export interface Column {
   typeId: string;
   title: string;
   config: Record<string, unknown>;
+  /**
+   * Optional comma/semicolon/space-separated list of alert keywords. When set,
+   * matching feed items get a yellow highlight ring and the column header
+   * shows a badge with the match count. Purely client-side — never sent to
+   * server fetchers, so it works with every plugin without per-plugin opt-in.
+   */
+  alertKeywords?: string;
   items: FeedItem[];
   lastFetchedAt?: string;
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -23,6 +23,7 @@ export const columns = pgTable("columns", {
   typeId: text("type_id").notNull(),
   title: text("title").notNull(),
   config: jsonb("config").notNull().default({}),
+  alertKeywords: text("alert_keywords"),
   position: integer("position").notNull().default(0),
   lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -18,6 +18,7 @@ import {
   renameDeck as serverRenameDeck,
   reorderColumnsInDeck as serverReorderColumns,
   reorderDecks as serverReorderDecks,
+  updateColumnAlertKeywords as serverUpdateAlertKeywords,
   updateColumnConfig as serverUpdateConfig,
   type ImportedDeckResult,
   type Snapshot,
@@ -46,6 +47,7 @@ interface DeckState {
     config: Record<string, unknown>,
   ) => { id: string; ready: Promise<void> };
   updateColumnConfig: (columnId: string, config: Record<string, unknown>) => void;
+  updateAlertKeywords: (columnId: string, alertKeywords: string) => void;
   renameColumn: (columnId: string, title: string) => void;
   removeColumn: (columnId: string) => void;
   reorderColumnsInDeck: (deckId: string, order: string[]) => void;
@@ -160,6 +162,27 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
     fireAndLog("updateColumnConfig", serverUpdateConfig(columnId, config));
   },
 
+  updateAlertKeywords: (columnId, alertKeywords) => {
+    const next = alertKeywords.slice(0, 512);
+    set((s) => {
+      const col = s.columns[columnId];
+      if (!col) return s;
+      return {
+        columns: {
+          ...s.columns,
+          [columnId]: {
+            ...col,
+            alertKeywords: next.length === 0 ? undefined : next,
+          },
+        },
+      };
+    });
+    fireAndLog(
+      "updateColumnAlertKeywords",
+      serverUpdateAlertKeywords(columnId, next),
+    );
+  },
+
   renameColumn: (columnId, title) => {
     set((s) => {
       const col = s.columns[columnId];
@@ -241,6 +264,7 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
           typeId: c.typeId,
           title: c.title,
           config: c.config,
+          alertKeywords: c.alertKeywords,
           items: [],
         };
       }


### PR DESCRIPTION
## What

An optional `alertKeywords` string on every column. Items whose author / handle / content / URL contains any term (case-insensitive substring match) get a yellow inset ring; the column header shows a `Bell` badge with the live match count plus a tooltip listing the terms.

Purely client-side per-column UI — works with **every existing plugin on day one** because the value is stored as a column-level property (sibling to `title`), never sent to server fetchers. No plugin-level Zod schema changes; no per-plugin opt-in.

Sourced from `articles/repo-actions-2026-05-14.md` idea #4 (Column Keyword Alerts, Feature / Medium).

## Why

Minitor's 43 column types are pure display — they fetch, you read. But the dominant monitoring use case is *"tell me when X appears,"* not *"show me everything."* Operators today either eyeball every column or build out-of-band alerting elsewhere. With `alertKeywords`, every column gains a lightweight scan-for-me layer without changing the fetcher contract.

## Changes

**Schema + migration**
- `lib/db/schema.ts` — new `alert_keywords text` nullable column.
- `drizzle/0001_alert_keywords.sql` — `ALTER TABLE columns ADD COLUMN alert_keywords text`.
- `drizzle/meta/_journal.json`, `drizzle/meta/0001_snapshot.json` — Drizzle migration metadata.

**Types + server actions**
- `lib/columns/types.ts` — `alertKeywords?: string` on `Column`.
- `app/actions.ts` — new `updateColumnAlertKeywords(id, value)`; persisted with 512-char clamp (empty → null). `exportDeck` includes it; `importDeck` validates via `z.string().max(512).optional()` and round-trips it. Backward-compatible — old deck JSON without the field still imports cleanly.

**Store**
- `lib/store/use-deck-store.ts` — new `updateAlertKeywords` action with optimistic UI update + fire-and-log server sync. Imported decks bring `alertKeywords` into client state.

**Match logic**
- `lib/columns/keyword-match.ts` — `parseAlertKeywords` (lowercase, dedup, max 16 terms, max 64 chars per term, accepts comma / semicolon / whitespace separators) + `itemMatchesAlertKeywords` (substring scan across author name, handle, content, URL).

**UI**
- `components/column/column-card.tsx` — `useMemo`-backed match set from `column.items × alertTerms`; matched items wrap in a `ring-1 ring-inset ring-yellow-400/50 bg-yellow-50/40 dark:bg-yellow-400/[0.06]` div above the existing `ItemRenderer`; header gets a yellow pill badge with the match count + a tooltip listing the active terms. Badge hidden when count is 0.
- `components/column/configure-column-dialog.tsx` — new \"Alert keywords\" field below the plugin config, with placeholder `aeon, anthropic, claude` and a live parsed-count hint (`Parsed 3 terms.`). Saves alongside the plugin config; an unchanged value never triggers a server write.

## Design quirks worth noting

1. **Column-level, not config-level.** The May-14 idea proposed adding `alertKeywords` to a `BaseColumnConfig` in `lib/columns/schema.ts`, but no such base type exists — each plugin owns its strict Zod schema and would reject `alertKeywords` as an unknown key. Hoisting it to the column row (alongside `title`) keeps the plugin contract untouched and means every plugin gets the feature for free.
2. **Match scope intentionally wide.** Author name, handle, content, and URL all participate. Limiting to title would miss organisation tags / handle-based mentions; including content covers the substantive cases. URL participation lets `aaronjmars/aeon` match GitHub-flavoured columns even when the visible title is shortened.
3. **Badge clears when alerts are cleared, not when read.** The original idea proposed clearing the badge on \"Load more\" or refresh to signal *unread*. That's a stretch for a v1 — the badge here is honestly *\"items matching your alert terms in the current visible window\"*, which is unambiguous and doesn't require a new read/unread persistence layer.
4. **Migration is additive.** `alert_keywords` is nullable; existing rows continue to work without backfill.

## Test plan

- [ ] Configure a column, paste `aeon, anthropic`, save → yellow ring appears on items matching either term; header pill shows the count.
- [ ] Clear the field, save → ring + badge disappear.
- [ ] Set keywords longer than 512 chars → trimmed silently on save.
- [ ] Set keywords with mixed separators (`foo, bar;baz qux`) → all 4 terms parsed.
- [ ] Export a deck with `alertKeywords` set → JSON round-trips it; import shows the highlight on the new deck.
- [ ] Import a pre-feature deck (no `alertKeywords` field) → imports cleanly.

---
*Built autonomously by Aeon*