### PR TITLE
feat: per-column refresh intervals

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -80,6 +80,7 @@ export async function loadSnapshot(): Promise<Snapshot> {
       title: c.title,
       config: (c.config as Record<string, unknown>) ?? {},
       alertKeywords: c.alertKeywords ?? undefined,
+      refreshIntervalSeconds: c.refreshIntervalSeconds ?? undefined,
       items: [],
       lastFetchedAt: c.lastFetchedAt ? c.lastFetchedAt.toISOString() : undefined,
     };
@@ -179,6 +180,41 @@ export async function updateColumnAlertKeywords(
     .where(eq(columns.id, id));
 }
 
+/**
+ * Whitelist of refresh-interval cadences (seconds). Anything outside this set
+ * is rejected server-side and persisted as NULL (manual-only). Keeping the
+ * allowlist short prevents the UI from being used to schedule pathological
+ * sub-minute polling that would hammer upstream rate limits.
+ */
+export const REFRESH_INTERVAL_OPTIONS = [60, 300, 900, 3600] as const;
+export type RefreshIntervalSeconds = (typeof REFRESH_INTERVAL_OPTIONS)[number];
+
+const REFRESH_INTERVAL_SET = new Set<number>(REFRESH_INTERVAL_OPTIONS);
+
+export function isAllowedRefreshInterval(
+  value: unknown,
+): value is RefreshIntervalSeconds {
+  return typeof value === "number" && REFRESH_INTERVAL_SET.has(value);
+}
+
+/**
+ * Persist a column's auto-refresh cadence. Pass `null` to clear (manual-only).
+ * Non-allowlisted values are coerced to `null` server-side — never trust the
+ * client to enforce the cadence floor.
+ */
+export async function updateColumnRefreshInterval(
+  id: string,
+  refreshIntervalSeconds: number | null,
+): Promise<void> {
+  const next = isAllowedRefreshInterval(refreshIntervalSeconds)
+    ? refreshIntervalSeconds
+    : null;
+  await db
+    .update(columns)
+    .set({ refreshIntervalSeconds: next })
+    .where(eq(columns.id, id));
+}
+
 export async function renameColumn(id: string, title: string): Promise<void> {
   await db.update(columns).set({ title }).where(eq(columns.id, id));
 }
@@ -211,6 +247,10 @@ const importedColumnSchema = z.object({
   title: z.string().min(1).max(256),
   config: z.record(z.string(), z.unknown()),
   alertKeywords: z.string().max(512).optional(),
+  // Optional auto-refresh cadence. Unknown / non-allowlisted values are dropped
+  // in importDeck so a tampered or hand-edited payload can't smuggle a 1-second
+  // poll past the server-side guard.
+  refreshIntervalSeconds: z.number().int().positive().optional(),
 });
 
 const importedDeckSchema = z.object({
@@ -239,6 +279,7 @@ export async function exportDeck(deckId: string): Promise<string> {
       title: columns.title,
       config: columns.config,
       alertKeywords: columns.alertKeywords,
+      refreshIntervalSeconds: columns.refreshIntervalSeconds,
     })
     .from(columns)
     .where(eq(columns.deckId, deckId))
@@ -253,6 +294,9 @@ export async function exportDeck(deckId: string): Promise<string> {
       title: c.title,
       config: (c.config as Record<string, unknown>) ?? {},
       ...(c.alertKeywords ? { alertKeywords: c.alertKeywords } : {}),
+      ...(isAllowedRefreshInterval(c.refreshIntervalSeconds)
+        ? { refreshIntervalSeconds: c.refreshIntervalSeconds }
+        : {}),
     })),
   };
   return JSON.stringify(payload, null, 2);
