### PR TITLE
feat: deck version history — auto-captured snapshots, restorable as a new deck

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Full plugin manifest: [`lib/columns/plugins/manifest.ts`](lib/columns/plugins/ma
 | **Database** (4) | PGlite default (zero install), node-postgres for self-hosted, `@neondatabase/serverless` HTTP driver for Neon, runtime selector by `DATABASE_URL` |
 | **UI** (7) | ⌘K command palette, `@dnd-kit` drag-reorder, conic-gradient refresh beam (CSS-only), live-ticking timestamps (1Hz `useSyncExternalStore`), onboarding flow, missing-key dimming on Add column, full-column loading skeleton |
 | **State** (3) | zustand + server-action writes, optimistic mutations, no localStorage (every device sees the same state) |
+| **Deck portability** (5) | Export (copy JSON), import (paste JSON), share link (`#deck=…` URL fragment), starter templates, and version history — auto-captured snapshots (last 5 per deck) restorable as a new deck from the deck menu |
 
 ### Use cases
 

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -2,11 +2,11 @@
 
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { db } from "@/lib/db/client";
-import { columns, decks, feedItems } from "@/lib/db/schema";
+import { columns, deckSnapshots, decks, feedItems } from "@/lib/db/schema";
 import type { Column, Deck, FeedItem } from "@/lib/columns/types";
 import { MAX_ITEMS_PER_COLUMN } from "@/lib/columns/constants";
 import { ENV_KEYS, ENV_KEY_NAMES } from "@/lib/env-keys";
@@ -156,6 +156,8 @@ export async function createColumn(
   title: string,
   config: Record<string, unknown>,
 ): Promise<void> {
+  // Snapshot the pre-add deck state so the add is reversible from version history.
+  await captureDeckSnapshot(deckId);
   const [{ maxPos }] = await db
     .select({ maxPos: sql<number>`coalesce(max(${columns.position}), -1)` })
     .from(columns)
@@ -284,6 +286,13 @@ export async function renameColumn(id: string, title: string): Promise<void> {
 }
 
 export async function deleteColumn(id: string): Promise<void> {
+  // Snapshot the deck (still holding this column) before the delete, so an
+  // accidental removal can be recovered from version history.
+  const [col] = await db
+    .select({ deckId: columns.deckId })
+    .from(columns)
+    .where(eq(columns.id, id));
+  if (col) await captureDeckSnapshot(col.deckId);
   await db.delete(columns).where(eq(columns.id, id));
 }
 
@@ -292,6 +301,8 @@ export async function reorderColumnsInDeck(
   orderedIds: string[],
 ): Promise<void> {
   if (orderedIds.length === 0) return;
+  // Snapshot the pre-reorder column order before mutating positions.
+  await captureDeckSnapshot(deckId);
   const values = sql.join(
     orderedIds.map((id, i) => sql`(${id}::text, ${i}::int)`),
     sql`, `,
@@ -405,10 +416,14 @@ export interface ImportedDeckResult {
  * Validate `json` against the deck-export schema and create a new deck with
  * the imported columns. Always inserts as a new deck (never merges into an
  * existing one) and appends ` (imported)` to the name so the source deck
- * remains untouched. Returns the IDs needed to update the client store
- * without a full re-fetch.
+ * remains untouched. `nameSuffix` overrides the parenthetical tag (e.g.
+ * `"restored"` when called from `restoreDeckSnapshot`). Returns the IDs needed
+ * to update the client store without a full re-fetch.
  */
-export async function importDeck(json: string): Promise<ImportedDeckResult> {
+export async function importDeck(
+  json: string,
+  nameSuffix = "imported",
+): Promise<ImportedDeckResult> {
   let parsed: unknown;
   try {
     parsed = JSON.parse(json);
@@ -424,7 +439,7 @@ export async function importDeck(json: string): Promise<ImportedDeckResult> {
   const data = result.data;
 
   const deckId = nanoid();
-  const deckName = `${data.deckName} (imported)`;
+  const deckName = `${data.deckName} (${nameSuffix})`;
   const created: ImportedDeckColumn[] = [];
 
   await db.transaction(async (tx) => {
@@ -491,7 +506,107 @@ export async function importDeck(json: string): Promise<ImportedDeckResult> {
     }
   });
 
+  // Seed version history for the freshly created deck (also covers restores,
+  // which route through this same path). Fire-and-forget — never fails import.
+  await captureDeckSnapshot(deckId);
+
   return { deckId, deckName, columns: created };
+}
+
+const DECK_SNAPSHOT_CAP = 5;
+
+export interface DeckSnapshotMeta {
+  id: number;
+  capturedAt: string;
+  columnCount: number;
+}
+
+/**
+ * Capture the current state of `deckId` into the rolling version-history log.
+ * Serializes via the same `exportDeck` path (so a snapshot is a valid
+ * DeckExport v1 payload that restores cleanly) and trims the deck's history to
+ * the most recent `DECK_SNAPSHOT_CAP` rows in one transaction. Fire-and-forget:
+ * it swallows its own errors so a failed capture never breaks the mutation that
+ * triggered it. Empty decks are skipped — an empty snapshot is noise with
+ * nothing to restore. Note: like every export path, snapshots deliberately omit
+ * `notifyWebhookUrl` (it can embed a secret), so a restored deck re-prompts for
+ * any alert webhook — same contract as deck export / share links.
+ */
+export async function captureDeckSnapshot(deckId: string): Promise<void> {
+  try {
+    const json = await exportDeck(deckId);
+    const parsed = JSON.parse(json) as DeckExport;
+    if (!parsed.columns || parsed.columns.length === 0) return;
+    await db.transaction(async (tx) => {
+      await tx.insert(deckSnapshots).values({ deckId, snapshotJson: json });
+      await tx.execute(sql`
+        DELETE FROM deck_snapshots
+        WHERE deck_id = ${deckId}
+          AND id NOT IN (
+            SELECT id FROM deck_snapshots
+            WHERE deck_id = ${deckId}
+            ORDER BY captured_at DESC, id DESC
+            LIMIT ${DECK_SNAPSHOT_CAP}
+          )
+      `);
+    });
+  } catch {
+    // Snapshotting must never break the triggering mutation.
+  }
+}
+
+/**
+ * Return the most recent snapshots for a deck (newest first), each with a
+ * lightweight column count parsed from the stored payload for the UI.
+ */
+export async function loadDeckSnapshots(
+  deckId: string,
+): Promise<DeckSnapshotMeta[]> {
+  const rows = await db
+    .select({
+      id: deckSnapshots.id,
+      capturedAt: deckSnapshots.capturedAt,
+      snapshotJson: deckSnapshots.snapshotJson,
+    })
+    .from(deckSnapshots)
+    .where(eq(deckSnapshots.deckId, deckId))
+    .orderBy(desc(deckSnapshots.capturedAt), desc(deckSnapshots.id))
+    .limit(DECK_SNAPSHOT_CAP);
+
+  return rows.map((r) => {
+    let columnCount = 0;
+    try {
+      const parsed = JSON.parse(r.snapshotJson) as DeckExport;
+      columnCount = parsed.columns?.length ?? 0;
+    } catch {
+      // Leave columnCount at 0 if a stored payload is somehow unparseable.
+    }
+    return {
+      id: r.id,
+      capturedAt: r.capturedAt.toISOString(),
+      columnCount,
+    };
+  });
+}
+
+/**
+ * Restore a snapshot by replaying its stored DeckExport JSON through
+ * `importDeck`. Non-destructive: it always creates a NEW deck (suffixed
+ * `(restored)`) rather than overwriting the current one, so a restore can
+ * itself be undone by deleting the new deck. Reuses importDeck's full Zod
+ * validation + SSRF re-check + new-deck contract.
+ */
+export async function restoreDeckSnapshot(
+  snapshotId: number,
+): Promise<ImportedDeckResult> {
+  const [row] = await db
+    .select({ snapshotJson: deckSnapshots.snapshotJson })
+    .from(deckSnapshots)
+    .where(eq(deckSnapshots.id, snapshotId));
+  if (!row) {
+    throw new Error("Snapshot not found");
+  }
+  return importDeck(row.snapshotJson, "restored");
 }
 
 export async function persistFetchedItems(

--- a/components/dialogs/version-history-dialog.tsx
+++ b/components/dialogs/version-history-dialog.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { History, RotateCcw } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { RelativeTime } from "@/components/relative-time";
+import { useDeckStore } from "@/lib/store/use-deck-store";
+import type { DeckSnapshotMeta } from "@/app/actions";
+
+interface Props {
+  deckId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function VersionHistoryDialog({ deckId, open, onOpenChange }: Props) {
+  const deckName = useDeckStore((s) =>
+    deckId ? (s.decks[deckId]?.name ?? "") : "",
+  );
+  const loadDeckSnapshots = useDeckStore((s) => s.loadDeckSnapshots);
+  const restoreDeckSnapshot = useDeckStore((s) => s.restoreDeckSnapshot);
+
+  const [snapshots, setSnapshots] = useState<DeckSnapshotMeta[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [restoringId, setRestoringId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!open || !deckId) return;
+    let cancelled = false;
+    setLoading(true);
+    loadDeckSnapshots(deckId)
+      .then((rows) => {
+        if (!cancelled) setSnapshots(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setSnapshots([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, deckId, loadDeckSnapshots]);
+
+  async function handleRestore(id: number) {
+    if (restoringId !== null) return;
+    setRestoringId(id);
+    try {
+      const result = await restoreDeckSnapshot(id);
+      toast.success(`Restored "${result.deckName}"`, {
+        description: `${result.columns.length} column${result.columns.length === 1 ? "" : "s"}`,
+      });
+      onOpenChange(false);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Restore failed";
+      toast.error("Restore failed", { description: msg });
+    } finally {
+      setRestoringId(null);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <History className="size-4" />
+            Version history
+            {deckName ? (
+              <span className="truncate font-normal text-muted-foreground">
+                · {deckName}
+              </span>
+            ) : null}
+          </DialogTitle>
+        </DialogHeader>
+
+        <p className="text-xs text-muted-foreground">
+          Snapshots are captured automatically before you add, remove, or
+          reorder columns. Restoring creates a new deck with “(restored)”
+          appended — your current deck isn’t touched.
+        </p>
+
+        <div className="grid gap-1.5">
+          {loading ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              Loading…
+            </p>
+          ) : snapshots.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              No version history yet. Make a change to this deck and a snapshot
+              will appear here.
+            </p>
+          ) : (
+            snapshots.map((snap) => (
+              <div
+                key={snap.id}
+                className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <div className="text-sm">
+                    <RelativeTime date={snap.capturedAt} addSuffix />
+                  </div>
+                  <div className="text-xs text-muted-foreground tabular-nums">
+                    {snap.columnCount} column{snap.columnCount === 1 ? "" : "s"}
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={restoringId !== null}
+                  onClick={() => handleRestore(snap.id)}
+                >
+                  <RotateCcw className="mr-1.5 size-3.5" />
+                  {restoringId === snap.id ? "Restoring…" : "Restore"}
+                </Button>
+              </div>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/sidebar-01/nav-decks.tsx
+++ b/components/sidebar-01/nav-decks.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ChevronDown, MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react";
+import {
+  ChevronDown,
+  History,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { useState } from "react";
 
 import {
@@ -29,6 +36,7 @@ import { getColumnType } from "@/lib/columns/registry";
 import { useDeckStore } from "@/lib/store/use-deck-store";
 import { RenameDialog } from "@/components/dialogs/rename-dialog";
 import { ConfirmDialog } from "@/components/dialogs/confirm-dialog";
+import { VersionHistoryDialog } from "@/components/dialogs/version-history-dialog";
 import { AddColumnDialog } from "@/components/column/add-column-dialog";
 
 export function focusColumn(columnId: string) {
@@ -53,6 +61,7 @@ export function NavDecks() {
   const [addColumnDeckId, setAddColumnDeckId] = useState<string | null>(null);
   const [deleteDeckId, setDeleteDeckId] = useState<string | null>(null);
   const [deleteColumnId, setDeleteColumnId] = useState<string | null>(null);
+  const [historyDeckId, setHistoryDeckId] = useState<string | null>(null);
 
   // Per-deck explicit open overrides. Decks not in this map fall back to
   // "open if active". Once the user toggles a deck, the override sticks.
@@ -193,6 +202,10 @@ export function NavDecks() {
                     <Pencil className="mr-2 size-4" />
                     <span className="whitespace-nowrap">Rename deck</span>
                   </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setHistoryDeckId(deckId)}>
+                    <History className="mr-2 size-4" />
+                    <span className="whitespace-nowrap">Version history</span>
+                  </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
                     variant="destructive"
@@ -257,6 +270,11 @@ export function NavDecks() {
           if (deleteColumnId) removeColumn(deleteColumnId);
           setDeleteColumnId(null);
         }}
+      />
+      <VersionHistoryDialog
+        deckId={historyDeckId}
+        open={historyDeckId !== null}
+        onOpenChange={(o) => !o && setHistoryDeckId(null)}
       />
     </>
   );

--- a/drizzle/0005_deck_snapshots.sql
+++ b/drizzle/0005_deck_snapshots.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "deck_snapshots" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"deck_id" text NOT NULL,
+	"snapshot_json" text NOT NULL,
+	"captured_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "deck_snapshots" ADD CONSTRAINT "deck_snapshots_deck_id_decks_id_fk" FOREIGN KEY ("deck_id") REFERENCES "public"."decks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "deck_snapshots_deck_captured_idx" ON "deck_snapshots" USING btree ("deck_id","captured_at");

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,346 @@
+{
+  "id": "7e4f0b6d-9a8c-4e4f-0d3b-5c1f8a4b9005",
+  "prevId": "6d3e9a5c-8f7b-4d3e-9c2a-4b0e7f3a8003",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.columns": {
+      "name": "columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "alert_keywords": {
+          "name": "alert_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_interval_seconds": {
+          "name": "refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notify_webhook_url": {
+          "name": "notify_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter_keywords": {
+          "name": "filter_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_keywords": {
+          "name": "exclude_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "columns_deck_id_decks_id_fk": {
+          "name": "columns_deck_id_decks_id_fk",
+          "tableFrom": "columns",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deck_snapshots": {
+      "name": "deck_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deck_snapshots_deck_captured_idx": {
+          "name": "deck_snapshots_deck_captured_idx",
+          "columns": [
+            {
+              "expression": "deck_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deck_snapshots_deck_id_decks_id_fk": {
+          "name": "deck_snapshots_deck_id_decks_id_fk",
+          "tableFrom": "deck_snapshots",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decks": {
+      "name": "decks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_column_created_idx": {
+          "name": "feed_items_column_created_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_column_id_columns_id_fk": {
+          "name": "feed_items_column_id_columns_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feed_items_column_id_id_pk": {
+          "name": "feed_items_column_id_id_pk",
+          "columns": [
+            "column_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1779753600000,
       "tag": "0004_column_filters",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1779840000000,
+      "tag": "0005_deck_snapshots",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -2,6 +2,7 @@ import {
   pgTable,
   text,
   integer,
+  serial,
   timestamp,
   jsonb,
   primaryKey,
@@ -32,6 +33,25 @@ export const columns = pgTable("columns", {
   lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 });
+
+// Rolling per-deck snapshot log for version history. Each row is a full
+// DeckExport v1 JSON of the deck at a moment just before a structural mutation
+// (or just after an import/restore). Capped to the most recent few rows per
+// deck in app/actions.ts; cascades away with its parent deck.
+export const deckSnapshots = pgTable(
+  "deck_snapshots",
+  {
+    id: serial("id").primaryKey(),
+    deckId: text("deck_id")
+      .notNull()
+      .references(() => decks.id, { onDelete: "cascade" }),
+    snapshotJson: text("snapshot_json").notNull(),
+    capturedAt: timestamp("captured_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (t) => [index("deck_snapshots_deck_captured_idx").on(t.deckId, t.capturedAt)],
+);
 
 export const feedItems = pgTable(
   "feed_items",

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -23,7 +23,10 @@ import {
   updateColumnWebhookUrl as serverUpdateWebhookUrl,
   updateColumnRefreshInterval as serverUpdateRefreshInterval,
   updateColumnFilters as serverUpdateFilters,
+  loadDeckSnapshots as serverLoadDeckSnapshots,
+  restoreDeckSnapshot as serverRestoreDeckSnapshot,
   isAllowedRefreshInterval,
+  type DeckSnapshotMeta,
   type ImportedDeckResult,
   type Snapshot,
 } from "@/app/actions";
@@ -75,6 +78,45 @@ interface DeckState {
 
   exportDeck: (deckId: string) => Promise<string>;
   importDeck: (json: string) => Promise<ImportedDeckResult>;
+  loadDeckSnapshots: (deckId: string) => Promise<DeckSnapshotMeta[]>;
+  restoreDeckSnapshot: (snapshotId: number) => Promise<ImportedDeckResult>;
+}
+
+// Build the store patch that lands a freshly imported/restored deck (a new deck
+// plus its columns) and activates it. Shared by importDeck and
+// restoreDeckSnapshot since both create a new deck from a DeckExport payload.
+function importedDeckPatch(
+  s: DeckState,
+  result: ImportedDeckResult,
+): Partial<DeckState> {
+  const cols = { ...s.columns };
+  for (const c of result.columns) {
+    cols[c.id] = {
+      id: c.id,
+      typeId: c.typeId,
+      title: c.title,
+      config: c.config,
+      alertKeywords: c.alertKeywords,
+      notifyWebhookUrl: c.notifyWebhookUrl,
+      refreshIntervalSeconds: c.refreshIntervalSeconds,
+      filterKeywords: c.filterKeywords,
+      excludeKeywords: c.excludeKeywords,
+      items: [],
+    };
+  }
+  return {
+    decks: {
+      ...s.decks,
+      [result.deckId]: {
+        id: result.deckId,
+        name: result.deckName,
+        columnIds: result.columns.map((c) => c.id),
+      },
+    },
+    deckOrder: [...s.deckOrder, result.deckId],
+    activeDeckId: result.deckId,
+    columns: cols,
+  };
 }
 
 function fireAndLog<T>(label: string, p: Promise<T>) {
@@ -337,36 +379,15 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
 
   importDeck: async (json) => {
     const result = await serverImportDeck(json);
-    set((s) => {
-      const cols = { ...s.columns };
-      for (const c of result.columns) {
-        cols[c.id] = {
-          id: c.id,
-          typeId: c.typeId,
-          title: c.title,
-          config: c.config,
-          alertKeywords: c.alertKeywords,
-          notifyWebhookUrl: c.notifyWebhookUrl,
-          refreshIntervalSeconds: c.refreshIntervalSeconds,
-          filterKeywords: c.filterKeywords,
-          excludeKeywords: c.excludeKeywords,
-          items: [],
-        };
-      }
-      return {
-        decks: {
-          ...s.decks,
-          [result.deckId]: {
-            id: result.deckId,
-            name: result.deckName,
-            columnIds: result.columns.map((c) => c.id),
-          },
-        },
-        deckOrder: [...s.deckOrder, result.deckId],
-        activeDeckId: result.deckId,
-        columns: cols,
-      };
-    });
+    set((s) => importedDeckPatch(s, result));
+    return result;
+  },
+
+  loadDeckSnapshots: (deckId) => serverLoadDeckSnapshots(deckId),
+
+  restoreDeckSnapshot: async (snapshotId) => {
+    const result = await serverRestoreDeckSnapshot(snapshotId);
+    set((s) => importedDeckPatch(s, result));
     return result;
   },
 


### PR DESCRIPTION
## What
Deck version history. Every time a deck is structurally mutated, Minitor silently captures a snapshot (a full DeckExport v1 JSON of the deck). The last 5 snapshots per deck surface in a new **Version history** entry on the deck options menu — each shows a relative timestamp + column count and a one-click **Restore**.

## Why
Operators who build up a 10–15 column deck over weeks have one unrecoverable failure mode: accidentally removing or misconfiguring a column. Export/import is a manual backup nobody remembers to take until they need it. Version history makes recovery automatic — and because the DeckExport v1 serialization already handles everything, this is almost entirely a persistence layer + a small UI surface on top of the existing export contract.

## Changes
- **`drizzle/0005_deck_snapshots.sql`** (+ `meta/_journal.json`, `meta/0005_snapshot.json`): new `deck_snapshots` table — `serial` id, `deck_id` FK → `decks.id` `ON DELETE CASCADE`, `snapshot_json` text, `captured_at` timestamptz, plus a `(deck_id, captured_at)` index. Migration sequence is `0004 → 0005`.
- **`lib/db/schema.ts`**: `deckSnapshots` table.
- **`app/actions.ts`**:
  - `captureDeckSnapshot(deckId)` — serializes via the existing `exportDeck` path (so a snapshot is a valid DeckExport that restores cleanly), inserts, and trims to the 5 most recent for that deck in **one transaction**. Fire-and-forget: it swallows its own errors so a failed capture never breaks the triggering mutation, and skips empty decks (an empty snapshot is noise).
  - `loadDeckSnapshots(deckId)` — last 5, newest first, with a parsed column count for the UI.
  - `restoreDeckSnapshot(snapshotId)` — replays the stored JSON through `importDeck`.
  - Capture wired into the four structural mutation paths: `createColumn` (pre-add), `deleteColumn` (pre-delete — looks up the column's deck first so the snapshot still holds the column), `reorderColumnsInDeck` (pre-reorder), and `importDeck` (post-create, to seed history for imported/restored decks).
  - `importDeck` gained an optional `nameSuffix` (default `"imported"`) so restore tags new decks `"(restored)"` while reusing importDeck's full Zod validation + webhook SSRF re-check + new-deck contract.
- **`lib/store/use-deck-store.ts`**: `loadDeckSnapshots` + `restoreDeckSnapshot` store actions; extracted a shared `importedDeckPatch` helper used by both `importDeck` and `restoreDeckSnapshot`.
- **`components/dialogs/version-history-dialog.tsx`** (new) + **`nav-decks.tsx`**: the UI — a "Version history" item in the deck options dropdown opens the dialog (reuses the shared `RelativeTime` ticker).
- **`README.md`**: a deck-portability feature row.

## Design decisions / deviations from the idea sketch
- **No "Configure Deck dialog" exists** in Minitor — deck actions live in the sidebar deck options dropdown (Rename / Delete). I added "Version history" there as the natural sibling, and built a dedicated dialog for the list.
- The idea referenced `addColumn` / `removeColumn` / `reorderColumns`; the actual server actions are `createColumn` / `deleteColumn` / `reorderColumnsInDeck`. Capture is wired into those.
- **Capture is pre-mutation** for add/remove/reorder, so the most recent snapshot is the state *just before* the change you want to undo. Import seeds a post-create baseline.
- **Restore is non-destructive** — it always creates a NEW deck (`(restored)` suffix) rather than overwriting the current one, so a restore can itself be undone by deleting the new deck.
- **Snapshots omit `notifyWebhookUrl`**, inheriting `exportDeck`'s deliberate secret-omission contract (a webhook URL can embed a Slack/Discord token) — a restored deck re-prompts for any alert webhook, same as export / share links already do.

## Notes
Could not run the Next build / typecheck (offline sandbox — no `node_modules`), so this was reviewed manually. The migration, schema, server actions, store wiring, and dialog were each cross-checked against the existing patterns (`importDeck`'s transaction, `persistFetchedItems`'s `NOT IN (… LIMIT …)` trim, the `RelativeTime` component, the existing dialog/menu structure).

---
*Built autonomously by Aeon*