### PR TITLE
feat: producthunt column

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 43 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
+- 44 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -41,7 +41,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, npm, PyPI, crates.io, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, Product Hunt, npm, PyPI, crates.io, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -60,7 +60,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 |----------|---------|
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
 | **GitHub** (9) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks`, `github-actions` |
-| **News & web** (10) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto`, `npm`, `pypi`, `crates` |
+| **News & web** (11) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto`, `npm`, `pypi`, `crates`, `producthunt` |
 | **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -47,6 +47,7 @@ import { meta as githubActions } from "./github-actions/plugin";
 import { meta as npm } from "./npm/plugin";
 import { meta as pypi } from "./pypi/plugin";
 import { meta as crates } from "./crates/plugin";
+import { meta as producthunt } from "./producthunt/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -92,6 +93,7 @@ export const PLUGIN_METAS = [
   npm,
   pypi,
   crates,
+  producthunt,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/plugins/producthunt/client.tsx
+++ b/lib/columns/plugins/producthunt/client.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { Rocket } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import {
+  meta,
+  type ProductHuntConfig,
+  type ProductHuntMeta,
+} from "./plugin";
+
+const MODE_LABELS: Record<ProductHuntConfig["mode"], string> = {
+  today: "Today's launches",
+  topic: "Filter by topic",
+};
+
+function ConfigForm({ value, onChange }: ConfigFormProps<ProductHuntConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Mode</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as ProductHuntConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="today">Today — full daily slate</SelectItem>
+            <SelectItem value="topic">Topic — filter by keyword</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="ph-topic">Topic keywords (optional)</Label>
+        <Input
+          id="ph-topic"
+          placeholder="ai, design, productivity, developer-tools…"
+          value={value.topic}
+          onChange={(e) => onChange({ ...value, topic: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Up to five keywords, comma- or space-separated. Keywords OR-match
+          against the product name, tagline, description, and link. Leave empty
+          to see every launch in today&apos;s slate.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<ProductHuntMeta>) {
+  const m = item.meta;
+  const productName = m?.productName ?? item.content.split("\n\n")[0] ?? "";
+  const tagline = m?.tagline ?? "";
+  const description = item.content.includes("\n\n")
+    ? item.content.split("\n\n").slice(1).join("\n\n").trim()
+    : "";
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(218, 85, 47, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-white"
+            style={{ backgroundColor: "#DA552F" }}
+          >
+            <Rocket className="size-2.5" strokeWidth={3} />
+          </span>
+          PH
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 block"
+      >
+        <h3
+          className="font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{
+            letterSpacing: "-0.005em",
+            fontFeatureSettings: '"cswh" 1',
+          }}
+        >
+          {productName}
+        </h3>
+        {tagline && (
+          <p className="mt-0.5 text-[13px] leading-snug text-foreground/80 break-words">
+            {tagline}
+          </p>
+        )}
+      </a>
+      {description && description !== tagline && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words">
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export const column = defineColumnUI<ProductHuntConfig, ProductHuntMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/producthunt/plugin.ts
+++ b/lib/columns/plugins/producthunt/plugin.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { Rocket } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  mode: z.enum(["today", "topic"]).default("today"),
+  topic: z.string().default(""),
+});
+
+export type ProductHuntConfig = z.infer<typeof schema>;
+
+export interface ProductHuntMeta {
+  source: string;
+  feedTitle?: string;
+  slug?: string;
+  productName?: string;
+  tagline?: string;
+}
+
+export const meta: PluginMeta<ProductHuntConfig, ProductHuntMeta> = {
+  id: "producthunt",
+  label: "Product Hunt",
+  description:
+    "Today's Product Hunt launches — the full daily slate or an optional keyword filter across name, tagline, and description.",
+  icon: Rocket,
+  // Product Hunt's brand "Rocket" orange — the colour used on the .com header
+  // and the official kit. Distinct from the existing palette: hacker-news
+  // flame, substack orange #ff6719 (more muted), devto indigo #3b49df, npm
+  // red #CB3837, pypi blue #3776AB, crates #DEA584.
+  accent: "#DA552F",
+  category: "news",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const topic = c.topic.trim();
+    if (topic) {
+      const first = topic
+        .split(/[,;\s]+/)
+        .map((t) => t.trim())
+        .find(Boolean);
+      return first ? `PH · ${first}` : "Product Hunt";
+    }
+    return "Product Hunt";
+  },
+  capabilities: { paginated: true },
+};

--- a/lib/columns/plugins/producthunt/server.ts
+++ b/lib/columns/plugins/producthunt/server.ts
@@ -1,0 +1,25 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchProductHuntPage } from "@/lib/integrations/producthunt";
+import { sliceForPage } from "@/lib/columns/paginate";
+import { meta, type ProductHuntConfig, type ProductHuntMeta } from "./plugin";
+
+const fetch: ServerFetcher<ProductHuntConfig, ProductHuntMeta> = async (
+  config,
+  cursor,
+) => {
+  // The PH feed is a fixed daily window — there's no native cursor to thread.
+  // Pull a generous batch once and slice it locally; the same pattern Substack
+  // and other RSS-backed plugins use.
+  const items = await fetchProductHuntPage(config.mode, config.topic, 50);
+  return sliceForPage(items, cursor);
+};
+
+export const server = defineColumnServer<ProductHuntConfig, ProductHuntMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -55,6 +55,7 @@ import { column as githubActions } from "@/lib/columns/plugins/github-actions/cl
 import { column as npm } from "@/lib/columns/plugins/npm/client";
 import { column as pypi } from "@/lib/columns/plugins/pypi/client";
 import { column as crates } from "@/lib/columns/plugins/crates/client";
+import { column as producthunt } from "@/lib/columns/plugins/producthunt/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -103,6 +104,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   npm,
   pypi,
   crates,
+  producthunt,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -51,6 +51,7 @@ import { server as githubActions } from "@/lib/columns/plugins/github-actions/se
 import { server as npm } from "@/lib/columns/plugins/npm/server";
 import { server as pypi } from "@/lib/columns/plugins/pypi/server";
 import { server as crates } from "@/lib/columns/plugins/crates/server";
+import { server as producthunt } from "@/lib/columns/plugins/producthunt/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -96,6 +97,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   npm,
   pypi,
   crates,
+  producthunt,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/producthunt.ts
+++ b/lib/integrations/producthunt.ts
@@ -1,0 +1,164 @@
+import type { FeedItem } from "@/lib/columns/types";
+import { fetchFeed } from "@/lib/integrations/rss";
+
+// Product Hunt RSS feed — keyless, public. The frontpage feed
+// (https://www.producthunt.com/feed) lists every product launched today plus a
+// rolling tail of the previous days. Each <item> has:
+//   - title       "{Product Name} — {tagline}"
+//   - link        https://www.producthunt.com/posts/{slug}
+//   - description HTML with the tagline + an embedded product image
+//   - pubDate     launch timestamp
+//
+// PH used to expose a public GraphQL API but it now requires an OAuth flow with
+// rate caps that aren't usable for a keyless dashboard column. RSS is the
+// stable, key-free surface — it lags a few minutes behind the live frontpage
+// but covers the same set of daily launches.
+const FEED_URL = "https://www.producthunt.com/feed";
+
+export type ProductHuntMode = "today" | "topic";
+
+export interface ProductHuntMeta {
+  source: string;
+  feedTitle?: string;
+  // The product slug extracted from the post URL (e.g. "linear-3"). Useful for
+  // dedupe across days when the same product re-appears in the rolling window.
+  slug?: string;
+  // The product name (left half of the "{name} — {tagline}" title split). Kept
+  // separately so the renderer can highlight it without re-parsing every row.
+  productName?: string;
+  // The tagline (right half of the title split). Often empty if the publisher
+  // didn't add an em-dash; falls back to feed description in that case.
+  tagline?: string;
+}
+
+interface FeedRowMeta {
+  source?: string;
+  feedTitle?: string;
+}
+
+// PH titles ship as "Linear — A better way to build software". Both em-dash
+// (U+2014) and en-dash (U+2013) appear in the wild; ASCII hyphen-minus is
+// reserved for names like "Add-on" and stays inside the product name. Split on
+// the first em/en-dash surrounded by whitespace and treat both halves as
+// optional — if the title shape is anything else, fall through to the raw
+// title as the product name.
+function splitTitle(title: string): { productName: string; tagline: string } {
+  const trimmed = title.trim();
+  const match = trimmed.match(/^(.+?)\s+[—–]\s+(.+)$/);
+  if (match) {
+    return {
+      productName: match[1].trim(),
+      tagline: match[2].trim(),
+    };
+  }
+  return { productName: trimmed, tagline: "" };
+}
+
+function slugFromUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    // /posts/{slug} — the slug is the last segment, which is what PH uses for
+    // its permalink. Other paths (/topics/, /collections/) wouldn't show up in
+    // the daily feed but we defensively bail rather than misclassify.
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments[0] !== "posts" || !segments[1]) return undefined;
+    return segments[1].toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+// `fetchFeed` already cleans HTML out of the description and merges it into
+// `content` as "{title}\n\n{description}". For the PH renderer we want the
+// description by itself so it can render under the structured product name +
+// tagline — split it back out here.
+function splitContent(content: string): { title: string; description: string } {
+  const idx = content.indexOf("\n\n");
+  if (idx === -1) return { title: content, description: "" };
+  return {
+    title: content.slice(0, idx),
+    description: content.slice(idx + 2).trim(),
+  };
+}
+
+function tagWithProductHunt(item: FeedItem): FeedItem<ProductHuntMeta> {
+  const { title } = splitContent(item.content);
+  const { productName, tagline } = splitTitle(title);
+  const slug = slugFromUrl(item.url);
+  const prevMeta = item.meta as FeedRowMeta | undefined;
+  return {
+    ...item,
+    // Prefer the PH slug for the id so the same product across multiple fetches
+    // collapses to one row in the column store. Fall back to the upstream id
+    // (which is itself derived from guid/link in lib/integrations/rss.ts) when
+    // the slug isn't extractable — e.g. a feed item that isn't a /posts/ link.
+    id: slug ? `producthunt:${slug}` : item.id,
+    meta: {
+      source: prevMeta?.source ?? "Product Hunt",
+      feedTitle: prevMeta?.feedTitle ?? "Product Hunt",
+      slug,
+      productName,
+      tagline,
+    },
+  };
+}
+
+// Normalise the user-entered topic filter into a list of lowercase needles.
+// Accepts the same separators as the DEV.to integration (comma / semicolon /
+// whitespace), deduplicates, and caps at 5 — the same shape minitor uses for
+// keyword inputs across plugins.
+export function parseTopicFilter(input: string): string[] {
+  const parts = input
+    .split(/[,;\s]+/)
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const p of parts) {
+    if (seen.has(p)) continue;
+    seen.add(p);
+    out.push(p);
+    if (out.length === 5) break;
+  }
+  return out;
+}
+
+function matchesTopic(item: FeedItem<ProductHuntMeta>, needles: string[]): boolean {
+  if (needles.length === 0) return true;
+  const haystack = [
+    item.content,
+    item.url ?? "",
+    item.meta?.productName ?? "",
+    item.meta?.tagline ?? "",
+  ]
+    .join(" ")
+    .toLowerCase();
+  // OR-match across needles — a multi-topic filter ("ai, design") returns
+  // products tagged with either, not the (much narrower) intersection. PH
+  // launches are sparse per day; AND would zero out most queries.
+  return needles.some((n) => haystack.includes(n));
+}
+
+export async function fetchProductHuntPage(
+  mode: ProductHuntMode,
+  topic: string,
+  limit: number,
+): Promise<FeedItem<ProductHuntMeta>[]> {
+  // The feed always returns the same window (today + a rolling tail). Both
+  // modes share the same fetch — `topic` just adds a client-side filter step.
+  // Mode is kept as a type so future PH endpoints (per-topic RSS, leaderboard)
+  // can plug in without breaking the column config shape.
+  void mode;
+
+  // Pull a generous batch so the topic filter has room to find matches. The
+  // PH feed only exposes ~30 items at the tail so 50 is the practical ceiling
+  // even when topic is empty.
+  const raw = await fetchFeed(FEED_URL, Math.max(limit, 50));
+  const tagged = raw.map(tagWithProductHunt);
+  const needles = parseTopicFilter(topic);
+  const filtered = needles.length === 0
+    ? tagged
+    : tagged.filter((item) => matchesTopic(item, needles));
+  return filtered.slice(0, limit);
+}


### PR DESCRIPTION
## What

Adds Product Hunt as the 44th column type. News & web cluster 10 → 11. Daily launches via the keyless `producthunt.com/feed` RSS surface.

## Why

Minitor is "a dashboard for the internet" but until now had no visibility into the world's #1 product launch platform. Two concrete uses:

- **Watch your own launch day** — operator is actively preparing a PH submission (aeon PRs #175 + #49 ship the `product-hunt-launch` skill that drafts the asset pack); a PH column means watching the live rank inside the dashboard rather than refreshing producthunt.com in a separate tab.
- **Monitor the daily ecosystem** — every day PH ships ~30 launches; a column with a topic filter ("ai", "design", "developer-tools") gives a focused feed of relevant ones without leaving the dashboard.

This is May-16's repo-actions idea #1.

## Changes

- `lib/integrations/producthunt.ts` — fetches `producthunt.com/feed` via the existing `fetchFeed` helper, splits the `{name} — {tagline}` title into structured `productName`/`tagline`, extracts the PH slug from `/posts/{slug}` URLs, and applies an optional keyword filter.
- `lib/columns/plugins/producthunt/{plugin.ts, server.ts, client.tsx}` — 3-file plugin with two modes (`today` / `topic`), 5-keyword cap with comma/semicolon/space separation, `Rocket` icon, `#DA552F` PH orange accent (distinct from every existing column accent), structured renderer that surfaces product name + tagline + description as separate visual layers.
- `lib/columns/plugins/manifest.ts` — added `producthunt` import + push (44 total).
- `lib/columns/registry.ts` — added client column import + map entry.
- `lib/columns/server-registry.ts` — added server fetcher import + map entry.
- `README.md` — bumped column count 43 → 44, News & web cluster 10 → 11, added Product Hunt to the keyless-columns list.