@@ -264,6 +308,7 @@ export interface ImportedDeckColumn {
   title: string;
   config: Record<string, unknown>;
   alertKeywords?: string;
+  refreshIntervalSeconds?: number;
 }
 
 export interface ImportedDeckResult {
@@ -314,6 +359,11 @@ export async function importDeck(json: string): Promise<ImportedDeckResult> {
       const id = nanoid();
       const alertKeywords =
         c.alertKeywords && c.alertKeywords.length > 0 ? c.alertKeywords : null;
+      const refreshIntervalSeconds = isAllowedRefreshInterval(
+        c.refreshIntervalSeconds,
+      )
+        ? c.refreshIntervalSeconds
+        : null;
       await tx.insert(columns).values({
         id,
         deckId,
@@ -321,6 +371,7 @@ export async function importDeck(json: string): Promise<ImportedDeckResult> {
         title: c.title,
         config: c.config,
         alertKeywords,
+        refreshIntervalSeconds,
         position: i,
       });
       created.push({
@@ -329,6 +380,7 @@ export async function importDeck(json: string): Promise<ImportedDeckResult> {
         title: c.title,
         config: c.config,
         ...(alertKeywords ? { alertKeywords } : {}),
+        ...(refreshIntervalSeconds !== null ? { refreshIntervalSeconds } : {}),
       });
     }
   });

--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, type CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useMemo } from "react";
 import {
   Bell,
+  Clock,
   GripVertical,
   Loader2,
   MoreHorizontal,
@@ -103,6 +104,52 @@ export function ColumnCard({ column }: { column: Column }) {
     return out;
   }, [alertTerms, column.items]);
   const matchCount = matchedItemIds.size;
+
+  // Auto-refresh tick — useRef snapshots so the interval closure always reads
+  // the latest typeId/config without forcing a tear-down on every config edit.
+  const typeIdRef = useRef(column.typeId);
+  const configRef = useRef(column.config);
+  typeIdRef.current = column.typeId;
+  configRef.current = column.config;
+
+  useEffect(() => {
+    const intervalSeconds = column.refreshIntervalSeconds;
+    if (!intervalSeconds || intervalSeconds <= 0) return;
+
+    let inFlight = false;
+    const tick = async () => {
+      // Pause while the tab is hidden so background tabs don't burn upstream
+      // rate limits. Re-checked each tick rather than via visibilitychange
+      // listener so the check stays colocated with the fetch decision.
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState !== "visible"
+      ) {
+        return;
+      }
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        const { items } = await callColumnApi(
+          typeIdRef.current,
+          configRef.current,
+        );
+        await applyFetchedItems(column.id, items);
+      } catch (err) {
+        // Silent on auto-refresh so a flaky upstream doesn't spam toasts; the
+        // operator already has the manual refresh button to surface errors.
+        console.warn(
+          `[minitor] auto-refresh failed for column ${column.id}`,
+          err,
+        );
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    const handle = setInterval(tick, intervalSeconds * 1000);
+    return () => clearInterval(handle);
+  }, [applyFetchedItems, column.id, column.refreshIntervalSeconds]);
 
   async function onRefresh() {
     if (!type) return;
@@ -245,6 +292,25 @@ export function ColumnCard({ column }: { column: Column }) {
               </TooltipContent>
             </Tooltip>
           )}
+          {column.refreshIntervalSeconds !== undefined &&
+            column.refreshIntervalSeconds > 0 && (
+              <Tooltip>
+                <TooltipTrigger
+                  aria-label={`Auto-refreshing every ${formatRefreshLabel(column.refreshIntervalSeconds)}`}
+                  className="inline-flex shrink-0 items-center gap-1 rounded-full bg-surface px-2 py-0.5 text-[11px] font-medium text-muted-foreground ring-1 ring-border"
+                >
+                  <Clock className="size-3" strokeWidth={2.5} />
+                  <span className="tabular-nums">
+                    {formatRefreshLabel(column.refreshIntervalSeconds)}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  Auto-refreshes every{" "}
+                  {formatRefreshLabel(column.refreshIntervalSeconds)} while the
+                  tab is visible
+                </TooltipContent>
+              </Tooltip>
+            )}
           <Tooltip>
             <TooltipTrigger
               onClick={onRefresh}
@@ -397,6 +463,22 @@ function LoadingSkeleton() {
       ))}
     </div>
   );
