### PR TITLE
feat: per-column include/exclude item filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - You name a deck. Minitor packs it with whatever you're watching.
 - 47 column types out of the box — social feeds, news, GitHub (including CI runs and Discussions), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, CoinGecko prices, DeFiLlama TVL, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
+- Shape the signal per column — highlight items with alert keywords, or filter the feed to "show only" / "hide" by keyword so a firehose column shows just what matters.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
 - Local-first by default — embedded PGlite, no Postgres install needed.
 

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -92,6 +92,8 @@ export async function loadSnapshot(): Promise<Snapshot> {
       alertKeywords: c.alertKeywords ?? undefined,
       notifyWebhookUrl: c.notifyWebhookUrl ?? undefined,
       refreshIntervalSeconds: c.refreshIntervalSeconds ?? undefined,
+      filterKeywords: c.filterKeywords ?? undefined,
+      excludeKeywords: c.excludeKeywords ?? undefined,
       items: [],
       lastFetchedAt: c.lastFetchedAt ? c.lastFetchedAt.toISOString() : undefined,
     };
@@ -254,6 +256,29 @@ export async function updateColumnRefreshInterval(
     .where(eq(columns.id, id));
 }
 
+/**
+ * Persist a column's include/exclude item filters. Pass empty strings to clear
+ * either side. Both are bounded to 512 chars (same budget as alert keywords) so
+ * a paste can't bloat storage; the UI never silently rejects, it just truncates.
+ * Unlike the webhook URL these are not secrets — they round-trip through deck
+ * export / import / share links.
+ */
+export async function updateColumnFilters(
+  id: string,
+  filterKeywords: string,
+  excludeKeywords: string,
+): Promise<void> {
+  const include = filterKeywords.slice(0, 512);
+  const exclude = excludeKeywords.slice(0, 512);
+  await db
+    .update(columns)
+    .set({
+      filterKeywords: include.length === 0 ? null : include,
+      excludeKeywords: exclude.length === 0 ? null : exclude,
+    })
+    .where(eq(columns.id, id));
+}
+
 export async function renameColumn(id: string, title: string): Promise<void> {
   await db.update(columns).set({ title }).where(eq(columns.id, id));
 }
@@ -294,6 +319,10 @@ const importedColumnSchema = z.object({
   // in importDeck so a tampered or hand-edited payload can't smuggle a 1-second
   // poll past the server-side guard.
   refreshIntervalSeconds: z.number().int().positive().optional(),
+  // Optional include/exclude item filters. Not secrets, so (unlike the webhook)
+  // they are emitted by exportDeck and round-trip through share links.
+  filterKeywords: z.string().max(512).optional(),
+  excludeKeywords: z.string().max(512).optional(),
 });
 
 const importedDeckSchema = z.object({
@@ -323,6 +352,8 @@ export async function exportDeck(deckId: string): Promise<string> {
       config: columns.config,
       alertKeywords: columns.alertKeywords,
       refreshIntervalSeconds: columns.refreshIntervalSeconds,
+      filterKeywords: columns.filterKeywords,
+      excludeKeywords: columns.excludeKeywords,
     })
     .from(columns)
     .where(eq(columns.deckId, deckId))
@@ -345,6 +376,8 @@ export async function exportDeck(deckId: string): Promise<string> {
       ...(isAllowedRefreshInterval(c.refreshIntervalSeconds)
         ? { refreshIntervalSeconds: c.refreshIntervalSeconds }
         : {}),
+      ...(c.filterKeywords ? { filterKeywords: c.filterKeywords } : {}),
+      ...(c.excludeKeywords ? { excludeKeywords: c.excludeKeywords } : {}),
     })),
   };
   return JSON.stringify(payload, null, 2);
