### PR TITLE
feat: github-discussions column (45th column type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm + PyPI + crates.io packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm + PyPI + crates.io packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions / Discussions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 44 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
+- 45 column types out of the box — social feeds, news, GitHub (including CI runs and Discussions), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -59,7 +59,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 | Category | Columns |
 |----------|---------|
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
-| **GitHub** (9) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks`, `github-actions` |
+| **GitHub** (10) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks`, `github-actions`, `github-discussions` |
 | **News & web** (11) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto`, `npm`, `pypi`, `crates`, `producthunt` |
 | **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
@@ -69,7 +69,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 
 Full plugin manifest: [`lib/columns/plugins/manifest.ts`](lib/columns/plugins/manifest.ts). Add a new source by copying [`lib/columns/plugins/_template/`](lib/columns/plugins/_template/) — see [`lib/columns/README.md`](lib/columns/README.md) for the full contract.
 
-**Keys:** `XAI_API_KEY` for `x-*`, `news-search`, `linkedin`, `facebook`, `instagram` (and Substack's keyword-only mode). Optional `NEYNAR_API_KEY` for Farcaster (demo-key fallback works), optional `YOUTUBE_API_KEY` for YouTube *search* (channel / playlist Atom feeds are keyless). Everything else runs without keys.
+**Keys:** `XAI_API_KEY` for `x-*`, `news-search`, `linkedin`, `facebook`, `instagram` (and Substack's keyword-only mode). Optional `NEYNAR_API_KEY` for Farcaster (demo-key fallback works), optional `YOUTUBE_API_KEY` for YouTube *search* (channel / playlist Atom feeds are keyless), optional `GITHUB_TOKEN` for every `github-*` column (60 req/hr keyless → 5000 req/hr with a token; `github-discussions` follows the same rule). Everything else runs without keys.
 
 ### Features
 

--- a/lib/columns/plugins/github-discussions/client.tsx
+++ b/lib/columns/plugins/github-discussions/client.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import {
+  ArrowBigUp,
+  Check,
+  Circle,
+  MessageSquare,
+  MessageSquareText,
+} from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import {
+  meta,
+  type GHDiscussionsConfig,
+  type GHDiscussionsMeta,
+} from "./plugin";
+
+const MODE_LABELS: Record<GHDiscussionsConfig["mode"], string> = {
+  recent: "Recent — newest first",
+  unanswered: "Unanswered — open questions only",
+  top: "Top — most upvoted",
+};
+
+function ConfigForm({ value, onChange }: ConfigFormProps<GHDiscussionsConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghd-repo">Repository</Label>
+        <Input
+          id="ghd-repo"
+          placeholder="vercel/next.js"
+          value={value.repo}
+          onChange={(e) => onChange({ ...value, repo: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          <code>owner/repo</code> or full GitHub URL. The repo must have
+          Discussions enabled in its settings.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Mode</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({
+              ...value,
+              mode: v as GHDiscussionsConfig["mode"],
+            })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {(Object.keys(MODE_LABELS) as GHDiscussionsConfig["mode"][]).map(
+              (m) => (
+                <SelectItem key={m} value={m}>
+                  {MODE_LABELS[m]}
+                </SelectItem>
+              ),
+            )}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          <code>GITHUB_TOKEN</code> is optional — it raises the rate limit from
+          60 to 5000 requests/hour but isn&apos;t required for the column to
+          work.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function AnsweredIndicator({ answered }: { answered: boolean }) {
+  if (answered) {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px] font-medium"
+        style={{
+          backgroundColor: "rgba(16, 185, 129, 0.18)",
+          color: "#047857",
+        }}
+        title="Answered"
+      >
+        <Check className="size-3" strokeWidth={3} />
+        answered
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground ring-1 ring-border/60"
+      title="Unanswered"
+    >
+      <Circle className="size-3" />
+      unanswered
+    </span>
+  );
+}
+
+function CategoryPill({ name }: { name: string }) {
+  // GitHub returns emojiHTML like `<g-emoji>💬</g-emoji>`. We deliberately
+  // don't render it as HTML — that would mean inserting an arbitrary fetched
+  // string into the DOM, and the security note in CLAUDE.md treats all
+  // upstream strings as untrusted. The category name alone is plenty.
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px] font-medium text-foreground/90 ring-1 ring-black/5"
+      style={{ backgroundColor: "rgba(124, 58, 237, 0.14)" }}
+    >
+      <MessageSquare className="size-3" style={{ color: "#7C3AED" }} />
+      {name}
+    </span>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<GHDiscussionsMeta>) {
+  const m = item.meta;
+  if (!m) return null;
+  // Q&A categories are the only ones that carry a meaningful answered state.
+  // For Announcements / Polls / General / Show-and-tell etc. there's no
+  // "answer" concept — hide the indicator rather than render a misleading
+  // "unanswered" pill on every announcement.
+  const isQA =
+    (m.categoryName ?? "").trim().toLowerCase().includes("q&a") ||
+    (m.categoryName ?? "").trim().toLowerCase().includes("question");
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        {m.categoryName && <CategoryPill name={m.categoryName} />}
+        {isQA && <AnsweredIndicator answered={m.isAnswered} />}
+        <span className="truncate text-foreground/80">
+          {item.author.handle ?? item.author.name}
+        </span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {item.content}
+      </h3>
+      <div className="mt-2 flex items-center gap-4 text-[11.5px] text-muted-foreground">
+        <span className="tabular-nums text-foreground/70">#{m.number}</span>
+        <span className="flex items-center gap-1">
+          <ArrowBigUp className="size-3.5" />
+          <span className="tabular-nums">
+            {formatCompactCount(m.upvotes)}
+          </span>
+        </span>
+        <span className="flex items-center gap-1">
+          <MessageSquareText className="size-3.5" />
+          <span className="tabular-nums">
+            {formatCompactCount(m.comments)}
+          </span>
+        </span>
+      </div>
+    </a>
+  );
+}
+
+export const column = defineColumnUI<GHDiscussionsConfig, GHDiscussionsMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-discussions/plugin.ts
+++ b/lib/columns/plugins/github-discussions/plugin.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import { MessageSquare } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+// The owner/name shape is validated at fetch time by
+// `lib/integrations/github-discussions.ts:parseRepo` (same regex). Mirroring
+// the validation in the schema would duplicate the source of truth; we follow
+// the github-actions / github-releases pattern of letting the integration
+// throw a clear error on bad input and keeping the schema permissive so empty
+// defaults parse cleanly.
+export const schema = z.object({
+  repo: z.string().default(""),
+  // recent      — newest by createdAt (server default order)
+  // unanswered  — drop rows where isAnswered === true (Q&A-style filter)
+  // top         — re-sort the page by upvotes desc, then comments desc
+  mode: z.enum(["recent", "unanswered", "top"]).default("recent"),
+});
+
+export type GHDiscussionsConfig = z.infer<typeof schema>;
+
+// Renderer-facing meta. Mirrors `GHDiscussionMeta` in the integration but kept
+// local so the plugin owns its renderer contract. The integration's type is
+// structurally identical; the cast in server.ts is documented there.
+export interface GHDiscussionsMeta {
+  kind: "discussion";
+  repo: string;
+  number: number;
+  upvotes: number;
+  comments: number;
+  isAnswered: boolean;
+  categoryName?: string;
+  categoryEmojiHTML?: string;
+}
+
+export const meta: PluginMeta<GHDiscussionsConfig, GHDiscussionsMeta> = {
+  id: "github-discussions",
+  label: "GitHub Discussions",
+  description:
+    "Latest discussions for a GitHub repo — the async Q&A and community layer. Modes: recent, unanswered, or top by upvotes. Works keyless at the 60 req/hr public rate; set GITHUB_TOKEN for 5000 req/hr.",
+  icon: MessageSquare,
+  // Purple — picked to be visually distinct from every other GitHub-cluster
+  // colour: trending #e88a4d (orange), releases #22c55e (green), issues /
+  // prs #26251e (near-black), stars #f5a623 (gold), forks #9fbbe0 (pale
+  // blue), search #1f2328 (charcoal), backlinks #5e6dc7 (muted indigo),
+  // actions #2088ff (vivid blue). The closest in hue is farcaster
+  // (#7c65c1, muted lavender) which sits in a different cluster and is
+  // perceptibly less saturated than this one.
+  accent: "#7C3AED",
+  // Same convention as the other github-* plugins so the "Add column"
+  // picker groups Discussions next to PRs / Issues / Actions.
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const repo = c.repo.trim();
+    if (!repo) return "Discussions";
+    return `${repo} Discussions`;
+  },
+  capabilities: {
+    paginated: true,
+    rateLimitHint: "60 req/hr without GITHUB_TOKEN, 5000 with.",
+  },
+};

--- a/lib/columns/plugins/github-discussions/server.ts
+++ b/lib/columns/plugins/github-discussions/server.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchDiscussions } from "@/lib/integrations/github-discussions";
+import { sliceForPage } from "@/lib/columns/paginate";
+import {
+  meta,
+  type GHDiscussionsConfig,
+  type GHDiscussionsMeta,
+} from "./plugin";
+
+const fetch: ServerFetcher<GHDiscussionsConfig, GHDiscussionsMeta> = async (
+  config,
+  cursor,
+) => {
+  const repo = config.repo.trim();
+  if (!repo) throw new Error("Repository is required (owner/repo).");
+  // GraphQL doesn't expose a native cursor for the orderings we use here
+  // (CREATED_AT for recent / unanswered, in-memory upvote sort for top), so we
+  // follow the same pattern as github-actions and producthunt: pull a generous
+  // batch once and slice it for pagination via `sliceForPage`.
+  const items = await fetchDiscussions(repo, config.mode, 50);
+  // The integration produces `FeedItem<GHDiscussionMeta>`; structurally
+  // identical to `GHDiscussionsMeta` (the renderer contract owned by this
+  // plugin). One-line cast keeps the ownership split clear: plugin owns the
+  // renderer contract, integration owns the fetch shape — same pattern
+  // github-actions uses.
+  return sliceForPage(
+    items as unknown as FeedItem<GHDiscussionsMeta>[],
+    cursor,
+  );
+};
+
+export const server = defineColumnServer<
+  GHDiscussionsConfig,
+  GHDiscussionsMeta
+>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -48,6 +48,7 @@ import { meta as npm } from "./npm/plugin";
 import { meta as pypi } from "./pypi/plugin";
 import { meta as crates } from "./crates/plugin";
 import { meta as producthunt } from "./producthunt/plugin";
+import { meta as githubDiscussions } from "./github-discussions/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -94,6 +95,7 @@ export const PLUGIN_METAS = [
   pypi,
   crates,
   producthunt,
+  githubDiscussions,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -56,6 +56,7 @@ import { column as npm } from "@/lib/columns/plugins/npm/client";
 import { column as pypi } from "@/lib/columns/plugins/pypi/client";
 import { column as crates } from "@/lib/columns/plugins/crates/client";
 import { column as producthunt } from "@/lib/columns/plugins/producthunt/client";
+import { column as githubDiscussions } from "@/lib/columns/plugins/github-discussions/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -105,6 +106,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   pypi,
   crates,
   producthunt,
+  "github-discussions": githubDiscussions,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -52,6 +52,7 @@ import { server as npm } from "@/lib/columns/plugins/npm/server";
 import { server as pypi } from "@/lib/columns/plugins/pypi/server";
 import { server as crates } from "@/lib/columns/plugins/crates/server";
 import { server as producthunt } from "@/lib/columns/plugins/producthunt/server";
+import { server as githubDiscussions } from "@/lib/columns/plugins/github-discussions/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -98,6 +99,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   pypi,
   crates,
   producthunt,
+  "github-discussions": githubDiscussions,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/github-discussions.ts
+++ b/lib/integrations/github-discussions.ts
@@ -1,0 +1,228 @@
+import type { FeedItem } from "@/lib/columns/types";
+import { identiconUrl } from "@/lib/utils";
+
+// GitHub Discussions integration. Discussions are *only* exposed through the
+// GraphQL API — there's no REST surface for them — so this file is a
+// purpose-built GraphQL client that lives alongside the REST helpers in
+// `github.ts` rather than inside it. The REST module is intentionally left
+// untouched so its API surface (legacy callers) stays stable.
+//
+// Auth: optional `GITHUB_TOKEN`. With a token we get the standard 5000 req/hr
+// authenticated GraphQL quota; without one we degrade to the 60 req/hr
+// unauthenticated public quota (same as the rest of the github-* plugins).
+// The column never fails because of a missing token — that's a deliberate
+// product decision: keyless dashboards are a first-class use case.
+
+const GRAPHQL_ENDPOINT = "https://api.github.com/graphql";
+
+export type GHDiscussionMode = "recent" | "unanswered" | "top";
+
+export interface GHDiscussionMeta {
+  kind: "discussion";
+  repo: string;
+  number: number;
+  upvotes: number;
+  comments: number;
+  isAnswered: boolean;
+  categoryName?: string;
+  /** Raw emoji HTML returned by GitHub (e.g. `<g-emoji>💬</g-emoji>`). */
+  categoryEmojiHTML?: string;
+}
+
+interface GHDiscussionNode {
+  number: number;
+  title: string;
+  url: string;
+  author: { login: string; avatarUrl?: string } | null;
+  createdAt: string;
+  upvoteCount: number;
+  isAnswered: boolean | null;
+  category: { name: string; emojiHTML: string } | null;
+  comments: { totalCount: number };
+}
+
+interface GHDiscussionsResponse {
+  data?: {
+    repository: {
+      discussions: {
+        nodes: GHDiscussionNode[];
+      } | null;
+    } | null;
+  };
+  errors?: Array<{
+    message: string;
+    type?: string;
+    path?: Array<string | number>;
+  }>;
+}
+
+const DISCUSSIONS_QUERY = `
+  query($owner: String!, $name: String!, $first: Int!) {
+    repository(owner: $owner, name: $name) {
+      discussions(first: $first, orderBy: {field: CREATED_AT, direction: DESC}) {
+        nodes {
+          number
+          title
+          url
+          author { login avatarUrl }
+          createdAt
+          upvoteCount
+          isAnswered
+          category { name emojiHTML }
+          comments { totalCount }
+        }
+      }
+    }
+  }
+`;
+
+const REPO_REGEX =
+  /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export function parseRepo(input: string): { owner: string; name: string } {
+  const clean = input
+    .trim()
+    .replace(/^https?:\/\//, "")
+    .replace(/^github\.com\//, "")
+    .replace(/\/+$/, "");
+  if (!REPO_REGEX.test(clean)) {
+    throw new Error(
+      `Invalid repo "${input}". Use owner/repo (e.g. vercel/next.js).`,
+    );
+  }
+  const [owner, name] = clean.split("/");
+  return { owner, name };
+}
+
+function headers(): HeadersInit {
+  const h: Record<string, string> = {
+    accept: "application/json",
+    "content-type": "application/json",
+    "user-agent": "minitor/0.1",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) h.authorization = `Bearer ${token}`;
+  return h;
+}
+
+// Sentinel error so the column renderer can surface a friendlier empty state
+// ("Discussions not enabled on this repo") instead of a generic GraphQL
+// failure. GitHub returns either an empty/null `discussions` field or a typed
+// error when a repo has the Discussions feature disabled — we normalise both.
+export class DiscussionsDisabledError extends Error {
+  constructor(repo: string) {
+    super(`Discussions are not enabled on ${repo}.`);
+    this.name = "DiscussionsDisabledError";
+  }
+}
+
+function isDiscussionsDisabledError(message: string): boolean {
+  const m = message.toLowerCase();
+  return (
+    m.includes("discussions") &&
+    (m.includes("disabled") ||
+      m.includes("not enabled") ||
+      m.includes("not available") ||
+      m.includes("does not have"))
+  );
+}
+
+export async function fetchDiscussions(
+  repo: string,
+  mode: GHDiscussionMode,
+  first: number,
+): Promise<FeedItem<GHDiscussionMeta>[]> {
+  const { owner, name } = parseRepo(repo);
+  const fullRepo = `${owner}/${name}`;
+  // We always pull a generous batch (caller controls `first`, usually 50) so
+  // the three modes can do their filtering / re-sorting client-side without
+  // running multiple round trips. GraphQL's `orderBy` only supports
+  // CREATED_AT / UPDATED_AT, not upvotes; "top" mode needs the full batch in
+  // memory to sort by upvotes anyway.
+  const res = await fetch(GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: headers(),
+    body: JSON.stringify({
+      query: DISCUSSIONS_QUERY,
+      variables: { owner, name, first },
+    }),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(
+      `GitHub GraphQL ${res.status}: ${body.slice(0, 200)}`,
+    );
+  }
+  const json = (await res.json()) as GHDiscussionsResponse;
+
+  if (json.errors?.length) {
+    const joined = json.errors.map((e) => e.message).join("; ");
+    if (isDiscussionsDisabledError(joined)) {
+      throw new DiscussionsDisabledError(fullRepo);
+    }
+    throw new Error(`GitHub GraphQL: ${joined}`);
+  }
+
+  const repository = json.data?.repository;
+  if (!repository) {
+    throw new Error(`Repository ${fullRepo} not found.`);
+  }
+  if (!repository.discussions) {
+    // GraphQL returns `discussions: null` on repos where the feature is off.
+    throw new DiscussionsDisabledError(fullRepo);
+  }
+
+  const nodes = repository.discussions.nodes ?? [];
+  const items: FeedItem<GHDiscussionMeta>[] = nodes.map((n) => {
+    const login = n.author?.login ?? "ghost";
+    const avatarUrl = n.author?.avatarUrl ?? identiconUrl(login);
+    return {
+      // Stable, dedupe-friendly id so the same discussion across refreshes /
+      // re-fetches collapses to one row in the column store.
+      id: `github-discussions:${fullRepo}#${n.number}`,
+      author: { name: login, handle: login, avatarUrl },
+      content: n.title,
+      url: n.url,
+      createdAt: n.createdAt,
+      meta: {
+        kind: "discussion",
+        repo: fullRepo,
+        number: n.number,
+        upvotes: n.upvoteCount,
+        comments: n.comments.totalCount,
+        // `isAnswered` is only meaningful for Q&A-category discussions; for
+        // Announcements / General / Polls etc. the field is null. Treat null
+        // as "no concept of answered" — we map it to `false` here so the
+        // unanswered filter still surfaces those rows, but the renderer uses
+        // the raw category to decide whether to show the indicator at all.
+        isAnswered: n.isAnswered === true,
+        categoryName: n.category?.name,
+        categoryEmojiHTML: n.category?.emojiHTML,
+      },
+    } satisfies FeedItem<GHDiscussionMeta>;
+  });
+
+  switch (mode) {
+    case "unanswered":
+      // Drop discussions that are answered. We don't restrict to Q&A category
+      // here — repos use lots of category layouts, and an "unanswered" filter
+      // that hides every General / Announcement row would be confusing. Items
+      // without an isAnswered concept (null upstream → false in meta) pass.
+      return items.filter((it) => it.meta?.isAnswered !== true);
+    case "top":
+      // Sort by upvotes desc, with comments as a tiebreaker. Original
+      // `createdAt` order is preserved for items with identical scores.
+      return [...items].sort((a, b) => {
+        const upA = a.meta?.upvotes ?? 0;
+        const upB = b.meta?.upvotes ?? 0;
+        if (upA !== upB) return upB - upA;
+        const cA = a.meta?.comments ?? 0;
+        const cB = b.meta?.comments ?? 0;
+        return cB - cA;
+      });
+    case "recent":
+    default:
+      return items;
+  }
+}