+}
+
+// Short-form label for the clock badge: "1m" / "5m" / "15m" / "60m". Falls
+// back to a minute count for off-allowlist values so a future cadence option
+// (or a hand-edited deck import that slipped past the allowlist before this
+// build) still renders something useful instead of an empty pill.
+function formatRefreshLabel(seconds: number): string {
+  if (seconds >= 3600 && seconds % 3600 === 0) {
+    const hours = seconds / 3600;
+    return `${hours}h`;
+  }
+  if (seconds >= 60 && seconds % 60 === 0) {
+    const minutes = seconds / 60;
+    return `${minutes}m`;
+  }
+  return `${seconds}s`;
 }
 
 function SkeletonRow({ delay }: { delay: number }) {

--- a/components/column/configure-column-dialog.tsx
+++ b/components/column/configure-column-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Bell } from "lucide-react";
+import { Bell, Clock } from "lucide-react";
 
 import {
   Dialog,
@@ -14,6 +14,13 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { getColumnType } from "@/lib/columns/registry";
 import { useDeckStore } from "@/lib/store/use-deck-store";
@@ -28,14 +35,37 @@ interface Props {
 
 const ALERT_KEYWORDS_MAX = 512;
 
+// Sentinel for the Select value when the operator chooses "Manual only" —
+// Radix's Select disallows empty-string values, so we use a non-numeric token
+// and convert to `null` (= manual-only) on save.
+const REFRESH_MANUAL = "manual";
+
+const REFRESH_OPTIONS: { value: string; label: string }[] = [
+  { value: REFRESH_MANUAL, label: "Manual only" },
+  { value: "60", label: "Every minute" },
+  { value: "300", label: "Every 5 minutes" },
+  { value: "900", label: "Every 15 minutes" },
+  { value: "3600", label: "Every 60 minutes" },
+];
+
+function refreshIntervalToOption(value: number | undefined): string {
+  if (value === undefined) return REFRESH_MANUAL;
+  const match = REFRESH_OPTIONS.find((o) => o.value === String(value));
+  return match ? match.value : REFRESH_MANUAL;
+}
+
 export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
   const type = getColumnType(column.typeId);
   const updateColumnConfig = useDeckStore((s) => s.updateColumnConfig);
   const updateAlertKeywords = useDeckStore((s) => s.updateAlertKeywords);
+  const updateRefreshInterval = useDeckStore((s) => s.updateRefreshInterval);
 
   const [draft, setDraft] = useState<Record<string, unknown>>(column.config);
   const [alertDraft, setAlertDraft] = useState<string>(
     column.alertKeywords ?? "",
+  );
+  const [refreshDraft, setRefreshDraft] = useState<string>(
+    refreshIntervalToOption(column.refreshIntervalSeconds),
   );
   const [prevOpen, setPrevOpen] = useState(open);
   if (open !== prevOpen) {
@@ -43,6 +73,7 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
     if (open) {
       setDraft(column.config);
       setAlertDraft(column.alertKeywords ?? "");
+      setRefreshDraft(refreshIntervalToOption(column.refreshIntervalSeconds));
     }
   }
 
@@ -53,6 +84,12 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
     const next = alertDraft.slice(0, ALERT_KEYWORDS_MAX);
     if (next !== (column.alertKeywords ?? "")) {
       updateAlertKeywords(column.id, next);
+    }
+    const nextRefresh =
+      refreshDraft === REFRESH_MANUAL ? null : Number(refreshDraft);
+    const currentRefresh = column.refreshIntervalSeconds ?? null;
+    if (nextRefresh !== currentRefresh) {
+      updateRefreshInterval(column.id, nextRefresh);
     }
     onOpenChange(false);
   }
@@ -100,6 +137,38 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
                   Parsed {previewCount} term{previewCount === 1 ? "" : "s"}.
                 </>
               )}
