### PR TITLE
feat: /gallery public deck page

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,0 +1,173 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, Layers, Rocket, Sparkles, TrendingUp } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import {
+  DECK_TEMPLATE_VERSION,
+  TEMPLATES,
+  type DeckTemplate,
+} from "@/lib/deck-templates";
+import { DECK_SHARE_HASH_KEY, encodeDeckShareHash } from "@/lib/deck-share";
+import { getColumnType } from "@/lib/columns/registry";
+
+// SEO surface — public, no auth required. Canonical is the same path because
+// /gallery is the only place this deck-template catalog lives.
+export const metadata: Metadata = {
+  title: "Deck Gallery · Minitor",
+  description:
+    "Browse Minitor starter deck templates. One-click import to start monitoring HN, arXiv, GitHub, Hugging Face, X, DeFiLlama, CoinGecko, Polymarket, Product Hunt, DEV.to, and more.",
+  alternates: { canonical: "/gallery" },
+  openGraph: {
+    title: "Minitor Deck Gallery",
+    description:
+      "Curated starter decks for AI research, the Base ecosystem, DeFi, and startup tracking — one-click import.",
+    type: "website",
+  },
+};
+
+const ICONS: Record<DeckTemplate["iconName"], LucideIcon> = {
+  Sparkles,
+  Layers,
+  TrendingUp,
+  Rocket,
+};
+
+// Build the share fragment server-side so each card renders as a plain anchor.
+// The exported payload is deterministic (no timestamp) — we deliberately don't
+// add `exportedAt` here so the same template generates the same URL across
+// requests, which keeps the page cache-friendly and the links stable for
+// people who share the URL of an individual template card.
+function templateShareHref(template: DeckTemplate): string {
+  const json = JSON.stringify({
+    version: DECK_TEMPLATE_VERSION,
+    deckName: template.payload.deckName,
+    columns: template.payload.columns,
+  });
+  return `/#${DECK_SHARE_HASH_KEY}=${encodeDeckShareHash(json)}`;
+}
+
+export default function GalleryPage() {
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-5xl flex-col gap-8 px-4 py-10 sm:px-6 sm:py-14">
+      <header className="flex flex-col gap-3">
+        <p className="text-xs uppercase tracking-wider text-muted-foreground">
+          Minitor
+        </p>
+        <h1
+          className="font-serif text-4xl italic text-foreground sm:text-5xl"
+          style={{ letterSpacing: "-0.015em" }}
+        >
+          Deck Gallery
+        </h1>
+        <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
+          One-click starter decks. Pick a template — Minitor imports it as a new
+          deck the moment you land on the dashboard. Your existing decks aren&apos;t
+          touched.
+        </p>
+        <div className="mt-1 flex flex-wrap gap-2 text-xs">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-3 py-1.5 text-foreground transition-colors hover:bg-accent"
+          >
+            Open dashboard
+            <ArrowRight className="size-3.5" />
+          </Link>
+        </div>
+      </header>
+
+      <section
+        aria-label="Starter deck templates"
+        className="grid grid-cols-1 gap-3 sm:grid-cols-2"
+      >
+        {TEMPLATES.map((template) => (
+          <GalleryCard key={template.id} template={template} />
+        ))}
+      </section>
+
+      <footer className="mt-auto border-t border-border pt-6 text-xs text-muted-foreground">
+        <p>
+          Templates use the same import path as JSON-paste and share-link
+          imports. Each one lands as a brand-new deck with{" "}
+          <span className="font-mono">(imported)</span> appended to the name.
+        </p>
+      </footer>
+    </main>
+  );
+}
+
+function GalleryCard({ template }: { template: DeckTemplate }) {
+  const Icon = ICONS[template.iconName];
+  const href = templateShareHref(template);
+  return (
+    <article className="flex h-full flex-col gap-3 rounded-lg border border-border bg-card p-4 transition-colors hover:border-foreground/40">
+      <div className="flex items-center gap-3">
+        <span
+          aria-hidden
+          className="flex size-9 items-center justify-center rounded-md"
+          style={{
+            backgroundColor: `${template.accent}26`,
+            color: template.accent,
+          }}
+        >
+          <Icon className="size-5" strokeWidth={2.25} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h2
+            className="truncate text-sm font-medium text-foreground"
+            style={{ letterSpacing: "-0.005em" }}
+          >
+            {template.name}
+          </h2>
+          <p className="truncate text-xs text-muted-foreground">
+            {template.tagline}
+          </p>
+        </div>
+      </div>
+
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        {template.description}
+      </p>
+
+      <GalleryColumnPills template={template} />
+
+      <div className="mt-auto flex justify-end pt-1">
+        <Link
+          href={href}
+          className="inline-flex items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs font-medium text-background transition-opacity hover:opacity-90"
+        >
+          Import deck
+          <ArrowRight className="size-3.5" />
+        </Link>
+      </div>
+    </article>
+  );
+}
+
+function GalleryColumnPills({ template }: { template: DeckTemplate }) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {template.payload.columns.map((col, i) => {
+        const type = getColumnType(col.typeId);
+        const accent = type?.accent ?? "#999";
+        const PillIcon = type?.icon;
+        return (
+          <span
+            key={`${col.typeId}-${i}`}
+            className="inline-flex items-center gap-1 rounded-sm px-2 py-0.5 text-[11px] font-medium"
+            style={{
+              backgroundColor: `${accent}20`,
+              color: accent,
+            }}
+            title={col.title}
+          >
+            {PillIcon ? <PillIcon className="size-3" strokeWidth={2.5} /> : null}
+            <span className="max-w-[12rem] truncate">
+              {type?.label ?? col.typeId}
+            </span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/sidebar-01/nav-footer.tsx
+++ b/components/sidebar-01/nav-footer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { Plus, Settings } from "lucide-react";
+import Link from "next/link";
+import { LayoutTemplate, Plus, Settings } from "lucide-react";
 
 import {
   DropdownMenu,
@@ -35,6 +36,15 @@ export function NavFooter() {
     <>
       <SidebarFooter className="border-t border-sidebar-border p-2">
         <SidebarMenu>
+          <SidebarMenuItem>
+            <Link
+              href="/gallery"
+              className="flex h-8 items-center gap-2 rounded-md px-2 text-left text-sm text-sidebar-foreground/80 outline-hidden transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+            >
+              <LayoutTemplate className="size-4" />
+              <span>Browse deck gallery</span>
+            </Link>
+          </SidebarMenuItem>
           <SidebarMenuItem className="flex items-center gap-1">
             <DropdownMenu>
               <DropdownMenuTrigger className="flex h-8 flex-1 items-center justify-between gap-2 rounded-md px-2 text-left text-sm text-sidebar-foreground/80 outline-hidden transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground data-[popup-open]:bg-sidebar-accent data-[popup-open]:text-sidebar-foreground">


### PR DESCRIPTION
## What

Public, SEO-crawlable deck-templates gallery at `/gallery`. First-time visitors with no account can land on a curated card grid, click a template, and Minitor imports it as a new deck the moment they hit the dashboard.

## Why

Starter deck templates shipped in PR #47 (merged May 22) live inside a modal — a returning operator can find them via ⌘K, but a first-time visitor sees nothing until they sign in. A `/gallery` route is a public-facing, SEO-crawlable page that any link can land on: operator shares a URL, colleague opens it, sees curated decks, one-click imports, starts monitoring. Builds entirely on top of the share-link (PR #46) + templates (PR #47) infrastructure — no new schema, no new server routes, no new validation path.

May-22 repo-actions idea #5.

## Changes

- **`app/gallery/page.tsx`** (new): server component, no auth required. Imports `TEMPLATES` from `lib/deck-templates.ts` (same source as the modal) and renders a responsive card grid (1-col mobile, 2-col tablet+). Each card shows the template's brand-accented icon chip, name, tagline, full description, and column-type pills coloured by each plugin's brand. Cards render with deterministic share URLs of the form `/#deck=<base64url(payload)>` — same shape that the share-link flow (PR #46) produces, picked up by the existing `useEffect` in `deck-view.tsx`. The encoded payload omits `exportedAt` so each template generates a stable URL across requests (cache-friendly, individually shareable). Page sets `<title>`, `<meta description>`, OpenGraph metadata, and a canonical `/gallery` URL for SEO.
- **`components/sidebar-01/nav-footer.tsx`**: new "Browse deck gallery" `<Link>` above the Add-new dropdown. Returning operators discover the gallery from the dashboard without needing to know the URL; the link uses the `LayoutTemplate` lucide icon to visually echo the templates modal.

## How it works

Server-side rendering means the gallery is fully static-friendly — no client-side fetch, no hydration cost, no auth required. Each card's "Import deck" button is a plain `<a href="/#deck=...">` (Next.js `Link`) that triggers client-side navigation to the root. When `DeckView` mounts at `/`, its existing `useEffect` (added in PR #46) reads `window.location.hash`, decodes the fragment, and runs the same `importDeck` server action that JSON-paste and share-link imports use — same Zod validation, same `(imported)` rename, same activate-as-new-deck contract. Zero new validation surface.

`encodeDeckShareHash` works server-side because `btoa` and `TextEncoder` are Node globals on the Next.js 15 runtime. The share fragment is deterministic per template (no per-request timestamp) so the URLs are stable across page loads.

`getColumnType` is safe to call from a server component: only `accent`, `label`, and `icon` are accessed on the result, and `icon` is always a `LucideIcon` (framework-agnostic SVG component).

## Test plan

- [ ] Visit `/gallery` directly — page renders with all four template cards, brand colours match plugins.
- [ ] Click "Import deck" on a template → lands on `/`, toast confirms import, new deck is active.
- [ ] Visit `/` with an existing deck, open sidebar, click "Browse deck gallery" footer link → navigates to `/gallery`.
- [ ] View page source / inspect — `<title>`, `<meta description>`, and canonical link are present.

---
*Built autonomously by Aeon*