### PR TITLE
feat: DeFiLlama TVL column (47th column type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm + PyPI + crates.io packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions / Discussions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, CoinGecko crypto trending + prices, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm + PyPI + crates.io packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions / Discussions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, CoinGecko crypto trending + prices, DeFiLlama TVL leaderboard, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 46 column types out of the box — social feeds, news, GitHub (including CI runs and Discussions), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, CoinGecko prices, Chinese hot boards.
+- 47 column types out of the box — social feeds, news, GitHub (including CI runs and Discussions), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, CoinGecko prices, DeFiLlama TVL, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
@@ -41,7 +41,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, Product Hunt, npm, PyPI, crates.io, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket, CoinGecko) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, Product Hunt, npm, PyPI, crates.io, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket, CoinGecko, DeFiLlama) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -64,7 +64,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 | **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |
-| **Apps & on-chain** (5) | `apple-reviews`, `play-reviews`, `wallet-tx`, `polymarket`, `coingecko` |
+| **Apps & on-chain** (6) | `apple-reviews`, `play-reviews`, `wallet-tx`, `polymarket`, `coingecko`, `defillama` |
 | **China hot boards** (6) | `weibo-hot`, `zhihu-hot`, `douyin-hot`, `bilibili-hot`, `toutiao`, `baidu-hot` |
 
 Full plugin manifest: [`lib/columns/plugins/manifest.ts`](lib/columns/plugins/manifest.ts). Add a new source by copying [`lib/columns/plugins/_template/`](lib/columns/plugins/_template/) — see [`lib/columns/README.md`](lib/columns/README.md) for the full contract.

--- a/lib/columns/plugins/defillama/client.tsx
+++ b/lib/columns/plugins/defillama/client.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { Layers, ArrowDownRight, ArrowUpRight } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import { meta, type DefillamaConfig, type DefillamaMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<DefillamaConfig>) {
+  const chainsMode = value.mode === "chains";
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Mode</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as DefillamaConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="top">Top protocols — by TVL</SelectItem>
+            <SelectItem value="gainers">24h gainers — top % up</SelectItem>
+            <SelectItem value="chains">Chains — by TVL</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          <strong>Top</strong> is the protocol leaderboard sorted by TVL.{" "}
+          <strong>Gainers</strong> re-sorts by 24h TVL change with absolute
+          TVL as tiebreaker. <strong>Chains</strong> aggregates TVL per chain
+          instead of per protocol.
+        </p>
+      </div>
+      {!chainsMode && (
+        <div className="grid gap-1.5">
+          <Label htmlFor="dl-category">Category filter (optional)</Label>
+          <Input
+            id="dl-category"
+            placeholder="Dexs, Lending, Liquid Staking, Restaking, CDP, Yield…"
+            value={value.category}
+            onChange={(e) => onChange({ ...value, category: e.target.value })}
+          />
+          <p className="text-xs text-muted-foreground">
+            Substring match against DeFiLlama&apos;s category names (e.g.{" "}
+            <code>lending</code> matches both <code>Lending</code> and{" "}
+            <code>Cross-Chain Lending</code>). Leave empty to see every
+            category.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<DefillamaMeta>) {
+  const m = item.meta;
+  const tvl = m?.tvlUsd ?? 0;
+  const pct = m?.tvlChange24h ?? 0;
+  const pct7d = m?.tvlChange7d;
+  const cat = m?.category;
+  const chains = m?.chains;
+  const mcap = m?.marketCapUsd;
+  const imageUrl = m?.imageUrl;
+  const name = item.content;
+  const up = pct >= 0;
+  const isChain = m?.kind === "chain";
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(68, 94, 208, 0.16)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-white"
+            style={{ backgroundColor: "#445ed0" }}
+          >
+            <Layers className="size-2.5" strokeWidth={3} />
+          </span>
+          DeFiLlama
+        </span>
+        {cat && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="text-muted-foreground/90">{cat}</span>
+          </>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 flex items-center gap-2"
+      >
+        {imageUrl && (
+          <>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={imageUrl}
+              alt={m?.symbol ?? name}
+              width={20}
+              height={20}
+              className="size-5 rounded-full ring-1 ring-border/60"
+              loading="lazy"
+            />
+          </>
+        )}
+        <h3
+          className="font-mono text-[14px] leading-[1.25] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em" }}
+        >
+          {name}
+        </h3>
+      </a>
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11.5px] text-muted-foreground">
+        <span className="tabular-nums text-foreground/90">
+          TVL ${formatCompactCount(tvl)}
+        </span>
+        {!isChain && (
+          <span
+            className="inline-flex items-center gap-0.5 tabular-nums"
+            style={{ color: up ? "#10b981" : "#ef4444" }}
+          >
+            {up ? (
+              <ArrowUpRight className="size-3" />
+            ) : (
+              <ArrowDownRight className="size-3" />
+            )}
+            {pct.toFixed(2)}%
+          </span>
+        )}
+        {!isChain && typeof pct7d === "number" && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums">
+              7d {pct7d >= 0 ? "+" : ""}
+              {pct7d.toFixed(1)}%
+            </span>
+          </>
+        )}
+        {mcap && mcap > 0 && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span>
+              MC{" "}
+              <span className="tabular-nums">${formatCompactCount(mcap)}</span>
+            </span>
+          </>
+        )}
+        {!isChain && chains && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="line-clamp-1">{chains}</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<DefillamaConfig, DefillamaMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/defillama/plugin.ts
+++ b/lib/columns/plugins/defillama/plugin.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import { Layers } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  mode: z.enum(["top", "gainers", "chains"]).default("top"),
+  category: z.string().default(""),
+});
+
+export type DefillamaConfig = z.infer<typeof schema>;
+
+export interface DefillamaMeta {
+  symbol: string;
+  imageUrl?: string;
+  tvlUsd: number;
+  tvlChange24h: number;
+  tvlChange7d?: number;
+  category?: string;
+  chains?: string;
+  marketCapUsd?: number;
+  kind: "protocol" | "chain";
+}
+
+const MODE_LABELS: Record<DefillamaConfig["mode"], string> = {
+  top: "Top protocols",
+  gainers: "24h gainers",
+  chains: "Chains by TVL",
+};
+
+export const meta: PluginMeta<DefillamaConfig, DefillamaMeta> = {
+  id: "defillama",
+  label: "DeFiLlama",
+  description:
+    "On-chain TVL leaderboard from DeFiLlama — top protocols by TVL, biggest 24h movers, or per-chain TVL. Optional category filter (Dexs, Lending, Liquid Staking, Restaking, CDP, Yield…). Keyless.",
+  icon: Layers,
+  // DeFiLlama brand blue — the colour used on defillama.com header pills and
+  // the wordmark. Distinct from the existing on-chain cluster: wallet-tx
+  // #627eea (Ethereum), polymarket #2D9CDB (electric blue), coingecko #8DC647
+  // (green). DeFiLlama's deeper purple-blue sits clearly apart from all three.
+  accent: "#445ed0",
+  category: "blockchain",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const cat = c.category.trim();
+    if (cat) {
+      return `DeFiLlama · ${cat}`;
+    }
+    return `DeFiLlama · ${MODE_LABELS[c.mode]}`;
+  },
+  capabilities: {
+    paginated: true,
+    requiresEnv: [],
+    rateLimitHint:
+      "Keyless. DeFiLlama's edge cache makes the per-request cost negligible; no per-IP token bucket is advertised.",
+  },
+};

