### PR TITLE
feat(columns): per-column collapse to a 48px vertical strip

### DIFF
--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -6,6 +6,8 @@ import { CSS } from "@dnd-kit/utilities";
 import { useMemo } from "react";
 import {
   Bell,
+  ChevronLeft,
+  ChevronRight,
   Clock,
   Filter,
   GripVertical,
@@ -50,6 +52,8 @@ export function ColumnCard({ column }: { column: Column }) {
   const applyFetchedItems = useDeckStore((s) => s.applyFetchedItems);
   const renameColumn = useDeckStore((s) => s.renameColumn);
   const isAutoFetchingRaw = useDeckStore((s) => s.autoFetchingIds.has(column.id));
+  const isCollapsed = useDeckStore((s) => s.collapsedColumnIds.has(column.id));
+  const toggleColumnCollapsed = useDeckStore((s) => s.toggleColumnCollapsed);
 
   const [isFetchingRaw, setIsFetching] = useState(false);
   const isFetching = useMinDuration(isFetchingRaw, BEAM_MIN_DURATION_MS);
@@ -246,6 +250,85 @@ export function ColumnCard({ column }: { column: Column }) {
 
   const beamActive = isFetching || isAutoFetching;
 
+  // Collapsed view: render a narrow 48px vertical strip instead of the full
+  // 360px column. The strip keeps brand-accent + icon + a rotated title so the
+  // operator can still see what they collapsed, plus refresh-state and match
+  // badges so a column quietly accumulating alerts isn't invisible. Clicking
+  // anywhere on the strip (except the dnd drag distance threshold) re-expands.
+  // Auto-refresh and item-state computations continue normally — only the body
+  // is hidden, so the moment the operator expands they see the live state.
+  if (isCollapsed) {
+    return (
+      <div
+        ref={setNodeRef}
+        id={`column-${column.id}`}
+        style={style}
+        data-beam-active={beamActive ? "true" : "false"}
+        data-beam-variant="fetch"
+        className={cn(
+          "beam-frame group/col-collapsed relative flex h-full w-12 shrink-0 snap-start cursor-pointer flex-col items-center overflow-hidden rounded-lg border border-border bg-card shadow-[0_4px_12px_-10px_rgba(0,0,0,0.10)] transition-all hover:-translate-y-0.5 hover:bg-surface/40 hover:shadow-[0_10px_24px_-14px_rgba(0,0,0,0.18)] sm:snap-none",
+          isDragging &&
+            "cursor-grabbing shadow-[0_24px_60px_-20px_rgba(0,0,0,0.32)] ring-1 ring-foreground/10",
+        )}
+        onClick={() => toggleColumnCollapsed(column.id)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggleColumnCollapsed(column.id);
+          }
+        }}
+        aria-label={`Expand ${column.title}`}
+        title={`Expand ${column.title}`}
+        {...attributes}
+        {...listeners}
+      >
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-px opacity-70"
+          style={{
+            background: `linear-gradient(90deg, transparent, ${type.accent}, transparent)`,
+          }}
+        />
+        <div
+          className="mt-2.5 flex size-7 shrink-0 items-center justify-center rounded-md ring-1 ring-black/5"
+          style={{ backgroundColor: `${type.accent}33`, color: type.accent }}
+        >
+          <Icon className="size-4" strokeWidth={2.25} />
+        </div>
+        <div className="my-2 flex flex-1 w-full items-center justify-center overflow-hidden">
+          <div
+            className="origin-center -rotate-90 truncate text-[12.5px] font-medium leading-tight text-foreground"
+            style={{ width: "200px", letterSpacing: "-0.01em" }}
+          >
+            {column.title}
+          </div>
+        </div>
+        <div className="mb-2 flex flex-col items-center gap-1.5">
+          {beamActive && (
+            <Loader2
+              aria-label="Fetching"
+              className="size-3 animate-spin text-muted-foreground"
+            />
+          )}
+          {matchCount > 0 && (
+            <span
+              aria-label={`${matchCount} alert match${matchCount === 1 ? "" : "es"}`}
+              className="inline-flex items-center justify-center rounded-full bg-yellow-400/15 px-1.5 py-0.5 text-[10px] font-semibold tabular-nums text-yellow-700 ring-1 ring-yellow-400/40 dark:text-yellow-300"
+            >
+              {matchCount}
+            </span>
+          )}
+          <ChevronRight
+            className="size-4 text-muted-foreground/70 transition-colors group-hover/col-collapsed:text-foreground"
+            aria-hidden
+          />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <>
       <div
@@ -375,6 +458,17 @@ export function ColumnCard({ column }: { column: Column }) {
               )}
             </TooltipTrigger>
             <TooltipContent side="bottom">Refresh</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              onClick={() => toggleColumnCollapsed(column.id)}
+              title="Collapse"
+              aria-label="Collapse column"
+              className="inline-flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-surface hover:text-[color:var(--brand-hover)]"
+            >
+              <ChevronLeft className="size-4" />
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Collapse</TooltipContent>
           </Tooltip>
           <DropdownMenu>
             <DropdownMenuTrigger

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -51,9 +51,18 @@ interface DeckState {
    * switching decks restores the last tab the operator picked in this session.
    */
   selectedTabByDeck: Record<string, string>;
+  /**
+   * Per-column collapsed view state. NOT persisted — same as autoFetchingIds
+   * and selectedTabByDeck, this is purely an in-session UI shape and clears on
+   * reload so every deck opens with all columns at full width. Membership in
+   * the set means the column renders as a 48px vertical strip; absence means
+   * the standard 360px column.
+   */
+  collapsedColumnIds: Set<string>;
 
   hydrate: (snapshot: Snapshot) => void;
   setSelectedTab: (deckId: string, tab: string) => void;
+  toggleColumnCollapsed: (columnId: string) => void;
 
   addDeck: (name: string) => string;
   renameDeck: (deckId: string, name: string) => void;
@@ -149,6 +158,7 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
   columns: {},
   autoFetchingIds: new Set<string>(),
   selectedTabByDeck: {},
+  collapsedColumnIds: new Set<string>(),
 
   hydrate: (snapshot) =>
     set((s) => ({
@@ -166,6 +176,14 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
     set((s) => ({
       selectedTabByDeck: { ...s.selectedTabByDeck, [deckId]: tab },
     })),
+
+  toggleColumnCollapsed: (columnId) =>
+    set((s) => {
+      const next = new Set(s.collapsedColumnIds);
+      if (next.has(columnId)) next.delete(columnId);
+      else next.add(columnId);
+      return { collapsedColumnIds: next };
+    }),
 
   addDeck: (name) => {
     const id = nanoid();
@@ -198,7 +216,15 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
       const deckOrder = s.deckOrder.filter((id) => id !== deckId);
       let activeDeckId = s.activeDeckId;
       if (activeDeckId === deckId) activeDeckId = deckOrder[0] ?? null;
-      return { decks, columns: cols, deckOrder, activeDeckId };
+      const collapsed = new Set(s.collapsedColumnIds);
+      for (const cid of deck.columnIds) collapsed.delete(cid);
+      return {
+        decks,
+        columns: cols,
+        deckOrder,
+        activeDeckId,
+        collapsedColumnIds: collapsed,
+      };
     });
     fireAndLog("deleteDeck", serverDeleteDeck(deckId));
   },
@@ -372,7 +398,9 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
           };
         }
       }
-      return { columns: cols, decks };
+      const collapsed = new Set(s.collapsedColumnIds);
+      collapsed.delete(columnId);
+      return { columns: cols, decks, collapsedColumnIds: collapsed };
     });
     fireAndLog("deleteColumn", serverDeleteColumn(columnId));
   },


