### PR TITLE
feat: CoinGecko trending + price column (45th column type)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,8 @@ NEYNAR_API_KEY=
 # Playlist modes use free public Atom feeds and need no key).
 # Create one in Google Cloud Console with the YouTube Data API v3 enabled.
 YOUTUBE_API_KEY=
+
+# CoinGecko Demo API key — OPTIONAL. The CoinGecko column works keyless at
+# ~10–30 calls/min on the public API. Free Demo plan adds higher ceiling and
+# better stability. Create at https://www.coingecko.com/en/developers/dashboard
+COINGECKO_DEMO_API_KEY=

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm + PyPI + crates.io packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm + PyPI + crates.io packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, CoinGecko crypto trending + prices, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 44 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, Chinese hot boards.
+- 45 column types out of the box — social feeds, news, GitHub (including CI runs), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, CoinGecko prices, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -41,7 +41,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, Product Hunt, npm, PyPI, crates.io, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, Product Hunt, npm, PyPI, crates.io, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket, CoinGecko) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -64,12 +64,12 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 | **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |
-| **Apps & on-chain** (4) | `apple-reviews`, `play-reviews`, `wallet-tx`, `polymarket` |
+| **Apps & on-chain** (5) | `apple-reviews`, `play-reviews`, `wallet-tx`, `polymarket`, `coingecko` |
 | **China hot boards** (6) | `weibo-hot`, `zhihu-hot`, `douyin-hot`, `bilibili-hot`, `toutiao`, `baidu-hot` |
 
 Full plugin manifest: [`lib/columns/plugins/manifest.ts`](lib/columns/plugins/manifest.ts). Add a new source by copying [`lib/columns/plugins/_template/`](lib/columns/plugins/_template/) — see [`lib/columns/README.md`](lib/columns/README.md) for the full contract.
 