@@ -358,6 +391,8 @@ export interface ImportedDeckColumn {
   alertKeywords?: string;
   notifyWebhookUrl?: string;
   refreshIntervalSeconds?: number;
+  filterKeywords?: string;
+  excludeKeywords?: string;
 }
 
 export interface ImportedDeckResult {
@@ -421,6 +456,14 @@ export async function importDeck(json: string): Promise<ImportedDeckResult> {
       )
         ? c.refreshIntervalSeconds
         : null;
+      const filterKeywords =
+        c.filterKeywords && c.filterKeywords.length > 0
+          ? c.filterKeywords.slice(0, 512)
+          : null;
+      const excludeKeywords =
+        c.excludeKeywords && c.excludeKeywords.length > 0
+          ? c.excludeKeywords.slice(0, 512)
+          : null;
       await tx.insert(columns).values({
         id,
         deckId,
@@ -430,6 +473,8 @@ export async function importDeck(json: string): Promise<ImportedDeckResult> {
         alertKeywords,
         notifyWebhookUrl,
         refreshIntervalSeconds,
+        filterKeywords,
+        excludeKeywords,
         position: i,
       });
       created.push({
@@ -440,6 +485,8 @@ export async function importDeck(json: string): Promise<ImportedDeckResult> {
         ...(alertKeywords ? { alertKeywords } : {}),
         ...(notifyWebhookUrl ? { notifyWebhookUrl } : {}),
         ...(refreshIntervalSeconds !== null ? { refreshIntervalSeconds } : {}),
+        ...(filterKeywords ? { filterKeywords } : {}),
+        ...(excludeKeywords ? { excludeKeywords } : {}),
       });
     }
   });

--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -7,6 +7,7 @@ import { useMemo } from "react";
 import {
   Bell,
   Clock,
+  Filter,
   GripVertical,
   Loader2,
   MoreHorizontal,
@@ -95,14 +96,40 @@ export function ColumnCard({ column }: { column: Column }) {
     () => parseAlertKeywords(column.alertKeywords),
     [column.alertKeywords],
   );
+  const includeTerms = useMemo(
+    () => parseAlertKeywords(column.filterKeywords),
+    [column.filterKeywords],
+  );
+  const excludeTerms = useMemo(
+    () => parseAlertKeywords(column.excludeKeywords),
+    [column.excludeKeywords],
+  );
+  const filtersActive = includeTerms.length > 0 || excludeTerms.length > 0;
+
+  // Apply include/exclude filters client-side. Include = keep only items
+  // matching at least one term; exclude = drop items matching any term, and
+  // exclude wins when an item matches both. Reuses the alert-keyword matcher so
+  // filter semantics (author + content + url, case-insensitive substring) stay
+  // identical to the highlight behaviour operators already know.
+  const visibleItems = useMemo(() => {
+    if (!filtersActive) return column.items;
+    return column.items.filter((it) => {
+      if (includeTerms.length > 0 && !itemMatchesAlertKeywords(it, includeTerms))
+        return false;
+      if (excludeTerms.length > 0 && itemMatchesAlertKeywords(it, excludeTerms))
+        return false;
+      return true;
+    });
+  }, [filtersActive, column.items, includeTerms, excludeTerms]);
+
   const matchedItemIds = useMemo(() => {
     if (alertTerms.length === 0) return new Set<string>();
     const out = new Set<string>();
-    for (const it of column.items) {
+    for (const it of visibleItems) {
       if (itemMatchesAlertKeywords(it, alertTerms)) out.add(it.id);
     }
     return out;
-  }, [alertTerms, column.items]);
+  }, [alertTerms, visibleItems]);
   const matchCount = matchedItemIds.size;
 
   // Auto-refresh tick — useRef snapshots so the interval closure always reads
@@ -292,6 +319,28 @@ export function ColumnCard({ column }: { column: Column }) {
               </TooltipContent>
             </Tooltip>
           )}
