### PR TITLE
feat(columns): per-column tab groups + tab bar above the deck grid

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -94,6 +94,7 @@ export async function loadSnapshot(): Promise<Snapshot> {
       refreshIntervalSeconds: c.refreshIntervalSeconds ?? undefined,
       filterKeywords: c.filterKeywords ?? undefined,
       excludeKeywords: c.excludeKeywords ?? undefined,
+      tabGroup: c.tabGroup ?? undefined,
       items: [],
       lastFetchedAt: c.lastFetchedAt ? c.lastFetchedAt.toISOString() : undefined,
     };
@@ -281,6 +282,31 @@ export async function updateColumnFilters(
     .where(eq(columns.id, id));
 }
 
+/**
+ * Hard cap on a tab-group label. Generous enough for a Title-Case section name
+ * but tight enough to keep the tab bar readable and bound storage. Anything
+ * longer is truncated server-side rather than rejected — the UI never silently
+ * drops a paste.
+ */
+export const TAB_GROUP_MAX = 50;
+
+/**
+ * Persist a column's tab-group label. Pass an empty string to clear (no group).
+ * Whitespace is collapsed to a single space and trimmed so "AI", " AI ", and
+ * "AI  " all bucket to the same tab — operators don't have to think about
+ * exact-match casing when typing the same label across columns.
+ */
+export async function updateColumnTabGroup(
+  id: string,
+  tabGroup: string,
+): Promise<void> {
+  const normalized = tabGroup.replace(/\s+/g, " ").trim().slice(0, TAB_GROUP_MAX);
+  await db
+    .update(columns)
+    .set({ tabGroup: normalized.length === 0 ? null : normalized })
+    .where(eq(columns.id, id));
+}
+
 export async function renameColumn(id: string, title: string): Promise<void> {
   await db.update(columns).set({ title }).where(eq(columns.id, id));
 }
@@ -334,6 +360,10 @@ const importedColumnSchema = z.object({
   // they are emitted by exportDeck and round-trip through share links.
   filterKeywords: z.string().max(512).optional(),
   excludeKeywords: z.string().max(512).optional(),
+  // Optional tab-group label. Not a secret — round-trips through export /
+  // import / share links so a multi-section starter deck can ship pre-grouped.
+  // Normalized server-side (whitespace collapsed, trimmed, capped to TAB_GROUP_MAX).
+  tabGroup: z.string().max(TAB_GROUP_MAX).optional(),
 });
 
 const importedDeckSchema = z.object({
@@ -365,6 +395,7 @@ export async function exportDeck(deckId: string): Promise<string> {
       refreshIntervalSeconds: columns.refreshIntervalSeconds,
       filterKeywords: columns.filterKeywords,
       excludeKeywords: columns.excludeKeywords,
+      tabGroup: columns.tabGroup,
     })
     .from(columns)
     .where(eq(columns.deckId, deckId))
@@ -389,6 +420,7 @@ export async function exportDeck(deckId: string): Promise<string> {
         : {}),
       ...(c.filterKeywords ? { filterKeywords: c.filterKeywords } : {}),
       ...(c.excludeKeywords ? { excludeKeywords: c.excludeKeywords } : {}),
+      ...(c.tabGroup ? { tabGroup: c.tabGroup } : {}),
     })),
   };
   return JSON.stringify(payload, null, 2);