## Five integration quirks worth noting

1. **Title split on em-dash (—) or en-dash (–) bounded by whitespace.** The `{name} — {tagline}` shape is common but not universal on PH. The parser falls back to the raw title as `productName` when the shape doesn't match, so launches with an unusual title shape still render with the right product name (just no separated tagline).
2. **Product slug as the feed item id.** Extracted from `/posts/{slug}` URLs and used as the canonical id (`producthunt:{slug}`) so the same product across multiple fetches collapses to one row in the column store — even though PH's rolling feed includes a tail of the previous day's launches.
3. **Keyword cap of 5, OR-match across needles.** PH launches are sparse per day (~30); AND-matching would zero out most multi-keyword queries. OR returns "ai OR design" as the union, which is what the user wants from a daily slate. Same input shape and cap as the DEV.to integration.
4. **PH GraphQL isn't usable for a keyless column.** It needs OAuth + per-app rate caps that don't fit minitor's "no keys" model. RSS is the stable, key-free surface — it lags a few minutes behind the live frontpage but covers the same set of daily launches.
5. **Mode is a string union even though both modes share the same fetch today.** Leaves a clean extension point for future PH endpoints (per-topic RSS, leaderboard scrape) without breaking the column config shape — adding `"leaderboard"` later is a one-line plugin edit and a new branch in the integration.

## Visual

Rocket icon, `#DA552F` PH orange — distinct from every existing column accent (hacker-news flame, substack `#ff6719`, devto `#3b49df`, npm `#CB3837`, pypi `#3776AB`, crates `#DEA584`).

Product name renders in the serif headline style every news plugin uses; tagline gets its own line in foreground/80; full description (when distinct from the tagline) renders below in muted-foreground with `line-clamp-3` — same three-tier visual hierarchy the DEV.to plugin uses.

---
*Built autonomously by Aeon*