+          {filtersActive && (
+            <Tooltip>
+              <TooltipTrigger
+                aria-label={`Filtered: showing ${visibleItems.length} of ${column.items.length} items`}
+                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-sky-400/15 px-2 py-0.5 text-[11px] font-medium text-sky-700 ring-1 ring-sky-400/40 dark:text-sky-300"
+              >
+                <Filter className="size-3" strokeWidth={2.5} />
+                <span className="tabular-nums">
+                  {visibleItems.length}/{column.items.length}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                Showing {visibleItems.length} of {column.items.length}
+                {includeTerms.length > 0 && (
+                  <> · only: {includeTerms.join(", ")}</>
+                )}
+                {excludeTerms.length > 0 && (
+                  <> · hiding: {excludeTerms.join(", ")}</>
+                )}
+              </TooltipContent>
+            </Tooltip>
+          )}
           {column.refreshIntervalSeconds !== undefined &&
             column.refreshIntervalSeconds > 0 && (
               <Tooltip>
@@ -361,18 +410,22 @@ export function ColumnCard({ column }: { column: Column }) {
             )
           ) : (
             <div>
-              {column.items.map((item) =>
-                matchedItemIds.has(item.id) ? (
-                  <div
-                    key={item.id}
-                    data-alert-match="true"
-                    className="relative bg-yellow-50/40 ring-1 ring-inset ring-yellow-400/50 dark:bg-yellow-400/[0.06]"
-                  >
-                    <ItemRenderer item={item} />
-                  </div>
-                ) : (
-                  <ItemRenderer key={item.id} item={item} />
-                ),
+              {visibleItems.length === 0 ? (
+                <FilteredEmptyState totalCount={column.items.length} />
+              ) : (
+                visibleItems.map((item) =>
+                  matchedItemIds.has(item.id) ? (
+                    <div
+                      key={item.id}
+                      data-alert-match="true"
+                      className="relative bg-yellow-50/40 ring-1 ring-inset ring-yellow-400/50 dark:bg-yellow-400/[0.06]"
+                    >
+                      <ItemRenderer item={item} />
+                    </div>
+                  ) : (
+                    <ItemRenderer key={item.id} item={item} />
+                  ),
+                )
               )}
               {paginated && nextCursor !== null && (
                 <button
@@ -447,6 +500,19 @@ function EmptyState({
         )}
         Refresh
       </Button>
+    </div>
+  );
+}
+
+function FilteredEmptyState({ totalCount }: { totalCount: number }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+      <Filter className="size-5 text-muted-foreground/60" />
+      <div className="text-sm font-medium">No items match the filter</div>
+      <div className="text-xs text-muted-foreground">
+        {totalCount} item{totalCount === 1 ? "" : "s"} hidden. Adjust the
+        column&rsquo;s filters in Configure.
+      </div>
     </div>
   );
 }

--- a/components/column/configure-column-dialog.tsx
+++ b/components/column/configure-column-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Bell, Clock, Webhook } from "lucide-react";
+import { Bell, Clock, EyeOff, Filter, Webhook } from "lucide-react";
 
 import {
   Dialog,
@@ -61,6 +61,7 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
   const updateAlertKeywords = useDeckStore((s) => s.updateAlertKeywords);
   const updateWebhookUrl = useDeckStore((s) => s.updateWebhookUrl);
   const updateRefreshInterval = useDeckStore((s) => s.updateRefreshInterval);
+  const updateFilters = useDeckStore((s) => s.updateFilters);
 
   const [draft, setDraft] = useState<Record<string, unknown>>(column.config);
   const [alertDraft, setAlertDraft] = useState<string>(
@@ -72,6 +73,12 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
   const [refreshDraft, setRefreshDraft] = useState<string>(
     refreshIntervalToOption(column.refreshIntervalSeconds),
   );
+  const [filterDraft, setFilterDraft] = useState<string>(
+    column.filterKeywords ?? "",
+  );
+  const [excludeDraft, setExcludeDraft] = useState<string>(
+    column.excludeKeywords ?? "",
+  );
   const [prevOpen, setPrevOpen] = useState(open);
   if (open !== prevOpen) {
     setPrevOpen(open);
@@ -80,6 +87,8 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
       setAlertDraft(column.alertKeywords ?? "");
       setWebhookDraft(column.notifyWebhookUrl ?? "");
       setRefreshDraft(refreshIntervalToOption(column.refreshIntervalSeconds));
+      setFilterDraft(column.filterKeywords ?? "");
+      setExcludeDraft(column.excludeKeywords ?? "");
     }
   }
 
@@ -88,6 +97,9 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
   const parsedPreview = parseAlertKeywords(alertDraft);
   const previewCount = parsedPreview.length;
   const keywordsPresent = previewCount > 0;
+
+  const filterTermCount = parseAlertKeywords(filterDraft).length;
+  const excludeTermCount = parseAlertKeywords(excludeDraft).length;
 
   // Validate only when the field is shown (keywords present) and non-empty.
   const trimmedWebhook = webhookDraft.trim();
@@ -120,6 +132,14 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
     const currentRefresh = column.refreshIntervalSeconds ?? null;
     if (nextRefresh !== currentRefresh) {
       updateRefreshInterval(column.id, nextRefresh);
+    }
+    const nextFilter = filterDraft.slice(0, ALERT_KEYWORDS_MAX);
+    const nextExclude = excludeDraft.slice(0, ALERT_KEYWORDS_MAX);
+    if (
+      nextFilter !== (column.filterKeywords ?? "") ||
+      nextExclude !== (column.excludeKeywords ?? "")
+    ) {
+      updateFilters(column.id, nextFilter, nextExclude);
     }
     onOpenChange(false);
   }
@@ -230,6 +250,62 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
             <p className="text-xs text-muted-foreground">
               Auto-refresh pauses while the browser tab is hidden so background
               tabs don&rsquo;t burn upstream rate limits.
+            </p>
+          </div>
+
+          <Separator />
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="filter-keywords" className="flex items-center gap-1.5">
+              <Filter className="size-3.5" />
+              Show only
+              <span className="text-[11px] font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </Label>
+            <Input
+              id="filter-keywords"
+              placeholder="release, launch, vulnerability"
+              value={filterDraft}
+              maxLength={ALERT_KEYWORDS_MAX}
+              onChange={(e) => setFilterDraft(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Comma- or space-separated. When set, the column hides items that
+              match none of these terms (in title, body, or link).
+              {filterTermCount > 0 && (
+                <>
+                  {" "}
+                  Parsed {filterTermCount} term{filterTermCount === 1 ? "" : "s"}.
+                </>
+              )}
+            </p>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="exclude-keywords" className="flex items-center gap-1.5">
+              <EyeOff className="size-3.5" />
+              Hide items matching
+              <span className="text-[11px] font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </Label>
+            <Input
+              id="exclude-keywords"
+              placeholder="airdrop, giveaway"
+              value={excludeDraft}
+              maxLength={ALERT_KEYWORDS_MAX}
+              onChange={(e) => setExcludeDraft(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Items matching any of these terms are hidden. Exclude wins over
+              &ldquo;show only&rdquo; when an item matches both.
+              {excludeTermCount > 0 && (
+                <>
+                  {" "}
+                  Parsed {excludeTermCount} term{excludeTermCount === 1 ? "" : "s"}.
+                </>
+              )}
             </p>
           </div>
         </div>

--- a/drizzle/0004_column_filters.sql
+++ b/drizzle/0004_column_filters.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "columns" ADD COLUMN "filter_keywords" text;--> statement-breakpoint
+ALTER TABLE "columns" ADD COLUMN "exclude_keywords" text;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,272 @@
+{
+  "id": "6d3e9a5c-8f7b-4d3e-9c2a-4b0e7f3a8003",
+  "prevId": "5c2d8f4b-7e6a-4c2d-8b1f-3a9d6e2f7002",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.columns": {
+      "name": "columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "alert_keywords": {
+          "name": "alert_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_interval_seconds": {
+          "name": "refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notify_webhook_url": {
+          "name": "notify_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter_keywords": {
+          "name": "filter_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_keywords": {
+          "name": "exclude_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "columns_deck_id_decks_id_fk": {
+          "name": "columns_deck_id_decks_id_fk",
+          "tableFrom": "columns",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decks": {
+      "name": "decks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_column_created_idx": {
+          "name": "feed_items_column_created_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_column_id_columns_id_fk": {
+          "name": "feed_items_column_id_columns_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feed_items_column_id_id_pk": {
+          "name": "feed_items_column_id_id_pk",
+          "columns": [
+            "column_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1779667200000,
       "tag": "0003_notify_webhook",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1779753600000,
+      "tag": "0004_column_filters",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/columns/types.ts
+++ b/lib/columns/types.ts
@@ -164,6 +164,22 @@ export interface Column {
    * to {60, 300, 900, 3600}; any other input is treated as manual-only.
    */
   refreshIntervalSeconds?: number;
+  /**
+   * Optional comma/semicolon/space-separated include filter. When set, the
+   * column shows ONLY items whose author, content, or URL matches at least one
+   * term (same matcher as `alertKeywords`). Empty/unset = show everything.
+   * Purely client-side — never sent to server fetchers, so it works with every
+   * plugin without per-plugin opt-in. Unlike `notifyWebhookUrl` this is not a
+   * secret, so it round-trips through deck export / import / share links.
+   */
+  filterKeywords?: string;
+  /**
+   * Optional comma/semicolon/space-separated exclude filter. Items matching any
+   * term are hidden. Applied AFTER `filterKeywords`, so exclude wins: an item
+   * that matches both an include and an exclude term is hidden. Client-side and
+   * exported, same as `filterKeywords`.
+   */
+  excludeKeywords?: string;
   items: FeedItem[];
   lastFetchedAt?: string;
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -26,6 +26,8 @@ export const columns = pgTable("columns", {
   alertKeywords: text("alert_keywords"),
   notifyWebhookUrl: text("notify_webhook_url"),
   refreshIntervalSeconds: integer("refresh_interval_seconds"),
+  filterKeywords: text("filter_keywords"),
+  excludeKeywords: text("exclude_keywords"),
   position: integer("position").notNull().default(0),
   lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),

--- a/lib/deck-templates.ts
+++ b/lib/deck-templates.ts
@@ -32,6 +32,11 @@ export interface DeckTemplateColumn {
   // on this cadence after import. Allowed values are whitelisted server-side
   // to {60, 300, 900, 3600}; anything else is dropped during importDeck.
   refreshIntervalSeconds?: number;
+  // Optional include/exclude item filters (comma/space-separated). Let a
+  // starter template ship a pre-focused column — e.g. a security feed that
+  // only surfaces items mentioning "CVE". Round-trip through importDeck.
+  filterKeywords?: string;
+  excludeKeywords?: string;
 }
 
 export interface DeckTemplatePayload {

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -22,6 +22,7 @@ import {
   updateColumnConfig as serverUpdateConfig,
   updateColumnWebhookUrl as serverUpdateWebhookUrl,
   updateColumnRefreshInterval as serverUpdateRefreshInterval,
+  updateColumnFilters as serverUpdateFilters,
   isAllowedRefreshInterval,
   type ImportedDeckResult,
   type Snapshot,
@@ -55,6 +56,11 @@ interface DeckState {
   updateRefreshInterval: (
     columnId: string,
     refreshIntervalSeconds: number | null,
+  ) => void;
+  updateFilters: (
+    columnId: string,
+    filterKeywords: string,
+    excludeKeywords: string,
   ) => void;
   renameColumn: (columnId: string, title: string) => void;
   removeColumn: (columnId: string) => void;
@@ -235,6 +241,29 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
     );
   },
 
+  updateFilters: (columnId, filterKeywords, excludeKeywords) => {
+    const nextInclude = filterKeywords.slice(0, 512);
+    const nextExclude = excludeKeywords.slice(0, 512);
+    set((s) => {
+      const col = s.columns[columnId];
+      if (!col) return s;
+      return {
+        columns: {
+          ...s.columns,
+          [columnId]: {
+            ...col,
+            filterKeywords: nextInclude.length === 0 ? undefined : nextInclude,
+            excludeKeywords: nextExclude.length === 0 ? undefined : nextExclude,
+          },
+        },
+      };
+    });
+    fireAndLog(
+      "updateColumnFilters",
+      serverUpdateFilters(columnId, nextInclude, nextExclude),
+    );
+  },
+
   renameColumn: (columnId, title) => {
     set((s) => {
       const col = s.columns[columnId];
@@ -319,6 +348,8 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
           alertKeywords: c.alertKeywords,
           notifyWebhookUrl: c.notifyWebhookUrl,
           refreshIntervalSeconds: c.refreshIntervalSeconds,
+          filterKeywords: c.filterKeywords,
+          excludeKeywords: c.excludeKeywords,
           items: [],
         };
       }


### PR DESCRIPTION
## What
Per-column **item filters**: a "Show only" (include) field and a "Hide items matching" (exclude) field in each column's Configure dialog. They trim the feed in place — the column renders only the items that survive the filter, with a sky `N/M` badge in the header showing how many of the fetched items are visible.

## Why
`alertKeywords` (PR #41) only **highlights** matches — a yellow ring and a count badge. That's great for "tell me when X shows up," but it does nothing for the opposite problem: a high-volume column (an `x-search`, a busy subreddit, GitHub trending) where most items are noise. There was no way to say *"only show me items about releases"* or *"hide the airdrop spam."* This adds that missing half, turning a firehose column into a focused one. It's the natural completion of the keyword-match story (highlight → filter → webhook).

## How it works
- Reuses `lib/columns/keyword-match.ts` wholesale — `parseAlertKeywords` for parsing and `itemMatchesAlertKeywords` (author + content + URL, case-insensitive substring) for matching. Filter semantics are therefore identical to the highlight behaviour operators already know.
- **Include** keeps only items matching ≥1 term; **exclude** drops items matching any term; **exclude wins** when an item matches both.
- Filtering is **client-side render-time** (in `column-card.tsx`) — the fields are never sent to plugin fetchers, so all 50 column types work with zero per-plugin changes (same design contract as `alertKeywords` and `refreshIntervalSeconds`).
- Alert-keyword highlighting and the match-count badge are now scoped to the **visible** items, so the count never claims matches that the filter is hiding.
- When filters hide everything, a distinct "No items match the filter" empty state renders — and "Load more" stays available so the operator can pull more pages to find matches.

## Security / data model
- Two additive **NULLABLE** `text` columns (`filter_keywords`, `exclude_keywords`) — migration `0004_column_filters` (main is at `0003_notify_webhook`). Snapshot + journal authored to mirror `0001`–`0003`.
- Server action bounds each field to 512 chars; empty → `NULL`.
- Unlike `notifyWebhookUrl` (which is a secret and deliberately omitted from exports), these are **not secrets**, so they round-trip through `exportDeck` / `importDeck` / share links and are accepted on import (re-bounded to 512). `DeckTemplateColumn` gains the fields too, so a starter template can ship a pre-focused column (e.g. a security feed scoped to `CVE`).

## Changes
- `lib/db/schema.ts`, `drizzle/0004_column_filters.sql`, `drizzle/meta/0004_snapshot.json`, `drizzle/meta/_journal.json` — schema + migration.
- `lib/columns/types.ts` — `Column.filterKeywords?` / `excludeKeywords?` with docs.
- `app/actions.ts` — `updateColumnFilters` action; `loadSnapshot` / Zod / `exportDeck` / `importDeck` wiring.
- `lib/store/use-deck-store.ts` — `updateFilters` action + hydrate/import mappings.
- `components/column/configure-column-dialog.tsx` — two inputs with live parsed-term counts.
- `components/column/column-card.tsx` — render-time filtering, header badge, filtered-empty state.
- `lib/deck-templates.ts` — optional template fields.
- `README.md` — note per-column signal shaping.

No new dependencies.

## Test plan
- [ ] `npm run build` / typecheck (could not run in the authoring sandbox — offline, no `node_modules`; manual review only)
- [ ] Set "Show only" on a busy column → only matching items render; header shows `N/M`
- [ ] Set "Hide items matching" → matching items disappear; combine with include and confirm exclude wins
- [ ] Filter that matches nothing → "No items match the filter" state; "Load more" still works
- [ ] Export a deck with filters → re-import → filters round-trip; share link carries them
- [ ] Apply `drizzle/0004` against an existing DB → columns added, existing rows unaffected

---
*Built autonomously by Aeon*