### PR DESCRIPTION
## What

Per-column collapse/expand. Click the new chevron in any column header to fold the column down to a 48px vertical strip (icon + rotated title + activity indicators). Click the strip anywhere to expand it back to the standard 360px column.

## Why

Tab groups (PR #53, May-29) partition a deck into named sections so 8+ column decks stay navigable. But inside a single tab with 4-6 columns, operators often have **two focus columns + a few reference columns** — they want to keep the references visible without giving them equal screen space. Collapse closes that gap: the references reduce to thin strips that still show fetch activity + alert matches, and one click brings them back to full size.

This is the natural complement to tab groups on the same UX axis (deck density). Tabs are "which columns am I looking at right now"; collapse is "which of these columns are primary vs reference right now". Both work together — collapse state survives tab switching since it's per-column-id.

## What was built

- **`lib/store/use-deck-store.ts`** (+32, -2)
  - `collapsedColumnIds: Set<string>` — in-session view state, NOT persisted (matches `autoFetchingIds` and `selectedTabByDeck`). Every deck opens with all columns expanded on a fresh page load.
  - `toggleColumnCollapsed(columnId)` action.
  - `removeColumn` and `deleteDeck` now scrub deleted column ids from `collapsedColumnIds` so the set can't accumulate stale ids over a long-lived session.

- **`components/column/column-card.tsx`** (+94, +0 dependency adds)
  - New `lucide-react` imports: `ChevronLeft` (collapse, in expanded header) + `ChevronRight` (expand affordance, in collapsed strip).
  - Read `isCollapsed` + `toggleColumnCollapsed` from the store.
  - **Collapsed strip render** (early return): 48px wide vertical card, brand accent line at the top, type icon, rotated title (`-rotate-90` with fixed 200px inline width so truncation works), refresh spinner when fetching, alert-match-count badge when keywords matched, ChevronRight expand affordance. The whole strip is the click target (`cursor-pointer`, `role="button"`, keyboard handler for Space/Enter); dnd-kit attributes/listeners spread onto it so dragging to reorder still works — the PointerSensor's 4px activation distance separates a click from a drag.
  - **Expanded-header Collapse button**: tooltip-wrapped `ChevronLeft` between the existing Refresh button and the More-options dropdown.

## How it works

`collapsedColumnIds` is a plain `Set<string>` in zustand state, mirroring the existing `autoFetchingIds` shape that the store already uses for transient view state. The toggle action does a copy-on-write `new Set` so React picks up the change. When `useDeckStore((s) => s.collapsedColumnIds.has(column.id))` returns true, `ColumnCard` short-circuits to the strip render before the regular header + items layout. Auto-refresh, alert-keyword matching, and include/exclude filtering all keep running while collapsed — only the items list and the Configure/Rename/Delete dialogs are hidden. The moment the operator expands, they see live state with no re-fetch needed.

No DB schema change, no migration, no plugin contract touched — purely UI + zustand. Decks export / import / share-link fragment all continue to work unchanged because the collapsed state never leaves the browser session.

## What's next

The collapsed strip currently shows just the alert-match count when keywords are configured; a follow-up could surface the unread-item count too (column delta since last expand) so the strip becomes a more general "what's happening here" indicator. Also a deck-level "collapse all / expand all" command would compose nicely with tab groups for operators who want to switch a deck between "scan mode" (all collapsed) and "focus mode" (one column expanded).

## Test plan

- [ ] Click chevron in any column header → column collapses to a 48px strip. Icon + rotated title visible. Click strip → expands back to 360px.
- [ ] Configure alertKeywords on a column. Collapse it. When auto-refresh fetches an item matching the keyword, the yellow match-count badge appears on the strip without needing to expand.
- [ ] Drag a collapsed strip in a deck of multiple columns → reorders. Click (no drag) → expands. 4px threshold distinguishes the two.
- [ ] Keyboard: Tab to a collapsed strip, press Enter or Space → expands.
- [ ] Reload the page → all columns open expanded (view state cleared, by design).
- [ ] Switch decks / switch tabs → collapsed columns stay collapsed when revisited within the same session.
- [ ] Delete a collapsed column → no stale id left in the set; same column slot reused later (different id) starts expanded.
- [ ] Mobile / narrow viewport: strips still render correctly; full-column snap-scroll behavior preserved for expanded columns.

---

*Built autonomously by Aeon — \`feature\` skill, 2026-05-30.*