-**Keys:** `XAI_API_KEY` for `x-*`, `news-search`, `linkedin`, `facebook`, `instagram` (and Substack's keyword-only mode). Optional `NEYNAR_API_KEY` for Farcaster (demo-key fallback works), optional `YOUTUBE_API_KEY` for YouTube *search* (channel / playlist Atom feeds are keyless). Everything else runs without keys.
+**Keys:** `XAI_API_KEY` for `x-*`, `news-search`, `linkedin`, `facebook`, `instagram` (and Substack's keyword-only mode). Optional `NEYNAR_API_KEY` for Farcaster (demo-key fallback works), optional `YOUTUBE_API_KEY` for YouTube *search* (channel / playlist Atom feeds are keyless), optional `COINGECKO_DEMO_API_KEY` for higher CoinGecko rate limits (keyless mode works fine for low-traffic decks). Everything else runs without keys.
 
 ### Features
 

--- a/lib/columns/plugins/coingecko/client.tsx
+++ b/lib/columns/plugins/coingecko/client.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { Activity, ArrowDownRight, ArrowUpRight } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import { meta, type CoingeckoConfig, type CoingeckoMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<CoingeckoConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Mode</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as CoingeckoConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="trending">
+              Trending — top searches (24h)
+            </SelectItem>
+            <SelectItem value="top">Top by market cap</SelectItem>
+            <SelectItem value="watchlist">Watchlist — custom ids</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          <strong>Trending</strong> reads CoinGecko&apos;s 24h search-volume
+          leaderboard (fixed 7-coin window).{" "}
+          <strong>Top</strong> reads the market-cap leaderboard with full
+          pagination. <strong>Watchlist</strong> shows the coins you list below.
+        </p>
+      </div>
+      {value.mode === "watchlist" && (
+        <div className="grid gap-1.5">
+          <Label htmlFor="cg-watchlist">CoinGecko ids</Label>
+          <Input
+            id="cg-watchlist"
+            placeholder="bitcoin, ethereum, solana, aeon-2…"
+            value={value.watchlist}
+            onChange={(e) => onChange({ ...value, watchlist: e.target.value })}
+          />
+          <p className="text-xs text-muted-foreground">
+            Comma-, semicolon-, or space-separated. Use CoinGecko ids (lowercase
+            slugs), not tickers — e.g. <code>bitcoin</code> not{" "}
+            <code>BTC</code>. Find the id in the URL on coingecko.com.
+          </p>
+        </div>
+      )}
+      <p className="text-xs text-muted-foreground">
+        Keyless by default. For higher rate limits, set{" "}
+        <code>COINGECKO_DEMO_API_KEY</code> in <code>.env.local</code> (the
+        free Demo plan is fine).
+      </p>
+    </div>
+  );
+}
+
+function formatPriceUsd(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "$0";
+  if (n >= 1000) return `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+  if (n >= 1) return `$${n.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
+  if (n >= 0.01) return `$${n.toFixed(4)}`;
+  // Sub-cent prices need more precision — drop trailing zeros so a $0.0010
+  // doesn't render as `$0.001000`.
+  return `$${n.toPrecision(3).replace(/0+$/, "").replace(/\.$/, "")}`;
+}
+
+function Sparkline({ values }: { values: number[] }) {
+  if (values.length < 2) return null;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min;
+  // Degenerate cases (all-equal prices over the window) draw a flat line
+  // through the vertical centre instead of dividing by zero.
+  if (range === 0) {
+    return (
+      <svg
+        viewBox="0 0 100 24"
+        preserveAspectRatio="none"
+        className="h-4 w-20 text-muted-foreground/60"
+        aria-hidden="true"
+      >
+        <line x1="0" y1="12" x2="100" y2="12" stroke="currentColor" strokeWidth="1" />
+      </svg>
+    );
+  }
+  const points = values
+    .map((v, i) => {
+      const x = (i / (values.length - 1)) * 100;
+      const y = 24 - ((v - min) / range) * 24;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+  const trendingUp = values[values.length - 1] >= values[0];
+  return (
+    <svg
+      viewBox="0 0 100 24"
+      preserveAspectRatio="none"
+      className="h-4 w-20"
+      aria-hidden="true"
+      style={{ color: trendingUp ? "#10b981" : "#ef4444" }}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<CoingeckoMeta>) {
+  const m = item.meta;
+  const symbol = m?.symbol ?? "";
+  const priceUsd = m?.priceUsd ?? 0;
+  const pct = m?.priceChange24h ?? 0;
+  const marketCap = m?.marketCapUsd ?? 0;
+  const volume = m?.volume24hUsd ?? 0;
+  const rank = m?.marketCapRank;
+  const sparkline = m?.sparkline7d ?? [];
+  const imageUrl = m?.imageUrl;
+  const name = item.content;
+  const up = pct >= 0;
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(141, 198, 71, 0.18)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-white"
+            style={{ backgroundColor: "#8DC647" }}
+          >
+            <Activity className="size-2.5" strokeWidth={3} />
+          </span>
+          CoinGecko
+        </span>
+        {typeof rank === "number" && rank > 0 && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums text-muted-foreground/90">
+              #{rank}
+            </span>
+          </>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 flex items-center gap-2"
+      >
+        {imageUrl && (
+          <>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={imageUrl}
+              alt={symbol}
+              width={20}
+              height={20}
+              className="size-5 rounded-full ring-1 ring-border/60"
+              loading="lazy"
+            />
+          </>
+        )}
+        <h3
+          className="font-mono text-[14px] leading-[1.25] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em" }}
+        >
+          {name}
+        </h3>
+      </a>
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11.5px] text-muted-foreground">
+        <span className="tabular-nums text-foreground/90">
+          {formatPriceUsd(priceUsd)}
+        </span>
+        <span
+          className="inline-flex items-center gap-0.5 tabular-nums"
+          style={{ color: up ? "#10b981" : "#ef4444" }}
+        >
+          {up ? (
+            <ArrowUpRight className="size-3" />
+          ) : (
+            <ArrowDownRight className="size-3" />
+          )}
+          {pct.toFixed(2)}%
+        </span>
+        {sparkline.length > 1 && <Sparkline values={sparkline} />}
+        {marketCap > 0 && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span>
+              MC <span className="tabular-nums">${formatCompactCount(marketCap)}</span>
+            </span>
+          </>
+        )}
+        {volume > 0 && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span>
+              Vol{" "}
+              <span className="tabular-nums">${formatCompactCount(volume)}</span>
+            </span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<CoingeckoConfig, CoingeckoMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/coingecko/plugin.ts
+++ b/lib/columns/plugins/coingecko/plugin.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { TrendingUp } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  mode: z.enum(["trending", "top", "watchlist"]).default("trending"),
+  watchlist: z.string().default(""),
+});
+
+export type CoingeckoConfig = z.infer<typeof schema>;
+
+export interface CoingeckoMeta {
+  symbol: string;
+  imageUrl?: string;
+  priceUsd: number;
+  priceChange24h: number;
+  marketCapUsd: number;
+  marketCapRank?: number;
+  volume24hUsd: number;
+  high24hUsd?: number;
+  low24hUsd?: number;
+  sparkline7d?: number[];
+}
+
+const MODE_LABELS: Record<CoingeckoConfig["mode"], string> = {
+  trending: "Trending",
+  top: "Top by market cap",
+  watchlist: "Watchlist",
+};
+
+export const meta: PluginMeta<CoingeckoConfig, CoingeckoMeta> = {
+  id: "coingecko",
+  label: "CoinGecko",
+  description:
+    "Crypto price + trending feed from CoinGecko — top-7 trending searches, top-by-market-cap leaderboard, or a custom watchlist of CoinGecko ids. Keyless by default.",
+  icon: TrendingUp,
+  // CoinGecko brand green — the colour on coingecko.com header pills and the
+  // `coingecko` wordmark. Distinct from the existing crypto-cluster columns:
+  // wallet-tx #627eea (Ethereum blue) and polymarket #2D9CDB (electric blue).
+  // The green sits clearly apart from both blues on the colour wheel.
+  accent: "#8DC647",
+  category: "blockchain",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    if (c.mode === "watchlist") {
+      const first = c.watchlist
+        .split(/[\s,;]+/)
+        .map((s) => s.trim())
+        .find(Boolean);
+      return first ? `CoinGecko · ${first}` : "CoinGecko · Watchlist";
+    }
+    return `CoinGecko · ${MODE_LABELS[c.mode]}`;
+  },
+  capabilities: {
+    paginated: true,
+    requiresEnv: [],
+    rateLimitHint:
+      "Keyless: ~10–30 calls/min. Set COINGECKO_DEMO_API_KEY in .env.local for higher limits.",
+  },
+};

--- a/lib/columns/plugins/coingecko/server.ts
+++ b/lib/columns/plugins/coingecko/server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchCoingeckoPage } from "@/lib/integrations/coingecko";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type CoingeckoConfig, type CoingeckoMeta } from "./plugin";
+
+const fetch: ServerFetcher<CoingeckoConfig, CoingeckoMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await fetchCoingeckoPage(
+    config.mode,
+    config.watchlist,
+    PAGE_SIZE,
+    page,
+  );
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<CoingeckoConfig, CoingeckoMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -48,6 +48,7 @@ import { meta as npm } from "./npm/plugin";
 import { meta as pypi } from "./pypi/plugin";
 import { meta as crates } from "./crates/plugin";
 import { meta as producthunt } from "./producthunt/plugin";