@@ -404,6 +436,7 @@ export interface ImportedDeckColumn {
   refreshIntervalSeconds?: number;
   filterKeywords?: string;
   excludeKeywords?: string;
+  tabGroup?: string;
 }
 
 export interface ImportedDeckResult {
@@ -479,6 +512,15 @@ export async function importDeck(
         c.excludeKeywords && c.excludeKeywords.length > 0
           ? c.excludeKeywords.slice(0, 512)
           : null;
+      // Normalize the imported tab-group label through the same rule as the
+      // server action (collapse internal whitespace, trim, cap) so a hand-edited
+      // payload can't smuggle "  AI  " and "AI" as two distinct buckets.
+      const tabGroupRaw = c.tabGroup ?? "";
+      const tabGroupNormalized = tabGroupRaw
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, TAB_GROUP_MAX);
+      const tabGroup = tabGroupNormalized.length === 0 ? null : tabGroupNormalized;
       await tx.insert(columns).values({
         id,
         deckId,
@@ -490,6 +532,7 @@ export async function importDeck(
         refreshIntervalSeconds,
         filterKeywords,
         excludeKeywords,
+        tabGroup,
         position: i,
       });
       created.push({
@@ -502,6 +545,7 @@ export async function importDeck(
         ...(refreshIntervalSeconds !== null ? { refreshIntervalSeconds } : {}),
         ...(filterKeywords ? { filterKeywords } : {}),
         ...(excludeKeywords ? { excludeKeywords } : {}),
+        ...(tabGroup ? { tabGroup } : {}),
       });
     }
   });

--- a/components/column/configure-column-dialog.tsx
+++ b/components/column/configure-column-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Bell, Clock, EyeOff, Filter, Webhook } from "lucide-react";
+import { Bell, Clock, EyeOff, Filter, LayoutGrid, Webhook } from "lucide-react";
 
 import {
   Dialog,
@@ -35,6 +35,11 @@ interface Props {
 }
 
 const ALERT_KEYWORDS_MAX = 512;
+const TAB_GROUP_MAX = 50;
+
+function normalizeTabGroup(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim().slice(0, TAB_GROUP_MAX);
+}
 
 // Sentinel for the Select value when the operator chooses "Manual only" —
 // Radix's Select disallows empty-string values, so we use a non-numeric token
@@ -62,6 +67,7 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
   const updateWebhookUrl = useDeckStore((s) => s.updateWebhookUrl);
   const updateRefreshInterval = useDeckStore((s) => s.updateRefreshInterval);
   const updateFilters = useDeckStore((s) => s.updateFilters);
+  const updateTabGroup = useDeckStore((s) => s.updateTabGroup);
 
   const [draft, setDraft] = useState<Record<string, unknown>>(column.config);
   const [alertDraft, setAlertDraft] = useState<string>(
@@ -79,6 +85,9 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
   const [excludeDraft, setExcludeDraft] = useState<string>(
     column.excludeKeywords ?? "",
   );
+  const [tabGroupDraft, setTabGroupDraft] = useState<string>(
+    column.tabGroup ?? "",
+  );
   const [prevOpen, setPrevOpen] = useState(open);
   if (open !== prevOpen) {
     setPrevOpen(open);
@@ -89,6 +98,7 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
       setRefreshDraft(refreshIntervalToOption(column.refreshIntervalSeconds));
       setFilterDraft(column.filterKeywords ?? "");
       setExcludeDraft(column.excludeKeywords ?? "");
+      setTabGroupDraft(column.tabGroup ?? "");
     }
   }
 
@@ -140,6 +150,10 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
       nextExclude !== (column.excludeKeywords ?? "")
     ) {
       updateFilters(column.id, nextFilter, nextExclude);
+    }
+    const nextTabGroup = normalizeTabGroup(tabGroupDraft);
+    if (nextTabGroup !== (column.tabGroup ?? "")) {
+      updateTabGroup(column.id, nextTabGroup);
     }
     onOpenChange(false);
   }
@@ -306,6 +320,30 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
                   Parsed {excludeTermCount} term{excludeTermCount === 1 ? "" : "s"}.
                 </>
               )}