+            </p>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label
+              htmlFor="refresh-interval"
+              className="flex items-center gap-1.5"
+            >
+              <Clock className="size-3.5" />
+              Refresh interval
+              <span className="text-[11px] font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </Label>
+            <Select
+              value={refreshDraft}
+              onValueChange={(v) => setRefreshDraft(v ?? REFRESH_MANUAL)}
+            >
+              <SelectTrigger id="refresh-interval">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {REFRESH_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Auto-refresh pauses while the browser tab is hidden so background
+              tabs don&rsquo;t burn upstream rate limits.
             </p>
           </div>
         </div>

--- a/drizzle/0002_refresh_interval.sql
+++ b/drizzle/0002_refresh_interval.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "columns" ADD COLUMN "refresh_interval_seconds" integer;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,254 @@
+{
+  "id": "5a8c4f12-7d3a-4b21-8c4e-9f1e3b5d2002",
+  "prevId": "9b3e3a7a-1c1f-4a4d-9b89-2f7a7f9a3001",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.columns": {
+      "name": "columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "alert_keywords": {
+          "name": "alert_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_interval_seconds": {
+          "name": "refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "columns_deck_id_decks_id_fk": {
+          "name": "columns_deck_id_decks_id_fk",
+          "tableFrom": "columns",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decks": {
+      "name": "decks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_column_created_idx": {
+          "name": "feed_items_column_created_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_column_id_columns_id_fk": {
+          "name": "feed_items_column_id_columns_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feed_items_column_id_id_pk": {
+          "name": "feed_items_column_id_id_pk",
+          "columns": [
+            "column_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1779148800000,
       "tag": "0001_alert_keywords",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1779580800000,
+      "tag": "0002_refresh_interval",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/columns/types.ts
+++ b/lib/columns/types.ts
@@ -148,6 +148,14 @@ export interface Column {
    * server fetchers, so it works with every plugin without per-plugin opt-in.
    */
   alertKeywords?: string;
+  /**
+   * Optional auto-refresh cadence in seconds. When set, the column re-fetches
+   * on that interval (paused while the tab is hidden so background tabs don't
+   * burn upstream rate limits). When null/undefined, the column only refreshes
+   * on mount and on manual click. Allowed values are whitelisted server-side
+   * to {60, 300, 900, 3600}; any other input is treated as manual-only.
+   */
+  refreshIntervalSeconds?: number;
   items: FeedItem[];
   lastFetchedAt?: string;
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -24,6 +24,7 @@ export const columns = pgTable("columns", {
   title: text("title").notNull(),
   config: jsonb("config").notNull().default({}),
   alertKeywords: text("alert_keywords"),
+  refreshIntervalSeconds: integer("refresh_interval_seconds"),
   position: integer("position").notNull().default(0),
   lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),

--- a/lib/deck-templates.ts
+++ b/lib/deck-templates.ts
@@ -28,6 +28,10 @@ export interface DeckTemplateColumn {
   title: string;
   config: Record<string, unknown>;
   alertKeywords?: string;
+  // Optional auto-refresh cadence in seconds. When set, the column re-fetches
+  // on this cadence after import. Allowed values are whitelisted server-side
+  // to {60, 300, 900, 3600}; anything else is dropped during importDeck.
+  refreshIntervalSeconds?: number;
 }
 
 export interface DeckTemplatePayload {

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -20,6 +20,8 @@ import {
   reorderDecks as serverReorderDecks,
   updateColumnAlertKeywords as serverUpdateAlertKeywords,
   updateColumnConfig as serverUpdateConfig,
+  updateColumnRefreshInterval as serverUpdateRefreshInterval,
+  isAllowedRefreshInterval,
   type ImportedDeckResult,
   type Snapshot,
 } from "@/app/actions";
@@ -48,6 +50,10 @@ interface DeckState {
   ) => { id: string; ready: Promise<void> };
   updateColumnConfig: (columnId: string, config: Record<string, unknown>) => void;
   updateAlertKeywords: (columnId: string, alertKeywords: string) => void;
+  updateRefreshInterval: (
+    columnId: string,
+    refreshIntervalSeconds: number | null,
+  ) => void;
   renameColumn: (columnId: string, title: string) => void;
   removeColumn: (columnId: string) => void;
   reorderColumnsInDeck: (deckId: string, order: string[]) => void;
@@ -183,6 +189,32 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
     );
   },
 
+  updateRefreshInterval: (columnId, refreshIntervalSeconds) => {
+    // Mirror the server-side allowlist locally so the optimistic state can't
+    // drift from what was actually persisted. Anything outside the allowlist
+    // collapses to manual-only (undefined / null on the wire).
+    const next = isAllowedRefreshInterval(refreshIntervalSeconds)
+      ? refreshIntervalSeconds
+      : null;
+    set((s) => {
+      const col = s.columns[columnId];
+      if (!col) return s;
+      return {
+        columns: {
+          ...s.columns,
+          [columnId]: {
+            ...col,
+            refreshIntervalSeconds: next ?? undefined,
+          },
+        },
+      };
+    });
+    fireAndLog(
+      "updateColumnRefreshInterval",
+      serverUpdateRefreshInterval(columnId, next),
+    );
+  },
+
   renameColumn: (columnId, title) => {
     set((s) => {
       const col = s.columns[columnId];
@@ -265,6 +297,7 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
           title: c.title,
           config: c.config,
           alertKeywords: c.alertKeywords,
+          refreshIntervalSeconds: c.refreshIntervalSeconds,
           items: [],
         };
       }


### PR DESCRIPTION
## What

Adds an optional auto-refresh cadence to every column. Operators pick **Manual only** (default) / **Every minute** / **Every 5 / 15 / 60 minutes** in the column configure dialog. When set, the column re-fetches on that cadence, pausing while the browser tab is hidden so background tabs don't burn upstream rate limits. A small clock badge in the column header shows the active cadence.

## Why

From `articles/repo-actions-2026-05-22.md` idea #4: every column refreshed only on mount + manual click. Crypto / price columns (CoinGecko, DeFiLlama) need 1-5 min polling; GitHub-stars columns don't need more than hourly. Without per-column intervals, operators either over-poll slow APIs (rate limits) or under-poll fast ones (stale data).

## Changes

| File | Lines | Purpose |
|------|-------|---------|
| `drizzle/0002_refresh_interval.sql` | +1 | Additive NULLABLE `refresh_interval_seconds` integer on `columns`. |
| `drizzle/meta/_journal.json` | +7 | Entry for migration 0002. |
| `drizzle/meta/0002_snapshot.json` | +254 | Snapshot mirroring 0001 plus the new column. |
| `lib/db/schema.ts` | +1 | `refreshIntervalSeconds: integer("refresh_interval_seconds")` on `columns`. |
| `lib/columns/types.ts` | +8 | `Column.refreshIntervalSeconds?: number` with inline docs. |
| `app/actions.ts` | +52 | `REFRESH_INTERVAL_OPTIONS` allowlist + `isAllowedRefreshInterval` guard + new `updateColumnRefreshInterval` server action; export/import + `loadSnapshot` carry the new field; Zod schema accepts it as optional. |
| `lib/store/use-deck-store.ts` | +33 | `updateRefreshInterval` store action mirrors `updateAlertKeywords`; import-deck wiring carries the field through. |
| `components/column/configure-column-dialog.tsx` | +71 | "Refresh interval" `Select` (Manual only / 1m / 5m / 15m / 60m) wired to the store action. |
| `components/column/column-card.tsx` | +84 | `useEffect` sets `setInterval(fetchColumn, seconds * 1000)`; clears on unmount and on interval change; pauses when `document.visibilityState !== 'visible'`; clock badge in the header (lucide-react `Clock` + `formatRefreshLabel`). |
| `lib/deck-templates.ts` | +4 | `DeckTemplateColumn.refreshIntervalSeconds?: number` so future templates can opt-in. |

**Total**: 10 files, +513 / -2.

## Design notes

- **Tab visibility pause** — the interval still fires on a fixed cadence, but each tick checks `document.visibilityState` and returns early when hidden. Re-evaluated per tick (no `visibilitychange` listener) so the check stays colocated with the fetch decision. An `inFlight` guard prevents overlapping fetches when a tick lands while the previous one is still in flight.
- **Server-side whitelist** — `REFRESH_INTERVAL_OPTIONS = [60, 300, 900, 3600]`. `updateColumnRefreshInterval` and the import-deck path both run inputs through `isAllowedRefreshInterval`; anything outside the set is coerced to `NULL` (= manual-only). Prevents a tampered client or hand-edited deck JSON from smuggling a 1-second poll past the cadence floor.
- **Silent auto-tick errors** — auto-refresh swallows fetch errors (logs to `console.warn`) instead of toasting; a flaky upstream on a 1-minute cadence would otherwise spam the screen. The manual refresh button still surfaces errors as before.
- **Closure freshness** — `typeIdRef` / `configRef` snapshots let the interval read the latest config without forcing a tear-down on every config edit (otherwise editing the title would reset the cadence clock).

## Backward compatibility

- Migration is additive and nullable — existing rows default to `NULL` (manual-only).
- Decks exported before this PR import cleanly: the Zod schema marks `refreshIntervalSeconds` `.optional()`, so missing fields land as `undefined` and the column stays manual-only.
- Share-link payloads (`lib/deck-share.ts` base64url-encodes the DeckExport JSON) pass the new field through transparently — no changes needed there.
- Starter deck templates (`lib/deck-templates.ts`) keep the field optional, so the four existing templates render identically; new templates can opt-in by adding `refreshIntervalSeconds: 300`.

## Type-check

`npx tsc --noEmit` is clean on the diff. Two pre-existing errors in `lib/integrations/pypi.ts` (lines 286, 302) are present on `main` — confirmed via `git stash && tsc && stash pop`.

*Built autonomously by Aeon*