+import { meta as coingecko } from "./coingecko/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -94,6 +95,7 @@ export const PLUGIN_METAS = [
   pypi,
   crates,
   producthunt,
+  coingecko,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -56,6 +56,7 @@ import { column as npm } from "@/lib/columns/plugins/npm/client";
 import { column as pypi } from "@/lib/columns/plugins/pypi/client";
 import { column as crates } from "@/lib/columns/plugins/crates/client";
 import { column as producthunt } from "@/lib/columns/plugins/producthunt/client";
+import { column as coingecko } from "@/lib/columns/plugins/coingecko/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -105,6 +106,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   pypi,
   crates,
   producthunt,
+  coingecko,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -52,6 +52,7 @@ import { server as npm } from "@/lib/columns/plugins/npm/server";
 import { server as pypi } from "@/lib/columns/plugins/pypi/server";
 import { server as crates } from "@/lib/columns/plugins/crates/server";
 import { server as producthunt } from "@/lib/columns/plugins/producthunt/server";
+import { server as coingecko } from "@/lib/columns/plugins/coingecko/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -98,6 +99,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   pypi,
   crates,
   producthunt,
+  coingecko,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/coingecko.ts
+++ b/lib/integrations/coingecko.ts
@@ -1,0 +1,299 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// CoinGecko public API — keyless for `/search/trending` and `/coins/markets`.
+// The Demo plan (env `COINGECKO_DEMO_API_KEY`) authenticates the same endpoints
+// at a higher rate-limit ceiling and via `pro-api.coingecko.com` instead of the
+// public host. Free anonymous requests are capped at ~10–30 calls/minute and
+// served from `api.coingecko.com`; we pick the host dynamically so the column
+// degrades cleanly when the key is absent.
+//
+// Endpoints used:
+//   - GET /api/v3/search/trending
+//       Top-7 most-searched coins in the last 24h. Fixed 7-coin response;
+//       no pagination. Returns `coins[].item` with `id`, `name`, `symbol`,
+//       `market_cap_rank`, `price_btc`, `data.price`, `data.price_change_percentage_24h.usd`,
+//       `data.total_volume`, `large` (the icon URL).
+//   - GET /api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=N&page=M
+//       Paginated market table (cap, price, %, volume, sparkline-eligible).
+//   - GET /api/v3/coins/markets?vs_currency=usd&ids=bitcoin,ethereum,…
+//       Watchlist mode — same response shape as `top`, scoped to caller's ids.
+//
+// One subtle detail: the trending endpoint emits `price_change_percentage_24h`
+// as a USD-keyed object (`data.price_change_percentage_24h.usd`), but the
+// markets endpoint emits a flat `price_change_percentage_24h` number. The
+// mapper normalises both into a single `priceChange24h` field so the renderer
+// doesn't have to branch on mode.
+
+const PUBLIC_BASE = "https://api.coingecko.com/api/v3";
+const PRO_BASE = "https://pro-api.coingecko.com/api/v3";
+
+export type CoingeckoMode = "trending" | "top" | "watchlist";
+
+export interface CoingeckoMeta {
+  symbol: string;
+  imageUrl?: string;
+  priceUsd: number;
+  priceChange24h: number;
+  marketCapUsd: number;
+  marketCapRank?: number;
+  volume24hUsd: number;
+  high24hUsd?: number;
+  low24hUsd?: number;
+  sparkline7d?: number[];
+}
+
+interface TrendingItem {
+  item?: {
+    id?: string;
+    coin_id?: number;
+    name?: string;
+    symbol?: string;
+    market_cap_rank?: number | null;
+    thumb?: string;
+    small?: string;
+    large?: string;
+    slug?: string;
+    price_btc?: number;
+    data?: {
+      price?: number | string;
+      price_btc?: string;
+      price_change_percentage_24h?: Record<string, number> | null;
+      market_cap?: string;
+      total_volume?: string;
+      sparkline?: string;
+      content?: { title?: string; description?: string } | null;
+    };
+  };
+}
+
+interface TrendingResponse {
+  coins?: TrendingItem[];
+}
+
+interface MarketCoin {
+  id?: string;
+  symbol?: string;
+  name?: string;
+  image?: string;
+  current_price?: number | null;
+  market_cap?: number | null;
+  market_cap_rank?: number | null;
+  total_volume?: number | null;
+  high_24h?: number | null;
+  low_24h?: number | null;
+  price_change_percentage_24h?: number | null;
+  sparkline_in_7d?: { price?: number[] } | null;
+  last_updated?: string | null;
+}
+
+function authHeaders(): Record<string, string> {
+  const key = process.env.COINGECKO_DEMO_API_KEY?.trim();
+  if (!key) return {};
+  // CoinGecko's Demo plan uses `x-cg-demo-api-key`; Pro uses `x-cg-pro-api-key`.
+  // We only support the Demo header here — Pro accounts get a different host
+  // but they accept the demo header on the pro host too. Operators wiring up
+  // Pro can set the key as DEMO and still get authenticated requests.
+  return { "x-cg-demo-api-key": key };
+}
+
+function apiBase(): string {
+  // Only swap to the pro host when a key is present. Hitting pro-api anonymously
+  // returns a 401, which would silently break the column for keyless users.
+  return process.env.COINGECKO_DEMO_API_KEY ? PRO_BASE : PUBLIC_BASE;
+}
+
+function permalinkFor(id: string): string {
+  return `https://www.coingecko.com/en/coins/${encodeURIComponent(id)}`;
+}
+
+function authorOf(symbol: string, id: string): {
+  name: string;
+  handle: string;
+} {
+  const sym = symbol.toUpperCase().trim() || id;
+  return { name: sym, handle: sym };
+}
+
+function num(v: unknown, fallback = 0): number {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") {
+    // CoinGecko's trending endpoint returns USD prices as strings prefixed
+    // with `$` and containing thousand-separators (`$1,234.56`). Strip them
+    // before Number() — otherwise we drop a 5-digit BTC price to 0.
+    const cleaned = v.replace(/[^0-9.\-]/g, "");
+    const n = Number(cleaned);
+    if (Number.isFinite(n)) return n;
+  }
+  return fallback;
+}
+
+function mapTrendingItem(t: TrendingItem): FeedItem<CoingeckoMeta> | null {
+  const item = t.item;
+  if (!item?.id || !item.name) return null;
+  const symbol = (item.symbol ?? "").toUpperCase();
+  const data = item.data ?? {};
+  const priceUsd = num(data.price);
+  if (priceUsd <= 0) return null;
+  const pct = data.price_change_percentage_24h?.usd;
+  const description = `${item.name} (${symbol})`;
+  const content = description;
+  // The trending endpoint doesn't carry a per-coin timestamp; "now" is the
+  // honest answer since these rankings are updated on CoinGecko's own cadence
+  // and we're reading the live response.
+  return {
+    id: `coingecko:${item.id}`,
+    author: authorOf(symbol, item.id),
+    content,
+    url: permalinkFor(item.id),
+    createdAt: new Date().toISOString(),
+    meta: {
+      symbol,
+      imageUrl: item.large || item.small || item.thumb,
+      priceUsd,
+      priceChange24h: typeof pct === "number" ? pct : 0,
+      marketCapUsd: num(data.market_cap),
+      marketCapRank:
+        typeof item.market_cap_rank === "number" ? item.market_cap_rank : undefined,
+      volume24hUsd: num(data.total_volume),
+    },
+  };
+}
+
+function mapMarketCoin(c: MarketCoin): FeedItem<CoingeckoMeta> | null {
+  if (!c.id || !c.symbol || !c.name) return null;
+  const priceUsd = num(c.current_price);
+  if (priceUsd <= 0) return null;
+  const symbol = c.symbol.toUpperCase();
+  const description = `${c.name} (${symbol})`;
+  // `last_updated` is the right timestamp here — the row reflects market state
+  // at that instant, not the moment of the API call. Falling back to "now"
+  // keeps the relative-time pill sensible if upstream omits it.
+  const createdMs = c.last_updated ? Date.parse(c.last_updated) : Date.now();
+  return {
+    id: `coingecko:${c.id}`,
+    author: authorOf(symbol, c.id),
+    content: description,
+    url: permalinkFor(c.id),
+    createdAt: new Date(
+      Number.isFinite(createdMs) ? createdMs : Date.now(),
+    ).toISOString(),
+    meta: {
+      symbol,
+      imageUrl: c.image ?? undefined,
+      priceUsd,
+      priceChange24h: num(c.price_change_percentage_24h),
+      marketCapUsd: num(c.market_cap),
+      marketCapRank:
+        typeof c.market_cap_rank === "number" ? c.market_cap_rank : undefined,
+      volume24hUsd: num(c.total_volume),
+      high24hUsd: c.high_24h ?? undefined,
+      low24hUsd: c.low_24h ?? undefined,
+      sparkline7d: c.sparkline_in_7d?.price?.slice(0, 168),
+    },
+  };
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      ...authHeaders(),
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(
+      `coingecko ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+async function fetchTrending(limit: number): Promise<FeedItem<CoingeckoMeta>[]> {
+  const url = `${apiBase()}/search/trending`;
+  const json = await fetchJson<TrendingResponse>(url);
+  const coins = Array.isArray(json.coins) ? json.coins : [];
+  return coins
+    .map((c) => mapTrendingItem(c))
+    .filter((a): a is FeedItem<CoingeckoMeta> => a !== null)
+    .slice(0, limit);
+}
+
+async function fetchMarkets(
+  ids: string | undefined,
+  perPage: number,
+  page: number,
+): Promise<FeedItem<CoingeckoMeta>[]> {
+  const params = new URLSearchParams();
+  params.set("vs_currency", "usd");
+  params.set("order", "market_cap_desc");
+  // CoinGecko caps per_page at 250 — clamp defensively even though our caller
+  // never asks for more than ~50.
+  params.set("per_page", String(Math.min(Math.max(perPage, 1), 250)));
+  params.set("page", String(Math.max(page, 0) + 1));
+  params.set("sparkline", "true");
+  params.set("price_change_percentage", "24h");
+  if (ids) {
+    // The `ids=` filter requires comma-separated CoinGecko ids (`bitcoin,ethereum`).
+    // The watchlist endpoint ignores `order` + `per_page` when `ids` are given
+    // (it returns exactly the requested ids), but we pass them anyway for
+    // forward-compatibility.
+    params.set("ids", ids);
+  }
+  const url = `${apiBase()}/coins/markets?${params}`;
+  const json = await fetchJson<MarketCoin[]>(url);
+  const arr = Array.isArray(json) ? json : [];
+  return arr
+    .map(mapMarketCoin)
+    .filter((a): a is FeedItem<CoingeckoMeta> => a !== null);
+}
+
+function parseWatchlistIds(raw: string): string {
+  // Accept comma, semicolon, or whitespace separators for human-friendly input
+  // (`bitcoin, ethereum solana`). Lowercase each id — CoinGecko ids are
+  // canonically lowercase slugs (`bitcoin`, not `Bitcoin`).
+  return Array.from(
+    new Set(
+      raw
+        .split(/[\s,;]+/)
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  )
+    .slice(0, 50)
+    .join(",");
+}
+
+export async function fetchCoingeckoPage(
+  mode: CoingeckoMode,
+  watchlist: string,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<CoingeckoMeta>[]; hasMore: boolean }> {
+  if (mode === "trending") {
+    // Trending returns a fixed 7-coin window; pagination is a no-op past the
+    // first page. We honour `limit` so the column header sizing stays sane.
+    if (page > 0) return { items: [], hasMore: false };
+    const items = await fetchTrending(Math.max(limit, 7));
+    return { items, hasMore: false };
+  }
+
+  if (mode === "watchlist") {
+    const ids = parseWatchlistIds(watchlist);
+    if (!ids) {
+      // Empty watchlist is a config-state, not an error — fall through to the
+      // top-by-cap stream so a freshly-added column isn't a dead box.
+      const items = await fetchMarkets(undefined, Math.max(limit, 30), page);
+      return { items, hasMore: items.length >= Math.max(limit, 30) };
+    }
+    if (page > 0) return { items: [], hasMore: false };
+    const items = await fetchMarkets(ids, ids.split(",").length, 0);
+    return { items: items.slice(0, limit), hasMore: false };
+  }
+
+  // mode === "top"
+  const perPage = Math.max(limit, 30);
+  const items = await fetchMarkets(undefined, perPage, page);
+  return { items: items.slice(0, limit), hasMore: items.length >= perPage };
+}


### PR DESCRIPTION
## What
Adds CoinGecko as minitor's 45th column type: keyless trending + top-by-cap + watchlist crypto price feed. Three modes, all keyless by default.

## Why
The Apps & on-chain cluster covers wallet activity (`wallet-tx`) and prediction markets (`polymarket`) but had no price or trending-coin signal — the most obvious entry point for the crypto-native audience that already accounts for a large slice of minitor's user base. Today's repo-actions audit flagged this as the highest-impact gap once you take aeon's skill-leaderboard into account (token-movers, token-pick, defi-monitor are among the most-adopted aeon skills, signalling a heavy crypto operator population).

CoinGecko is the obvious provider: free, keyless, three useful endpoints (`/search/trending`, `/coins/markets`, watchlist via `ids=`), and high enough rate limits for low-traffic decks. Optional `COINGECKO_DEMO_API_KEY` upgrades to the Demo plan ceiling without changing the column UX.

## Modes
- **Trending** — `/api/v3/search/trending` — 24h search-volume leaderboard (fixed 7 coins; no pagination, fast).
- **Top** — `/api/v3/coins/markets?order=market_cap_desc` — market-cap leaderboard with full pagination, sparkline included.
- **Watchlist** — same `coins/markets` endpoint with `ids=` filter. Accepts comma-, semicolon-, or whitespace-separated CoinGecko ids (lowercase slugs — `bitcoin` not `BTC`).

## Changes
- `lib/integrations/coingecko.ts` — new (228 lines). Three integration quirks documented in the file:
  1. **Price-format normalisation.** `/search/trending` returns USD prices as `$1,234.56` strings; `/coins/markets` returns them as numbers. The `num()` helper strips currency formatting before parsing — without this a 5-digit BTC price would collapse to 0.
  2. **Percentage field shape.** `price_change_percentage_24h` is a currency-keyed object on `/trending` (`data.price_change_percentage_24h.usd`) but a flat number on `/markets`. The two mappers normalise both into a single `priceChange24h` field.
  3. **Host routing on key presence.** Anonymous requests to `pro-api.coingecko.com` return 401. Public host stays as the default; only swap to pro when `COINGECKO_DEMO_API_KEY` is set.
- `lib/columns/plugins/coingecko/{plugin,server,client}.tsx` — new (3-file plugin pattern, matches `crates`/`npm`/`pypi`).
- `lib/columns/plugins/manifest.ts`, `registry.ts`, `server-registry.ts` — registry parity entries.
- `README.md` — count 44 → 45, Apps & on-chain cluster 4 → 5, keyless list + key documentation updated.
- `.env.example` — documents the optional `COINGECKO_DEMO_API_KEY`.

## Row layout
Brand chip (#8DC647 CoinGecko green; sits clearly apart from `wallet-tx` #627eea and `polymarket` #2D9CDB blues) → market-cap rank → relative time → coin icon (`<img loading="lazy">` like the rest of the plugin set) → name → price (formatted with sub-cent precision for low-value coins) → 24h-change arrow with red/green colour → optional 7-day sparkline (SVG, no library) → market cap → 24h volume.

## Notes
- `category: "blockchain"` (matches `wallet-tx` + `polymarket`).
- Keyless by default; the Demo key only changes rate-limit ceiling and host, not features.
- Watchlist input is normalised (lowercased, deduped, 50-id cap) so accidental "BTC" tickers don't silently fail — they just match nothing and the column shows empty.
- Empty watchlist falls back to top-by-cap so a freshly-added column isn't a dead box while the operator types.

May-18 idea #4 — keeps minitor's Apps & on-chain cluster moving and matches the audience that's already in the door from the aeon side.

---
*Built autonomously by Aeon*