+            </p>
+          </div>
+
+          <Separator />
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="tab-group" className="flex items-center gap-1.5">
+              <LayoutGrid className="size-3.5" />
+              Tab group
+              <span className="text-[11px] font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </Label>
+            <Input
+              id="tab-group"
+              placeholder="DeFi, Social, Dev…"
+              value={tabGroupDraft}
+              maxLength={TAB_GROUP_MAX}
+              onChange={(e) => setTabGroupDraft(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              When any column in the deck has a tab group, a tab bar appears
+              above the grid. Untagged columns live under an &ldquo;All&rdquo;
+              tab. Leave blank to keep the column visible on every tab.
             </p>
           </div>
         </div>

--- a/components/deck/deck-board.tsx
+++ b/components/deck/deck-board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   DndContext,
   PointerSensor,
@@ -19,14 +19,19 @@ import {
 } from "@dnd-kit/sortable";
 import { Plus } from "lucide-react";
 
-import { useDeckStore } from "@/lib/store/use-deck-store";
+import { useDeckStore, TAB_GROUP_ALL } from "@/lib/store/use-deck-store";
 import { ColumnCard } from "@/components/column/column-card";
 import { AddColumnDialog } from "@/components/column/add-column-dialog";
+import { cn } from "@/lib/utils";
 
 export function DeckBoard({ deckId }: { deckId: string }) {
   const deck = useDeckStore((s) => s.decks[deckId]);
   const columns = useDeckStore((s) => s.columns);
   const reorderColumnsInDeck = useDeckStore((s) => s.reorderColumnsInDeck);
+  const selectedTab = useDeckStore(
+    (s) => s.selectedTabByDeck[deckId] ?? TAB_GROUP_ALL,
+  );
+  const setSelectedTab = useDeckStore((s) => s.setSelectedTab);
 
   const [addOpen, setAddOpen] = useState(false);
 
@@ -34,6 +39,46 @@ export function DeckBoard({ deckId }: { deckId: string }) {
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
+
+  // Build the unique, stable list of tab groups present in this deck. Sorted
+  // by the column position they first appear in, so the operator's reorder is
+  // the visual order of the tabs. Recomputed only when the deck's column list
+  // or any column's tabGroup changes.
+  const tabGroups = useMemo(() => {
+    if (!deck) return [];
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const id of deck.columnIds) {
+      const col = columns[id];
+      const tg = col?.tabGroup;
+      if (!tg || seen.has(tg)) continue;
+      seen.add(tg);
+      ordered.push(tg);
+    }
+    return ordered;
+  }, [deck, columns]);
+
+  // When the previously-selected tab disappears (last column in that group was
+  // moved or had its tab cleared), fall back to "All" so the deck doesn't end
+  // up showing zero columns with no obvious recovery.
+  useEffect(() => {
+    if (selectedTab === TAB_GROUP_ALL) return;
+    if (!tabGroups.includes(selectedTab)) {
+      setSelectedTab(deckId, TAB_GROUP_ALL);
+    }
+  }, [selectedTab, tabGroups, deckId, setSelectedTab]);
+
+  const visibleColumnIds = useMemo(() => {
+    if (!deck) return [];
+    if (selectedTab === TAB_GROUP_ALL) return deck.columnIds;
+    return deck.columnIds.filter((id) => {
+      const col = columns[id];
+      // Untagged columns ride along with every named tab too — otherwise an
+      // operator who partially groups a deck loses their unlabeled columns
+      // every time they click a tab, which reads as the feature being broken.
+      return !col || !col.tabGroup || col.tabGroup === selectedTab;
+    });
+  }, [deck, columns, selectedTab]);
 
   const scrollerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -70,50 +115,110 @@ export function DeckBoard({ deckId }: { deckId: string }) {
     reorderColumnsInDeck(deck.id, arrayMove(deck.columnIds, oldIndex, newIndex));
   }
 
+  const hasTabs = tabGroups.length > 0;
+
   return (
-    <div ref={scrollerRef} className="flex-1 overflow-x-auto overflow-y-hidden snap-x snap-mandatory sm:snap-none">
-      <div className="flex h-full gap-2 p-2 sm:gap-3 sm:p-3">
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          modifiers={[restrictToHorizontalAxis]}
-          onDragEnd={handleDragEnd}
-        >
-          <SortableContext
-            items={deck.columnIds}
-            strategy={horizontalListSortingStrategy}
-          >
-            {deck.columnIds.map((id) => {
-              const col = columns[id];
-              if (!col) return null;
-              return <ColumnCard key={id} column={col} />;
-            })}
-          </SortableContext>
-        </DndContext>
-
-        <button
-          type="button"
-          onClick={() => setAddOpen(true)}
-          className="group relative flex h-full w-[min(280px,calc(100vw-1rem))] shrink-0 snap-start flex-col items-center justify-center gap-3 overflow-hidden rounded-lg border border-dashed border-border bg-transparent text-sm text-muted-foreground transition-all duration-200 hover:-translate-y-0.5 hover:border-[oklab(0.263084_-0.00230259_0.0124794_/_0.22)] hover:bg-surface/40 hover:text-foreground hover:shadow-[0_8px_24px_-16px_rgba(0,0,0,0.18)] active:translate-y-0 sm:w-[280px] sm:snap-none"
-        >
-          <span
-            aria-hidden
-            className="pointer-events-none absolute inset-0 rounded-lg opacity-0 transition-opacity duration-300 group-hover:opacity-100"
-            style={{
-              background:
-                "radial-gradient(circle at 50% 40%, rgba(245,78,0,0.08), transparent 60%)",
-            }}
+    <div className="flex flex-1 flex-col overflow-hidden">
+      {hasTabs && (
+        <div className="flex h-10 shrink-0 items-center gap-1 overflow-x-auto border-b border-border bg-background/60 px-2 sm:px-3">
+          <TabButton
+            label="All"
+            count={deck.columnIds.length}
+            active={selectedTab === TAB_GROUP_ALL}
+            onClick={() => setSelectedTab(deck.id, TAB_GROUP_ALL)}
           />
-          <div className="relative flex size-11 items-center justify-center rounded-full bg-surface-elevated ring-1 ring-border transition-all duration-200 group-hover:scale-110 group-hover:rotate-90 group-hover:bg-[color:var(--brand)] group-hover:text-white group-hover:ring-[color:var(--brand)]/50 group-hover:shadow-[0_0_0_6px_rgba(245,78,0,0.08)]">
-            <Plus className="size-5 transition-transform duration-200" />
-          </div>
-          <span className="font-medium transition-transform duration-200 group-hover:translate-y-0.5">
-            Add column
-          </span>
-        </button>
-      </div>
+          {tabGroups.map((tg) => {
+            const count = deck.columnIds.reduce(
+              (n, id) => n + (columns[id]?.tabGroup === tg ? 1 : 0),
+              0,
+            );
+            return (
+              <TabButton
+                key={tg}
+                label={tg}
+                count={count}
+                active={selectedTab === tg}
+                onClick={() => setSelectedTab(deck.id, tg)}
+              />
+            );
+          })}
+        </div>
+      )}
 
-      <AddColumnDialog open={addOpen} onOpenChange={setAddOpen} deckId={deck.id} />
+      <div
+        ref={scrollerRef}
+        className="flex-1 overflow-x-auto overflow-y-hidden snap-x snap-mandatory sm:snap-none"
+      >
+        <div className="flex h-full gap-2 p-2 sm:gap-3 sm:p-3">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            modifiers={[restrictToHorizontalAxis]}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={visibleColumnIds}
+              strategy={horizontalListSortingStrategy}
+            >
+              {visibleColumnIds.map((id) => {
+                const col = columns[id];
+                if (!col) return null;
+                return <ColumnCard key={id} column={col} />;
+              })}
+            </SortableContext>
+          </DndContext>
+
+          <button
+            type="button"
+            onClick={() => setAddOpen(true)}
+            className="group relative flex h-full w-[min(280px,calc(100vw-1rem))] shrink-0 snap-start flex-col items-center justify-center gap-3 overflow-hidden rounded-lg border border-dashed border-border bg-transparent text-sm text-muted-foreground transition-all duration-200 hover:-translate-y-0.5 hover:border-[oklab(0.263084_-0.00230259_0.0124794_/_0.22)] hover:bg-surface/40 hover:text-foreground hover:shadow-[0_8px_24px_-16px_rgba(0,0,0,0.18)] active:translate-y-0 sm:w-[280px] sm:snap-none"
+          >
+            <span
+              aria-hidden
+              className="pointer-events-none absolute inset-0 rounded-lg opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+              style={{
+                background:
+                  "radial-gradient(circle at 50% 40%, rgba(245,78,0,0.08), transparent 60%)",
+              }}
+            />
+            <div className="relative flex size-11 items-center justify-center rounded-full bg-surface-elevated ring-1 ring-border transition-all duration-200 group-hover:scale-110 group-hover:rotate-90 group-hover:bg-[color:var(--brand)] group-hover:text-white group-hover:ring-[color:var(--brand)]/50 group-hover:shadow-[0_0_0_6px_rgba(245,78,0,0.08)]">
+              <Plus className="size-5 transition-transform duration-200" />
+            </div>
+            <span className="font-medium transition-transform duration-200 group-hover:translate-y-0.5">
+              Add column
+            </span>
+          </button>
+        </div>
+
+        <AddColumnDialog open={addOpen} onOpenChange={setAddOpen} deckId={deck.id} />
+      </div>
     </div>
+  );
+}
+
+interface TabButtonProps {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}
+
+function TabButton({ label, count, active, onClick }: TabButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors",
+        active
+          ? "bg-[color:var(--brand)]/10 text-[color:var(--brand)]"
+          : "text-muted-foreground hover:bg-surface hover:text-foreground",
+      )}
+    >
+      <span className="truncate max-w-[12rem]">{label}</span>
+      <span className="rounded bg-surface-elevated px-1 text-[10px] tabular-nums text-muted-foreground">
+        {count}
+      </span>
+    </button>
   );
 }

