### PR TITLE
feat: starter deck templates gallery (onboarding + browse anytime)

### DIFF
--- a/components/dialogs/templates-dialog.tsx
+++ b/components/dialogs/templates-dialog.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, Layers, Rocket, Sparkles, TrendingUp } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { getColumnType } from "@/lib/columns/registry";
+import {
+  TEMPLATES,
+  templateAsImportJson,
+  type DeckTemplate,
+} from "@/lib/deck-templates";
+import { useDeckStore } from "@/lib/store/use-deck-store";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// Resolved here (not inside deck-templates.ts) so the templates module stays
+// data-only and doesn't pull lucide into bundles that never render the gallery.
+const ICONS: Record<DeckTemplate["iconName"], LucideIcon> = {
+  Sparkles,
+  Layers,
+  TrendingUp,
+  Rocket,
+};
+
+export function TemplatesDialog({ open, onOpenChange }: Props) {
+  const importDeck = useDeckStore((s) => s.importDeck);
+  const [submittingId, setSubmittingId] = useState<string | null>(null);
+
+  async function applyTemplate(template: DeckTemplate) {
+    if (submittingId) return;
+    setSubmittingId(template.id);
+    try {
+      const json = templateAsImportJson(template);
+      const result = await importDeck(json);
+      toast.success(`Imported "${result.deckName}"`, {
+        description: `${result.columns.length} column${result.columns.length === 1 ? "" : "s"}`,
+      });
+      onOpenChange(false);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Template failed";
+      toast.error("Could not load template", { description: msg });
+    } finally {
+      setSubmittingId(null);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Start from a template</DialogTitle>
+        </DialogHeader>
+        <p className="text-xs text-muted-foreground">
+          Each template imports as a new deck. Your existing decks aren&apos;t
+          touched — feel free to try several.
+        </p>
+        <ul role="list" className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {TEMPLATES.map((template) => {
+            const Icon = ICONS[template.iconName];
+            const submitting = submittingId === template.id;
+            return (
+              <li key={template.id}>
+                <TemplateCard
+                  template={template}
+                  Icon={Icon}
+                  submitting={submitting}
+                  disabled={submittingId !== null && !submitting}
+                  onPick={() => void applyTemplate(template)}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface CardProps {
+  template: DeckTemplate;
+  Icon: LucideIcon;
+  submitting: boolean;
+  disabled: boolean;
+  onPick: () => void;
+}
+
+function TemplateCard({ template, Icon, submitting, disabled, onPick }: CardProps) {
+  return (
+    <div
+      className={cn(
+        "flex h-full flex-col gap-2 rounded-md border border-border bg-card p-3 transition-colors",
+        disabled ? "opacity-60" : "hover:border-foreground/40",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className="flex size-7 items-center justify-center rounded-sm"
+          style={{
+            backgroundColor: `${template.accent}33`,
+            color: template.accent,
+          }}
+        >
+          <Icon className="size-4" strokeWidth={2.25} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div
+            className="truncate text-[13px] font-medium text-foreground"
+            style={{ letterSpacing: "-0.005em" }}
+          >
+            {template.name}
+          </div>
+          <div className="truncate text-[11px] text-muted-foreground">
+            {template.tagline}
+          </div>
+        </div>
+      </div>
+      <p className="text-[11.5px] leading-relaxed text-muted-foreground">
+        {template.description}
+      </p>
+      <TemplateColumnPills template={template} />
+      <div className="mt-auto flex justify-end pt-1">
+        <Button
+          size="sm"
+          onClick={onPick}
+          disabled={submitting || disabled}
+          className="gap-1.5"
+        >
+          {submitting ? "Importing…" : "Use this deck"}
+          {!submitting && <ArrowRight className="size-3.5" />}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function TemplateColumnPills({ template }: { template: DeckTemplate }) {
+  // Show one pill per column with the registered plugin's brand colour so the
+  // operator can preview what they'll get without clicking. We tolerate
+  // unknown typeIds (renders the typeId itself) so a template that ships ahead
+  // of a plugin doesn't crash the gallery.
+  return (
+    <div className="flex flex-wrap gap-1">
+      {template.payload.columns.map((col, i) => {
+        const type = getColumnType(col.typeId);
+        const accent = type?.accent ?? "#999";
+        const Icon = type?.icon;
+        return (
+          <span
+            key={`${col.typeId}-${i}`}
+            className="inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px] font-medium"
+            style={{
+              backgroundColor: `${accent}20`,
+              color: accent,
+            }}
+            title={col.title}
+          >
+            {Icon ? <Icon className="size-2.5" strokeWidth={2.5} /> : null}
+            <span className="max-w-[10rem] truncate">{type?.label ?? col.typeId}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/onboarding/welcome.tsx
+++ b/components/onboarding/welcome.tsx
@@ -1,8 +1,18 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ArrowRight, Check } from "lucide-react";
+import {
+  ArrowRight,
+  Check,
+  Layers,
+  LayoutTemplate,
+  Rocket,
+  Sparkles,
+  TrendingUp,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import Image from "next/image";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -11,6 +21,18 @@ import { cn } from "@/lib/utils";
 import { listColumnTypes, getColumnType } from "@/lib/columns/registry";
 import { useDeckStore } from "@/lib/store/use-deck-store";
 import type { AnyColumnUI } from "@/lib/columns/types";
+import {
+  TEMPLATES,
+  templateAsImportJson,
+  type DeckTemplate,
+} from "@/lib/deck-templates";
+
+const TEMPLATE_ICONS: Record<DeckTemplate["iconName"], LucideIcon> = {
+  Sparkles,
+  Layers,
+  TrendingUp,
+  Rocket,
+};
 
 interface Suggestion {
   typeId: string;
@@ -65,11 +87,15 @@ export function Onboarding() {
   const addColumn = useDeckStore((s) => s.addColumn);
   const autoFetchColumn = useDeckStore((s) => s.autoFetchColumn);
   const setActiveDeck = useDeckStore((s) => s.setActiveDeck);
+  const importDeck = useDeckStore((s) => s.importDeck);
 
   const [deckName, setDeckName] = useState("Home");
   // Pre-select the first two suggestions — both are keyless so onboarding
   // works out of the box.
   const [picked, setPicked] = useState<Set<number>>(() => new Set([0, 1]));
+  const [templateLoadingId, setTemplateLoadingId] = useState<string | null>(
+    null,
+  );
 
   const types = useMemo(() => {
     const m = new Map<string, AnyColumnUI>();
@@ -99,6 +125,24 @@ export function Onboarding() {
       if (!type) continue;
       const { id: colId, ready } = addColumn(id, s.typeId, s.title, s.config);
       void autoFetchColumn(colId, type, ready);
+    }
+  }
+
+  async function applyTemplate(template: DeckTemplate) {
+    if (templateLoadingId) return;
+    setTemplateLoadingId(template.id);
+    try {
+      const result = await importDeck(templateAsImportJson(template));
+      toast.success(`Imported "${result.deckName}"`, {
+        description: `${result.columns.length} column${result.columns.length === 1 ? "" : "s"}`,
+      });
+      // importDeck sets activeDeckId to the new deck — the parent DeckView
+      // flips off the onboarding screen automatically once deckOrder grows.
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Template failed";
+      toast.error("Could not load template", { description: msg });
+    } finally {
+      setTemplateLoadingId(null);
     }
   }
 
@@ -149,11 +193,86 @@ export function Onboarding() {
           Welcome. Let&apos;s set up your first deck.
         </h1>
         <p className="mt-2 max-w-md text-[14px] leading-relaxed text-muted-foreground">
-          A deck is a collection of columns, each monitoring a different source.
-          Name it below, then pick a few sources to start watching.
+          Start from a template below, or build a deck manually by picking
+          sources one by one.
         </p>
 
-        <div className="mt-8 space-y-5">
+        <section className="mt-6 rounded-lg border border-border bg-card p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <LayoutTemplate className="size-4 text-foreground/70" />
+              <Label className="text-[13px] font-medium">
+                Start from a template
+              </Label>
+            </div>
+            <span className="text-[11px] text-muted-foreground tabular-nums">
+              {TEMPLATES.length} templates
+            </span>
+          </div>
+          <p className="mt-1 text-[11.5px] text-muted-foreground">
+            One click to import a pre-built deck. You can rename, edit, or
+            delete it after.
+          </p>
+          <ul
+            role="list"
+            className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2"
+          >
+            {TEMPLATES.map((template) => {
+              const Icon = TEMPLATE_ICONS[template.iconName];
+              const loading = templateLoadingId === template.id;
+              const disabled =
+                templateLoadingId !== null && templateLoadingId !== template.id;
+              return (
+                <li key={template.id}>
+                  <button
+                    type="button"
+                    onClick={() => void applyTemplate(template)}
+                    disabled={loading || disabled}
+                    className={cn(
+                      "group flex w-full items-stretch overflow-hidden rounded-md border bg-card text-left transition-all",
+                      "border-border hover:border-[oklab(0.263084_-0.00230259_0.0124794_/_0.22)]",
+                      (loading || disabled) && "cursor-not-allowed opacity-60",
+                    )}
+                  >
+                    <div
+                      className="flex w-10 shrink-0 items-center justify-center"
+                      style={{
+                        backgroundColor: `${template.accent}33`,
+                        color: template.accent,
+                      }}
+                    >
+                      <Icon className="size-4" strokeWidth={2.25} />
+                    </div>
+                    <div className="min-w-0 flex-1 px-2.5 py-2">
+                      <div
+                        className="truncate text-[12.5px] font-medium text-foreground"
+                        style={{ letterSpacing: "-0.005em" }}
+                      >
+                        {template.name}
+                      </div>
+                      <div className="truncate text-[11px] text-muted-foreground">
+                        {template.tagline}
+                      </div>
+                    </div>
+                    <div className="flex w-12 shrink-0 items-center justify-center pr-1.5 text-[10px] text-muted-foreground">
+                      {loading ? "…" : `${template.payload.columns.length} cols`}
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+
+        <div className="mt-6 flex items-center gap-3">
+          <div className="h-px flex-1 bg-border" />
+          <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+            or build manually
+          </span>
+          <div className="h-px flex-1 bg-border" />
+        </div>
+
+        <div className="mt-6 space-y-5">
           <section className="rounded-lg border border-border bg-card p-4">
             <div className="flex items-center gap-3">
               <div className="flex size-7 items-center justify-center rounded-full bg-foreground text-[12px] font-semibold text-primary-foreground">

--- a/components/sidebar-01/app-sidebar.tsx
+++ b/components/sidebar-01/app-sidebar.tsx
@@ -8,6 +8,7 @@ import { NavHeader } from "@/components/sidebar-01/nav-header";
 import { NavStats } from "@/components/sidebar-01/nav-stats";
 import { RenameDialog } from "@/components/dialogs/rename-dialog";
 import { ImportDeckDialog } from "@/components/dialogs/import-deck-dialog";
+import { TemplatesDialog } from "@/components/dialogs/templates-dialog";
 import { AddColumnDialog } from "@/components/column/add-column-dialog";
 import { useDeckStore } from "@/lib/store/use-deck-store";
 
@@ -19,6 +20,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const [newDeckOpen, setNewDeckOpen] = useState(false);
   const [addColOpen, setAddColOpen] = useState(false);
   const [importDeckOpen, setImportDeckOpen] = useState(false);
+  const [templatesOpen, setTemplatesOpen] = useState(false);
 
   return (
     <>
@@ -27,6 +29,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           onAddDeck={() => setNewDeckOpen(true)}
           onAddColumn={() => setAddColOpen(true)}
           onImportDeck={() => setImportDeckOpen(true)}
+          onBrowseTemplates={() => setTemplatesOpen(true)}
         />
         <SidebarContent>
           <NavDecks />
@@ -54,6 +57,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         />
       )}
       <ImportDeckDialog open={importDeckOpen} onOpenChange={setImportDeckOpen} />
+      <TemplatesDialog open={templatesOpen} onOpenChange={setTemplatesOpen} />
     </>
   );
 }

--- a/components/sidebar-01/nav-header.tsx
+++ b/components/sidebar-01/nav-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Download, Plus, Search, Share2, Upload } from "lucide-react";
+import { Download, LayoutTemplate, Plus, Search, Share2, Upload } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -24,6 +24,7 @@ interface Props {
   onAddDeck: () => void;
   onAddColumn: () => void;
   onImportDeck: () => void;
+  onBrowseTemplates: () => void;
 }
 
 async function copyToClipboard(text: string): Promise<boolean> {
@@ -53,7 +54,12 @@ async function copyToClipboard(text: string): Promise<boolean> {
   return ok;
 }
 
-export function NavHeader({ onAddDeck, onAddColumn, onImportDeck }: Props) {
+export function NavHeader({
+  onAddDeck,
+  onAddColumn,
+  onImportDeck,
+  onBrowseTemplates,
+}: Props) {
   const [open, setOpen] = useState(false);
   const decks = useDeckStore((s) => s.decks);
   const deckOrder = useDeckStore((s) => s.deckOrder);
@@ -228,6 +234,16 @@ export function NavHeader({ onAddDeck, onAddColumn, onImportDeck }: Props) {
               }}
             >
               <Upload className="mr-2 size-4" /> Import deck from JSON
+            </CommandItem>
+            <CommandItem
+              value="browse-templates"
+              onSelect={() => {
+                setOpen(false);
+                onBrowseTemplates();
+              }}
+            >
+              <LayoutTemplate className="mr-2 size-4" /> Browse starter
+              templates
             </CommandItem>
           </CommandGroup>
 

--- a/lib/deck-templates.ts
+++ b/lib/deck-templates.ts
@@ -1,0 +1,273 @@
+// Starter deck templates — pre-baked DeckExport v1 payloads operators can
+// import in two clicks. Templates use the SAME schema as Export/Import/Share
+// so there's no separate validation path: the existing `importDeck` server
+// action runs them through Zod just like a manually-pasted JSON.
+//
+// Adding a template:
+//   1. Append an entry to TEMPLATES with a unique id and a payload that
+//      validates against the deck-export schema (version: 1).
+//   2. Use plugin defaults where possible — columns whose config is "live
+//      data with no required field" (HN top, arXiv cs.AI, GitHub trending)
+//      work the moment the deck is imported. Columns with REQUIRED fields
+//      (wallet-tx address, github-stars repo, x-search query) need a
+//      sensible default that the operator can edit later.
+//   3. Keep deck names ≤ 128 chars and column counts ≤ 64 (server-side
+//      schema caps both).
+//
+// Why TS not JSON files:
+//   - Single source of truth for both UI metadata (name/description/accent)
+//     and the payload itself.
+//   - The bundler tree-shakes unused fields; templates rarely change so
+//     there's no value in a network round-trip to /templates/<id>.json.
+//   - Imports stay synchronous — no fetch failure modes for the gallery UI.
+
+export const DECK_TEMPLATE_VERSION = 1;
+
+export interface DeckTemplateColumn {
+  typeId: string;
+  title: string;
+  config: Record<string, unknown>;
+  alertKeywords?: string;
+}
+
+export interface DeckTemplatePayload {
+  version: typeof DECK_TEMPLATE_VERSION;
+  deckName: string;
+  columns: DeckTemplateColumn[];
+}
+
+export interface DeckTemplate {
+  id: string;
+  name: string;
+  // One-line pitch shown on the template card.
+  tagline: string;
+  // Two-or-three sentence description shown on hover/expanded card.
+  description: string;
+  // Brand accent colour for the card chip. Mirrors a plugin colour so the
+  // template feels at home with the columns it ships.
+  accent: string;
+  // Lucide icon name — resolved on the consumer side so we don't pull every
+  // lucide module into this file. Pick something that visually echoes the
+  // template's domain.
+  iconName: "Sparkles" | "Layers" | "TrendingUp" | "Rocket";
+  payload: DeckTemplatePayload;
+}
+
+// -----------------------------------------------------------------------------
+// AI Research
+// HN top + arXiv cs.AI + GitHub trending Python + Hugging Face trending models
+// + X search for "AI". All five run keyless EXCEPT x-search, which needs
+// XAI_API_KEY — the operator gets a one-off "missing key" toast on first fetch
+// and can either add the key or remove the column. Including it anyway because
+// the template's point is "what a research dashboard should look like" — every
+// AI-research user wants X coverage.
+// -----------------------------------------------------------------------------
+
+const aiResearch: DeckTemplate = {
+  id: "ai-research",
+  name: "AI Research",
+  tagline: "HN, arXiv, GitHub, Hugging Face, X",
+  description:
+    "A working starting deck for AI researchers and tinkerers. Front-page HN, newest arXiv cs.AI submissions, this-week GitHub trending in Python, Hugging Face trending models, and an X feed for the term 'AI'.",
+  accent: "#FFD21F",
+  iconName: "Sparkles",
+  payload: {
+    version: DECK_TEMPLATE_VERSION,
+    deckName: "AI Research",
+    columns: [
+      {
+        typeId: "hacker-news",
+        title: "HN · Front page",
+        config: { mode: "top", query: "" },
+      },
+      {
+        typeId: "arxiv",
+        title: "arXiv · cs.AI · Newest",
+        config: { category: "cs.AI", mode: "recent", search: "" },
+      },
+      {
+        typeId: "github-trending",
+        title: "Trending · Python · this week",
+        config: { language: "Python", period: "week" },
+      },
+      {
+        typeId: "huggingface",
+        title: "HF · Trending models",
+        config: { resource: "models", mode: "trending", search: "" },
+      },
+      {
+        typeId: "x-search",
+        title: "X · AI",
+        config: { query: "AI lang:en min_faves:50" },
+      },
+    ],
+  },
+};
+
+// -----------------------------------------------------------------------------
+// Base Ecosystem
+// GitHub stars for aaronjmars/aeon + aaronjmars/aeon-agent + CoinGecko AEON
+// watchlist + DeFiLlama top (operator filters category to Base) + X search
+// for "@aeonframework". No wallet-tx — it requires a wallet address per row
+// and a one-click template can't pick one for the operator.
+// -----------------------------------------------------------------------------
+
+const baseEcosystem: DeckTemplate = {
+  id: "base-ecosystem",
+  name: "Base Ecosystem",
+  tagline: "Aeon repos + AEON price + DeFiLlama + X",
+  description:
+    "Tracks the Aeon project + the Base on-chain stack. Two GitHub-stars columns for aeon and aeon-agent, a CoinGecko watchlist with $AEON, the DeFiLlama protocol leaderboard, and the X feed for @aeonframework.",
+  accent: "#445ed0",
+  iconName: "Layers",
+  payload: {
+    version: DECK_TEMPLATE_VERSION,
+    deckName: "Base Ecosystem",
+    columns: [
+      {
+        typeId: "github-stars",
+        title: "Stars · aaronjmars/aeon",
+        config: { repo: "aaronjmars/aeon" },
+      },
+      {
+        typeId: "github-stars",
+        title: "Stars · aaronjmars/aeon-agent",
+        config: { repo: "aaronjmars/aeon-agent" },
+      },
+      {
+        typeId: "coingecko",
+        title: "CoinGecko · Watchlist",
+        config: { mode: "watchlist", watchlist: "aeon" },
+      },
+      {
+        typeId: "defillama",
+        title: "DeFiLlama · Top protocols",
+        config: { mode: "top", category: "" },
+      },
+      {
+        typeId: "x-search",
+        title: "X · @aeonframework",
+        config: { query: "@aeonframework OR $AEON" },
+      },
+    ],
+  },
+};
+
+// -----------------------------------------------------------------------------
+// Crypto DeFi
+// DeFiLlama 24h gainers + Polymarket trending + CoinGecko top-by-market-cap
+// + X search for DeFi. Pairs the on-chain TVL flows (DeFiLlama) with the price
+// + narrative layer (CoinGecko, X) and the prediction-market reference
+// (Polymarket). All four are keyless except x-search.
+// -----------------------------------------------------------------------------
+
+const cryptoDefi: DeckTemplate = {
+  id: "crypto-defi",
+  name: "Crypto DeFi",
+  tagline: "DeFiLlama, CoinGecko, Polymarket, X",
+  description:
+    "DeFi-focused starting deck. DeFiLlama's 24h biggest TVL movers, CoinGecko's top-by-market-cap leaderboard, Polymarket trending markets, and an X feed for the term 'DeFi'.",
+  accent: "#8DC647",
+  iconName: "TrendingUp",
+  payload: {
+    version: DECK_TEMPLATE_VERSION,
+    deckName: "Crypto DeFi",
+    columns: [
+      {
+        typeId: "defillama",
+        title: "DeFiLlama · 24h gainers",
+        config: { mode: "gainers", category: "" },
+      },
+      {
+        typeId: "coingecko",
+        title: "CoinGecko · Top by market cap",
+        config: { mode: "top", watchlist: "" },
+      },
+      {
+        typeId: "polymarket",
+        title: "Polymarket · Trending",
+        config: { mode: "trending", tag: "" },
+      },
+      {
+        typeId: "x-search",
+        title: "X · DeFi",
+        config: { query: "DeFi OR defi lang:en min_faves:50" },
+      },
+    ],
+  },
+};
+
+// -----------------------------------------------------------------------------
+// Startup Tracker
+// GitHub trending + Product Hunt today + HN Show + DEV.to top week + Reddit
+// r/startups. All five are keyless, which makes this the lowest-friction
+// template — a brand-new install can land on this and have a fully-working
+// deck without setting a single env var.
+// -----------------------------------------------------------------------------
+
+const startupTracker: DeckTemplate = {
+  id: "startup-tracker",
+  name: "Startup Tracker",
+  tagline: "GitHub, PH, Show HN, DEV.to, r/startups",
+  description:
+    "The 'what's new in startup-land' deck. GitHub trending all-languages-this-week, Product Hunt today, Show HN, DEV.to top of the week, and the r/startups subreddit. Fully keyless — every column works out of the box.",
+  accent: "#DA552F",
+  iconName: "Rocket",
+  payload: {
+    version: DECK_TEMPLATE_VERSION,
+    deckName: "Startup Tracker",
+    columns: [
+      {
+        typeId: "github-trending",
+        title: "Trending · this week",
+        config: { language: "", period: "week" },
+      },
+      {
+        typeId: "producthunt",
+        title: "Product Hunt · Today",
+        config: { mode: "today", topic: "" },
+      },
+      {
+        typeId: "hacker-news",
+        title: "Show HN",
+        config: { mode: "show", query: "" },
+      },
+      {
+        typeId: "devto",
+        title: "DEV · Top week",
+        config: { mode: "top", tag: "" },
+      },
+      {
+        typeId: "reddit",
+        title: "r/startups",
+        config: { subreddit: "startups", sortBy: "hot" },
+      },
+    ],
+  },
+};
+
+export const TEMPLATES: DeckTemplate[] = [
+  aiResearch,
+  baseEcosystem,
+  cryptoDefi,
+  startupTracker,
+];
+
+export function getTemplate(id: string): DeckTemplate | undefined {
+  return TEMPLATES.find((t) => t.id === id);
+}
+
+/**
+ * Serialize a template's payload as a JSON string compatible with the
+ * `importDeck` server action. The string is what we hand to the same import
+ * path used by JSON-paste and share-link imports — no template-specific server
+ * route, no template-specific validation. If the schema ever changes, the
+ * server-side Zod check catches it at import time and the toast surfaces the
+ * exact failure to the operator.
+ */
+export function templateAsImportJson(template: DeckTemplate): string {
+  return JSON.stringify({
+    ...template.payload,
+    exportedAt: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## What

Starter deck templates gallery. Four pre-baked DeckExport v1 payloads operators can import in two clicks — surfaced on the empty-state onboarding screen and via a `Browse starter templates` ⌘K command for returning users.

## Why

May-20 repo-actions idea #5. A fresh minitor install lands on the onboarding screen with six hardcoded one-column suggestions; operators who don't have a clear mental model of "what columns make a useful dashboard" bounce instead of building one. Templates give them a meaningful starting point: a single click goes from blank to a working five-column deck.

Pairs cleanly with yesterday's deck-share link work (PR #46) — templates are essentially curated, pre-baked share payloads.

## Templates

| Template | Columns |
|----------|---------|
| **AI Research** | HN top + arXiv cs.AI + GitHub trending (Python) + Hugging Face trending models + X search "AI" |
| **Base Ecosystem** | GitHub stars `aaronjmars/aeon` + GitHub stars `aaronjmars/aeon-agent` + CoinGecko watchlist (`aeon`) + DeFiLlama top protocols + X `@aeonframework` |
| **Crypto DeFi** | DeFiLlama 24h gainers + CoinGecko top by market cap + Polymarket trending + X search "DeFi" |
| **Startup Tracker** | GitHub trending + Product Hunt today + Show HN + DEV.to top week + r/startups (fully keyless) |

## Changes

- **lib/deck-templates.ts** (new, 200 lines) — TS module exporting `TEMPLATES` (the four `DeckTemplate` records) plus `templateAsImportJson` which serializes a template into the exact JSON shape `importDeck` already accepts. Each template carries display metadata (name, tagline, description, brand accent, lucide icon name) alongside the payload.
- **components/dialogs/templates-dialog.tsx** (new) — Gallery modal shown by the `Browse starter templates` ⌘K command. Renders a card per template with brand chip, tagline, description, per-column type pills (using the registered plugin's brand colour), and a "Use this deck" button.
- **components/onboarding/welcome.tsx** — New "Start from a template" section above the existing manual-build flow. Same cards as the gallery dialog, optimized for the empty-state layout. Importing a template populates `deckOrder`, which automatically dismisses the onboarding screen.
- **components/sidebar-01/nav-header.tsx** — Adds the ⌘K command + a new `onBrowseTemplates` prop.
- **components/sidebar-01/app-sidebar.tsx** — Wires the templates dialog state + prop through.

## Validation

Templates use the SAME schema as Export/Import/Share (DeckExport v1) and go through the SAME server action (`importDeck`). No template-specific validation, no new server route. If the schema ever changes, the server-side Zod check catches it at import time and the toast surfaces the exact failure.

Imported templates always create a new deck (never merge into an existing one) — `importDeck`'s existing `(imported)` rename + new-deck contract is preserved.

## Why TS not JSON files

The May-20 idea proposed `public/templates/*.json`. I went with a single TS module because every template needs display metadata (brand colour, icon) alongside the payload. Keeping both in one place: one source of truth, tree-shakeable, no fetch failure mode for the gallery UI. The payload structure is still pure data — any future "templates from a remote registry" path can swap the loader without touching the consumers.

---
*Built autonomously by Aeon*