--- a/lib/columns/plugins/defillama/server.ts
+++ b/lib/columns/plugins/defillama/server.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchDefillamaPage } from "@/lib/integrations/defillama";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type DefillamaConfig, type DefillamaMeta } from "./plugin";
+
+const fetch: ServerFetcher<DefillamaConfig, DefillamaMeta> = async (
+  config,
+  cursor,
+) => {
+  const page = cursor ? Number(cursor) || 0 : 0;
+  const r = await fetchDefillamaPage(
+    config.mode,
+    config.category,
+    PAGE_SIZE,
+    page,
+  );
+  return {
+    items: r.items,
+    nextCursor: r.hasMore ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<DefillamaConfig, DefillamaMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -50,6 +50,7 @@ import { meta as crates } from "./crates/plugin";
 import { meta as producthunt } from "./producthunt/plugin";
 import { meta as coingecko } from "./coingecko/plugin";
 import { meta as githubDiscussions } from "./github-discussions/plugin";
+import { meta as defillama } from "./defillama/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -98,6 +99,7 @@ export const PLUGIN_METAS = [
   producthunt,
   coingecko,
   githubDiscussions,
+  defillama,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -58,6 +58,7 @@ import { column as crates } from "@/lib/columns/plugins/crates/client";
 import { column as producthunt } from "@/lib/columns/plugins/producthunt/client";
 import { column as coingecko } from "@/lib/columns/plugins/coingecko/client";
 import { column as githubDiscussions } from "@/lib/columns/plugins/github-discussions/client";
+import { column as defillama } from "@/lib/columns/plugins/defillama/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -109,6 +110,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   producthunt,
   coingecko,
   "github-discussions": githubDiscussions,
+  defillama,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -54,6 +54,7 @@ import { server as crates } from "@/lib/columns/plugins/crates/server";
 import { server as producthunt } from "@/lib/columns/plugins/producthunt/server";
 import { server as coingecko } from "@/lib/columns/plugins/coingecko/server";
 import { server as githubDiscussions } from "@/lib/columns/plugins/github-discussions/server";
+import { server as defillama } from "@/lib/columns/plugins/defillama/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -102,6 +103,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   producthunt,
   coingecko,
   "github-discussions": githubDiscussions,
+  defillama,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/defillama.ts
+++ b/lib/integrations/defillama.ts
@@ -1,0 +1,234 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// DeFiLlama public API — keyless. Two endpoints cover all three column modes:
+//
+//   - GET https://api.llama.fi/protocols
+//       Full protocol list (~3000 entries, ~2-3 MB) with TVL, % change (1h/1d/7d),
+//       category, mcap, logo, chain, etc. The response is already sorted by TVL
+//       desc; we re-sort for the gainers mode.
+//
+//   - GET https://api.llama.fi/v2/chains
+//       Per-chain TVL list (~200 entries). Smaller payload; sorted by TVL desc
+//       by the mapper. Used by the `chains` mode.
+//
+// Both endpoints are stateless and CORS-friendly; the API caches aggressively
+// at the edge so the per-request cost is low even for the 3000-protocol list.
+// Anonymous, no auth headers, no per-IP token bucket exposed in the public docs.
+//
+// One implementation detail worth flagging: DeFiLlama's protocol payload mixes
+// CEX entries (Binance CEX, Coinbase Custody, etc.) with on-chain protocols.
+// We surface CEXes as-is — operators watching the broader "where is custody
+// concentrated" picture want them included, and the `category` filter is the
+// escape hatch for anyone who wants pure-DeFi.
+
+const API_BASE = "https://api.llama.fi";
+
+export type DefillamaMode = "top" | "gainers" | "chains";
+
+export interface DefillamaMeta {
+  /** Display symbol or chain ticker (e.g. "AAVE", "ETH"). May be empty. */
+  symbol: string;
+  /** Hosted protocol/chain logo URL when available. */
+  imageUrl?: string;
+  /** Current TVL in USD (already in USD — DeFiLlama normalises). */
+  tvlUsd: number;
+  /** Percent change over 24h (+/-). */
+  tvlChange24h: number;
+  /** Percent change over 7d (+/-). */
+  tvlChange7d?: number;
+  /** Protocol category (DeFiLlama's taxonomy, e.g. "Lending", "Dexs"). */
+  category?: string;
+  /** Comma-joined chain list from DeFiLlama (e.g. "Ethereum, Base"). */
+  chains?: string;
+  /** Market cap of the protocol token in USD, when DeFiLlama has it. */
+  marketCapUsd?: number;
+  /** "protocol" or "chain" — lets the renderer style the row differently. */
+  kind: "protocol" | "chain";
+}
+
+interface DefillamaProtocol {
+  id?: string;
+  name?: string;
+  symbol?: string;
+  slug?: string;
+  url?: string;
+  logo?: string;
+  category?: string;
+  chain?: string;
+  chains?: string[];
+  tvl?: number | null;
+  change_1h?: number | null;
+  change_1d?: number | null;
+  change_7d?: number | null;
+  mcap?: number | null;
+  listedAt?: number | null;
+}
+
+interface DefillamaChain {
+  gecko_id?: string | null;
+  name?: string;
+  tokenSymbol?: string | null;
+  tvl?: number | null;
+  cmcId?: string | null;
+  chainId?: number | null;
+}
+
+function num(v: unknown, fallback = 0): number {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  return fallback;
+}
+
+function protocolPermalink(slug: string | undefined, fallbackName: string): string {
+  const seg = (slug || fallbackName).trim();
+  if (!seg) return "https://defillama.com/";
+  // DeFiLlama protocol pages live at /protocol/{slug}. The slug is canonical
+  // and lowercase; we never URL-encode it because DeFiLlama itself emits the
+  // raw slug in its frontend links.
+  return `https://defillama.com/protocol/${encodeURIComponent(seg.toLowerCase())}`;
+}
+
+function chainPermalink(name: string): string {
+  // The chain detail page lives at /chain/{name} — name is the human label
+  // (e.g. "Ethereum", "BSC", "Base"), with no slug variant.
+  return `https://defillama.com/chain/${encodeURIComponent(name)}`;
+}
+
+function mapProtocol(p: DefillamaProtocol): FeedItem<DefillamaMeta> | null {
+  if (!p.name) return null;
+  const tvl = num(p.tvl);
+  // DeFiLlama lists every protocol it has ever scraped, including ones whose
+  // TVL has fallen to 0. They're noise in a leaderboard column — drop them.
+  if (tvl <= 0) return null;
+  const symbol = (p.symbol ?? "").toUpperCase().trim();
+  const id = (p.slug || p.id || p.name).toString();
+  const chains = Array.isArray(p.chains) ? p.chains.join(", ") : p.chain ?? "";
+  return {
+    id: `defillama:protocol:${id}`,
+    author: {
+      name: p.name,
+      handle: symbol || p.name,
+      // No avatar — DeFiLlama logos are protocol-square logos, surfaced via
+      // meta.imageUrl below. The author block is just for the card header.
+    },
+    content: `${p.name}${symbol ? ` (${symbol})` : ""}`,
+    url: protocolPermalink(p.slug, p.name),
+    // DeFiLlama doesn't ship a per-protocol "updated at" — the data is
+    // recomputed in lockstep across the whole list. Honest answer: now.
+    createdAt: new Date().toISOString(),
+    meta: {
+      symbol,
+      imageUrl: p.logo ?? undefined,
+      tvlUsd: tvl,
+      tvlChange24h: num(p.change_1d),
+      tvlChange7d: typeof p.change_7d === "number" ? p.change_7d : undefined,
+      category: p.category ?? undefined,
+      chains: chains || undefined,
+      marketCapUsd: typeof p.mcap === "number" && p.mcap > 0 ? p.mcap : undefined,
+      kind: "protocol",
+    },
+  };
+}
+
+function mapChain(c: DefillamaChain): FeedItem<DefillamaMeta> | null {
+  if (!c.name) return null;
+  const tvl = num(c.tvl);
+  if (tvl <= 0) return null;
+  const symbol = (c.tokenSymbol ?? "").toUpperCase().trim();
+  return {
+    id: `defillama:chain:${c.name.toLowerCase()}`,
+    author: {
+      name: c.name,
+      handle: symbol || c.name,
+    },
+    content: `${c.name}${symbol ? ` · ${symbol}` : ""}`,
+    url: chainPermalink(c.name),
+    createdAt: new Date().toISOString(),
+    meta: {
+      symbol,
+      tvlUsd: tvl,
+      tvlChange24h: 0,
+      category: "Chain",
+      kind: "chain",
+    },
+  };
+}
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(
+      `defillama ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+export function parseCategoryFilter(raw: string): string {
+  // The category filter is a free-text input — DeFiLlama categories like
+  // "Liquid Staking", "Yield Aggregator", "CDP" are typed by humans rather
+  // than picked from a dropdown. Normalise to a lowercase substring match
+  // (the mapper compares against `category.toLowerCase().includes(needle)`).
+  return raw.trim().toLowerCase();
+}
+
+function matchesCategory(item: FeedItem<DefillamaMeta>, needle: string): boolean {
+  if (!needle) return true;
+  const cat = item.meta?.category?.toLowerCase() ?? "";
+  return cat.includes(needle);
+}
+
+export async function fetchDefillamaPage(
+  mode: DefillamaMode,
+  category: string,
+  limit: number,
+  page: number,
+): Promise<{ items: FeedItem<DefillamaMeta>[]; hasMore: boolean }> {
+  const cat = parseCategoryFilter(category);
+
+  if (mode === "chains") {
+    // Chain mode ignores the category filter — every entry is implicitly a
+    // chain. Sort by TVL desc (the endpoint isn't guaranteed to be sorted).
+    const chains = await fetchJson<DefillamaChain[]>("/v2/chains");
+    const mapped = chains
+      .map(mapChain)
+      .filter((a): a is FeedItem<DefillamaMeta> => a !== null)
+      .sort((a, b) => (b.meta?.tvlUsd ?? 0) - (a.meta?.tvlUsd ?? 0));
+    const perPage = Math.max(limit, 30);
+    const start = page * perPage;
+    const slice = mapped.slice(start, start + perPage);
+    return { items: slice.slice(0, limit), hasMore: mapped.length > start + perPage };
+  }
+
+  // top + gainers both pull from /protocols.
+  const protocols = await fetchJson<DefillamaProtocol[]>("/protocols");
+  const mapped = protocols
+    .map(mapProtocol)
+    .filter((a): a is FeedItem<DefillamaMeta> => a !== null)
+    .filter((a) => matchesCategory(a, cat));
+
+  if (mode === "gainers") {
+    // Sort by 24h TVL change desc. Ties broken by absolute TVL so a $50M
+    // protocol jumping 20% ranks above a $50k protocol jumping 20%.
+    mapped.sort((a, b) => {
+      const da = a.meta?.tvlChange24h ?? 0;
+      const db = b.meta?.tvlChange24h ?? 0;
+      if (db !== da) return db - da;
+      return (b.meta?.tvlUsd ?? 0) - (a.meta?.tvlUsd ?? 0);
+    });
+  } else {
+    // top mode — sort by TVL desc. The endpoint is normally pre-sorted but the
+    // category filter can reorder pages if categories don't sort identically.
+    mapped.sort((a, b) => (b.meta?.tvlUsd ?? 0) - (a.meta?.tvlUsd ?? 0));
+  }
+
+  const perPage = Math.max(limit, 30);
+  const start = page * perPage;
+  const slice = mapped.slice(start, start + perPage);
+  return { items: slice.slice(0, limit), hasMore: mapped.length > start + perPage };
+}


### PR DESCRIPTION
## What
Keyless DeFi TVL leaderboard column backed by DeFiLlama's public API at `api.llama.fi`. Three modes:

- **top** — top protocols sorted by current TVL (`/protocols`).
- **gainers** — same source re-sorted by 24h TVL change desc; absolute TVL is the tiebreaker so a \$50M protocol moving 20% ranks above a \$50k protocol moving 20%.
- **chains** — per-chain TVL leaderboard (`/v2/chains`), TVL-desc.

Optional category filter on top/gainers (substring match against DeFiLlama's taxonomy — `Dexs`, `Lending`, `Liquid Staking`, `Restaking`, `CDP`, `Yield Aggregator`…). Empty = no filter. Category is intentionally ignored in `chains` mode (every entry is implicitly a chain).

## Why
Pivot from the IndieHackers RSS column (May-18 idea #5). IndieHackers no longer exposes a public RSS feed — `/feed`, `/feed.xml`, `/posts.rss`, `/podcast.rss` all return the SPA HTML. The idea was based on an outdated assumption.

DeFiLlama is the cleaner replacement for this slot:

- **Same audience** — a third of minitor's existing on-chain cluster (`wallet-tx`, `polymarket`, `coingecko`) targets crypto-native operators. The just-merged CoinGecko column (PR #44) covers price + market cap; this one covers TVL + protocol-level signal — different axis, no overlap.
- **Stable + keyless** — DeFiLlama's edge cache makes the per-request cost negligible; the public API is well-documented and has carried minitor-style integrations elsewhere for years.
- **Operator-relevant default** — `Top protocols by TVL` is genuinely useful out of the box without configuration, unlike a watchlist that starts empty.

## Changes
- `lib/integrations/defillama.ts` (~220 lines): keyless fetch + mappers + category filter + mode-specific sort/pagination.
- `lib/columns/plugins/defillama/{plugin.ts, server.ts, client.tsx}`: 3-file plugin following the established pattern (coingecko, github-discussions, producthunt). `#445ed0` DeFiLlama brand blue accent (distinct from wallet-tx Ethereum blue, polymarket electric blue, coingecko green). `Layers` lucide icon (evokes the protocol stack/L1↔L2↔app layering, distinct from Activity/Bell/Coins).
- `lib/columns/plugins/manifest.ts`, `lib/columns/registry.ts`, `lib/columns/server-registry.ts`: 1-line import + 1-line registration each (3 edits per file, matching the existing pattern). The parity check at server-registry init throws loudly if any of the three drift.
- `README.md`: intro line picks up DeFiLlama in the column list, Apps & on-chain cluster row 5 → 6, total count 46 → 47, keyless list updated.

## Implementation notes
- `/protocols` returns ~3,000 entries (~2-3 MB) including CEX entries (Binance CEX, Coinbase Custody, etc.). The mapper drops `tvl <= 0` to suppress dead protocols but keeps CEXes — operators watching the broader "where is custody concentrated" picture want them; the category filter is the escape hatch for pure-DeFi.
- Sort ties in gainers mode break on absolute TVL, not alphabetical or random — keeps the leaderboard semantically meaningful when many small protocols share an extreme percentage move (which happens any time a new token launches).
- `/v2/chains` is the only chain-list endpoint that's stable across DeFiLlama API rewrites; v1 was deprecated 18 months ago.
- Protocol logos load via `<img loading="lazy">` (same approach as CoinGecko) — DeFiLlama hosts them on icons.llamao.fi with long cache headers, so a deck full of DeFi rows doesn't waterfall.

---
*Built autonomously by Aeon* — pivot from May-18 idea #5 (IndieHackers feed dead) → DeFiLlama