--- a/drizzle/0006_tab_groups.sql
+++ b/drizzle/0006_tab_groups.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "columns" ADD COLUMN "tab_group" text;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,352 @@
+{
+  "id": "8f5e1c7f-ab9d-5f50-1e4c-6d2f9b5c0006",
+  "prevId": "7e4f0b6d-9a8c-4e4f-0d3b-5c1f8a4b9005",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.columns": {
+      "name": "columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "alert_keywords": {
+          "name": "alert_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_interval_seconds": {
+          "name": "refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notify_webhook_url": {
+          "name": "notify_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter_keywords": {
+          "name": "filter_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_keywords": {
+          "name": "exclude_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tab_group": {
+          "name": "tab_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "columns_deck_id_decks_id_fk": {
+          "name": "columns_deck_id_decks_id_fk",
+          "tableFrom": "columns",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deck_snapshots": {
+      "name": "deck_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deck_snapshots_deck_captured_idx": {
+          "name": "deck_snapshots_deck_captured_idx",
+          "columns": [
+            {
+              "expression": "deck_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deck_snapshots_deck_id_decks_id_fk": {
+          "name": "deck_snapshots_deck_id_decks_id_fk",
+          "tableFrom": "deck_snapshots",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decks": {
+      "name": "decks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_column_created_idx": {
+          "name": "feed_items_column_created_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_column_id_columns_id_fk": {
+          "name": "feed_items_column_id_columns_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feed_items_column_id_id_pk": {
+          "name": "feed_items_column_id_id_pk",
+          "columns": [
+            "column_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1779840000000,
       "tag": "0005_deck_snapshots",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1779926400000,
+      "tag": "0006_tab_groups",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/columns/types.ts
+++ b/lib/columns/types.ts
@@ -180,6 +180,15 @@ export interface Column {
    * exported, same as `filterKeywords`.
    */
   excludeKeywords?: string;
+  /**
+   * Optional tab-group label. When at least one column in the active deck has a
+   * `tabGroup`, the deck renders a tab bar above the grid: clicking a tab
+   * filters the visible columns to those sharing that group. Untagged columns
+   * appear under an implicit "All" tab so a half-grouped deck stays usable.
+   * Bounded to 50 chars server-side. Round-trips through export / import /
+   * share links (not a secret).
+   */
+  tabGroup?: string;
   items: FeedItem[];
   lastFetchedAt?: string;
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -29,6 +29,7 @@ export const columns = pgTable("columns", {
   refreshIntervalSeconds: integer("refresh_interval_seconds"),
   filterKeywords: text("filter_keywords"),
   excludeKeywords: text("exclude_keywords"),
+  tabGroup: text("tab_group"),
   position: integer("position").notNull().default(0),
   lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),

--- a/lib/deck-templates.ts
+++ b/lib/deck-templates.ts
@@ -37,6 +37,11 @@ export interface DeckTemplateColumn {
   // only surfaces items mentioning "CVE". Round-trip through importDeck.
   filterKeywords?: string;
   excludeKeywords?: string;
+  // Optional tab-group label. Let a multi-category starter deck ship pre-grouped
+  // (e.g. "DeFi" / "Social" / "Dev") so the tab bar renders on first import
+  // instead of forcing the operator to label each column by hand. Round-trips
+  // through importDeck — same TAB_GROUP_MAX cap, same whitespace normalization.
+  tabGroup?: string;
 }
 
 export interface DeckTemplatePayload {

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -23,13 +23,20 @@ import {
   updateColumnWebhookUrl as serverUpdateWebhookUrl,
   updateColumnRefreshInterval as serverUpdateRefreshInterval,
   updateColumnFilters as serverUpdateFilters,
+  updateColumnTabGroup as serverUpdateTabGroup,
   loadDeckSnapshots as serverLoadDeckSnapshots,
   restoreDeckSnapshot as serverRestoreDeckSnapshot,
   isAllowedRefreshInterval,
+  TAB_GROUP_MAX,
   type DeckSnapshotMeta,
   type ImportedDeckResult,
   type Snapshot,
 } from "@/app/actions";
+
+// Sentinel for the implicit "All" tab — used when a deck has tab groups
+// configured but the operator wants to see every column at once. Exported so
+// the deck-board can compare without re-deriving the string in both files.
+export const TAB_GROUP_ALL = "__all__";
 
 interface DeckState {
   hydrated: boolean;
@@ -38,8 +45,15 @@ interface DeckState {
   activeDeckId: string | null;
   columns: Record<string, Column>;
   autoFetchingIds: Set<string>;
+  /**
+   * Selected tab per deck. NOT persisted (view state only) — clears on reload,
+   * so the deck always opens to "All" on a fresh visit. Keyed on deck id so
+   * switching decks restores the last tab the operator picked in this session.
+   */
+  selectedTabByDeck: Record<string, string>;
 
   hydrate: (snapshot: Snapshot) => void;
+  setSelectedTab: (deckId: string, tab: string) => void;
 
   addDeck: (name: string) => string;
   renameDeck: (deckId: string, name: string) => void;
@@ -65,6 +79,7 @@ interface DeckState {
     filterKeywords: string,
     excludeKeywords: string,
   ) => void;
+  updateTabGroup: (columnId: string, tabGroup: string) => void;
   renameColumn: (columnId: string, title: string) => void;
   removeColumn: (columnId: string) => void;
   reorderColumnsInDeck: (deckId: string, order: string[]) => void;
@@ -101,6 +116,7 @@ function importedDeckPatch(
       refreshIntervalSeconds: c.refreshIntervalSeconds,
       filterKeywords: c.filterKeywords,
       excludeKeywords: c.excludeKeywords,
+      tabGroup: c.tabGroup,
       items: [],
     };
   }
@@ -132,6 +148,7 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
   activeDeckId: null,
   columns: {},
   autoFetchingIds: new Set<string>(),
+  selectedTabByDeck: {},
 
   hydrate: (snapshot) =>
     set((s) => ({
@@ -143,6 +160,11 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
           ? s.activeDeckId
           : (snapshot.deckOrder[0] ?? null),
       hydrated: true,
+    })),
+
+  setSelectedTab: (deckId, tab) =>
+    set((s) => ({
+      selectedTabByDeck: { ...s.selectedTabByDeck, [deckId]: tab },
     })),
 
   addDeck: (name) => {
@@ -304,6 +326,27 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
       "updateColumnFilters",
       serverUpdateFilters(columnId, nextInclude, nextExclude),
     );
+  },
+
+  updateTabGroup: (columnId, tabGroup) => {
+    // Mirror the server-side normalization exactly so the optimistic state
+    // can't drift: same whitespace collapse, trim, and length cap. Anything
+    // empty after normalization clears the group (undefined / NULL on the wire).
+    const next = tabGroup.replace(/\s+/g, " ").trim().slice(0, TAB_GROUP_MAX);
+    set((s) => {
+      const col = s.columns[columnId];
+      if (!col) return s;
+      return {
+        columns: {
+          ...s.columns,
+          [columnId]: {
+            ...col,
+            tabGroup: next.length === 0 ? undefined : next,
+          },
+        },
+      };
+    });
+    fireAndLog("updateColumnTabGroup", serverUpdateTabGroup(columnId, next));
   },
 
   renameColumn: (columnId, title) => {


### PR DESCRIPTION
## What

Per-column **tab groups**. When at least one column in the active deck has a non-empty `tabGroup` label, a tab bar renders above the column grid. Clicking a tab filters visible columns to those sharing that group; an implicit **All** tab always shows every column. Untagged columns ride along with every named tab too, so a half-grouped deck doesn't go blank on the first tab click.

## Why

May-28 repo-actions idea #5. Decks with 8+ columns require horizontal scrolling to navigate, and the alternative — splitting a multi-section workflow into separate decks — loses the cohesion of having related signals next to each other. Tab groups give operators a way to partition one deck into labeled sections (e.g. \"DeFi\", \"Social\", \"Dev\") without spawning new decks.

Builds entirely on top of the existing column infrastructure: no plugin schemas touched, so all 47+ plugins keep working with zero changes. Same shape as `alertKeywords` / `refreshIntervalSeconds` / `filterKeywords` — a sibling field on the column row that the UI reads but plugin fetchers never see.

## Changes

- **`drizzle/0006_tab_groups.sql`** + `drizzle/meta/_journal.json` (entry 6) + `drizzle/meta/0006_snapshot.json` — additive nullable `tab_group` text column on `columns`. Backwards-compatible: rows without a value stay un-grouped and render under the implicit **All** tab.
- **`lib/db/schema.ts`** — `tabGroup: text(\"tab_group\")` on the `columns` table.
- **`lib/columns/types.ts`** — `Column.tabGroup?: string` with a comment explaining the All-tab fallback and the export-round-trip contract.
- **`app/actions.ts`**:
  - `TAB_GROUP_MAX = 50` const exported for the store + dialog mirrors.
  - `updateColumnTabGroup(id, tabGroup)` server action with whitespace collapse + trim + length cap (empty → `NULL`).
  - `importedColumnSchema.tabGroup` Zod field bounded to `TAB_GROUP_MAX`.
  - `exportDeck` round-trips the field (it's not a secret, unlike `notifyWebhookUrl`).
  - `importDeck` re-normalizes the imported value through the same whitespace + length rule so a hand-edited payload can't smuggle `\"  AI  \"` and `\"AI\"` as two distinct buckets.
  - `loadSnapshot` reads it into the snapshot.
- **`lib/store/use-deck-store.ts`**:
  - `updateTabGroup(columnId, tabGroup)` action mirroring the server-side normalization locally (optimistic state can never drift from what was actually persisted).
  - `selectedTabByDeck: Record<string, string>` — per-deck selected tab, **not persisted** (clears on reload, restores on deck-switch within the same session — same shape as `autoFetchingIds`).
  - `TAB_GROUP_ALL = \"__all__\"` sentinel exported for the deck-board (avoids both files re-deriving the same string).
- **`components/column/configure-column-dialog.tsx`** — \"Tab group\" text input under the show-only/hide section. LayoutGrid icon. Live normalization on save: `\"AI  \"` saves as `\"AI\"`, empty clears the group.
- **`components/deck/deck-board.tsx`** — full rewrite to render the tab bar when ≥1 column has a group. Tabs are derived from `columns[id].tabGroup` in column-position order (operator's column reorder is the visual tab order). Falls back to All when the selected tab's last column moves away. Each tab badge shows the count of columns it includes.
- **`lib/deck-templates.ts`** — `DeckTemplateColumn.tabGroup?: string` so future multi-category starter decks can ship pre-grouped instead of forcing the operator to label each column by hand on import.

## How it works

**Schema migration is additive and nullable** — every existing column stays as-is (un-grouped); the `tab_group` value is read into `loadSnapshot`'s in-memory `Column` and the deck-board recomputes a stable tab list from it via `useMemo` keyed on the deck's `columnIds` + the columns map.

**Tab visibility** uses a per-column predicate: `selectedTab === ALL || !col.tabGroup || col.tabGroup === selectedTab`. The middle clause is what keeps un-grouped columns visible under every named tab — without it, an operator who labels two columns \"DeFi\" but leaves six others unlabeled would lose those six columns the moment they click the \"DeFi\" tab, which would read as the feature being broken.

**Normalization is consistent** across every entry point: the server action, the store action, and the import path all run `tabGroup.replace(/\\s+/g, \" \").trim().slice(0, TAB_GROUP_MAX)`. That guarantees `\"AI\"`, `\" AI \"`, and `\"AI  \"` bucket to the same tab regardless of which surface the value came in through (typing in the dialog, pasting a shared deck JSON, importing a starter template).

**Server-side guard is the source of truth.** The `TAB_GROUP_MAX = 50` cap is enforced server-side (`updateColumnTabGroup` truncates; `importDeck` re-validates); the dialog mirrors it client-side as `maxLength={TAB_GROUP_MAX}` purely for UX, not for security.

**DnD reorder still works** within the visible subset. The `SortableContext` is given the filtered `visibleColumnIds` so drag operations only reorder within the active tab — moving a column out of the tab requires explicitly editing the tab group from the Configure dialog.

## Test plan

- [ ] Run `pnpm db:generate` to confirm Drizzle still produces an empty diff vs the new snapshot (sanity check, not strictly needed since the snapshot is hand-edited but matches the migration)
- [ ] Run `pnpm db:migrate` against an existing pglite DB; confirm the `columns` table gains the `tab_group` column with no row changes
- [ ] Create a deck with 4 columns; label 2 as \"DeFi\" and 2 as \"Social\"; confirm the tab bar appears with three tabs (All / DeFi / Social) and clicking each tab filters the grid correctly
- [ ] Add a 5th column with no tab group; confirm it remains visible under both \"DeFi\" and \"Social\" tabs (the All-tab fallback for untagged columns)
- [ ] Export the deck via Copy JSON; confirm `tabGroup` appears for the labeled columns and is omitted for the untagged one
- [ ] Import the exported JSON; confirm tabs reappear in the imported deck
- [ ] Paste a deck JSON with `\"tabGroup\": \"  AI  \"` (intentional whitespace); confirm the imported column lands under tab \"AI\"
- [ ] Reload the page; confirm the deck opens to All (selected tab is view state only — not persisted)
- [ ] Delete the last column in a named tab; confirm the tab disappears from the bar and the selection falls back to All
- [ ] Share a deck via the share-link path; confirm tab groups round-trip through the URL fragment

---

*Built autonomously by Aeon — May-28 repo-actions idea #5*