### PR DESCRIPTION
## What
45th column type — GitHub Discussions. Completes the GitHub cluster: stars/forks/PRs/issues/releases/search/actions/backlinks/trending all had dedicated columns; Discussions (the async Q&A/community layer GitHub is pushing as a default) was missing until now.

## Why
Repos transitioning from Issues-only to Discussions-first lose visibility in minitor without this column. GitHub's GraphQL API is the only path to Discussions data (REST doesn't expose them); 5000 req/hr with GITHUB_TOKEN or 60 req/hr keyless.

## Changes
- lib/integrations/github-discussions.ts (new) — GraphQL fetcher with optional GITHUB_TOKEN auth, three modes (recent/unanswered/top)
- lib/columns/plugins/github-discussions/plugin.ts (new) — schema + metadata
- lib/columns/plugins/github-discussions/server.ts (new) — server-side fetch + slice
- lib/columns/plugins/github-discussions/client.tsx (new) — row UI with answered/unanswered indicator, category pill, author/upvotes/comments
- lib/columns/plugins/manifest.ts — add plugin entry
- lib/columns/registry.ts — client-side registration
- lib/columns/server-registry.ts — server-side registration
- README.md — count 44 → 45, GitHub cluster row increment

## How
GraphQL request to `api.github.com/graphql` with `repository(owner, name) { discussions(first: 50, orderBy: CREATED_AT DESC) { nodes { ... } } }`. Auth header set only when `GITHUB_TOKEN` is present so the column works keyless at the lower public-API rate limit. Repo config validated via regex `^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$`. Item ID `github-discussions:{owner}/{repo}#{number}` for cross-fetch dedup.

## Origin
May-16 repo-actions idea #2 — second open May-16 idea for minitor (Product Hunt column shipped May-17).

---
*Built autonomously by Aeon*