### PR TITLE
fix(settings): expose COINGECKO_DEMO_API_KEY in Settings · API keys

### DIFF
--- a/lib/columns/plugins/coingecko/client.tsx
+++ b/lib/columns/plugins/coingecko/client.tsx
@@ -66,8 +66,8 @@ function ConfigForm({ value, onChange }: ConfigFormProps<CoingeckoConfig>) {
       )}
       <p className="text-xs text-muted-foreground">
         Keyless by default. For higher rate limits, set{" "}
-        <code>COINGECKO_DEMO_API_KEY</code> in <code>.env.local</code> (the
-        free Demo plan is fine).
+        <code>COINGECKO_DEMO_API_KEY</code> in Settings · API keys (the free
+        Demo plan is fine).
       </p>
     </div>
   );

--- a/lib/columns/plugins/coingecko/plugin.ts
+++ b/lib/columns/plugins/coingecko/plugin.ts
@@ -56,6 +56,6 @@ export const meta: PluginMeta<CoingeckoConfig, CoingeckoMeta> = {
     paginated: true,
     requiresEnv: [],
     rateLimitHint:
-      "Keyless: ~10–30 calls/min. Set COINGECKO_DEMO_API_KEY in .env.local for higher limits.",
+      "Keyless: ~10–30 calls/min. Set COINGECKO_DEMO_API_KEY for higher limits.",
   },
 };

--- a/lib/env-keys.ts
+++ b/lib/env-keys.ts
@@ -44,6 +44,14 @@ export const ENV_KEYS: EnvKeySpec[] = [
     signupUrl: "https://github.com/settings/tokens",
     required: false,
   },
+  {
+    key: "COINGECKO_DEMO_API_KEY",
+    label: "CoinGecko (Demo)",
+    description:
+      "Optional — raises CoinGecko column rate limits beyond the keyless ~10–30 calls/min ceiling. Free Demo plan works.",
+    signupUrl: "https://www.coingecko.com/en/developers/dashboard",
+    required: false,
+  },
 ];
 
 export const ENV_KEY_NAMES = new Set(ENV_KEYS.map((k) => k.key));


### PR DESCRIPTION
## Summary
`COINGECKO_DEMO_API_KEY` is read by `lib/integrations/coingecko.ts` and documented in the README, `.env.example`, and the column's own help text — but it isn't in `ENV_KEYS`, so the Settings · API keys dialog doesn't surface it. Users have to hand-edit `.env.local` even though every other optional API key (NEYNAR_API_KEY, YOUTUBE_API_KEY, GITHUB_TOKEN) is in the allowlist.

## Changes
- `lib/env-keys.ts` — add a `COINGECKO_DEMO_API_KEY` entry (optional, signup URL points at the CoinGecko Developer Dashboard).
- `lib/columns/plugins/coingecko/plugin.ts` — drop the `.env.local` reference from `rateLimitHint` to match the phrasing the other plugins use for `GITHUB_TOKEN` / `YOUTUBE_API_KEY` / `NEYNAR_API_KEY`.
- `lib/columns/plugins/coingecko/client.tsx` — point users at Settings · API keys instead of editing `.env.local` by hand.

+11/-3 across 3 files. No behavior change beyond the in-app dialog now showing the field.

## Context
Same drift shape as the other "documented config option not wired into the canonical allowlist" finds — the integration reads the env var and the docs explain it, but the dialog that's supposed to manage it doesn't know it exists.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)
