### PR TITLE
feat(columns): one-click JSON export of cached column items

### DIFF
--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -9,6 +9,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Clock,
+  Download,
   Filter,
   GripVertical,
   Loader2,
@@ -51,6 +52,8 @@ export function ColumnCard({ column }: { column: Column }) {
   const removeColumn = useDeckStore((s) => s.removeColumn);
   const applyFetchedItems = useDeckStore((s) => s.applyFetchedItems);
   const renameColumn = useDeckStore((s) => s.renameColumn);
+  const downloadColumnItems = useDeckStore((s) => s.downloadColumnItems);
+  const hasItems = column.items.length > 0;
   const isAutoFetchingRaw = useDeckStore((s) => s.autoFetchingIds.has(column.id));
   const isCollapsed = useDeckStore((s) => s.collapsedColumnIds.has(column.id));
   const toggleColumnCollapsed = useDeckStore((s) => s.toggleColumnCollapsed);
@@ -483,6 +486,21 @@ export function ColumnCard({ column }: { column: Column }) {
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setRenameOpen(true)}>
                 <Pencil className="mr-2 size-4" /> Rename
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={!hasItems}
+                onClick={() => {
+                  const n = downloadColumnItems(column.id);
+                  if (n > 0) {
+                    toast.success(
+                      `Exported ${n} item${n === 1 ? "" : "s"}`,
+                      { description: column.title },
+                    );
+                  }
+                }}
+              >
+                <Download className="mr-2 size-4" />{" "}
+                {hasItems ? "Download items (JSON)" : "No items loaded yet"}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -102,6 +102,7 @@ interface DeckState {
 
   exportDeck: (deckId: string) => Promise<string>;
   importDeck: (json: string) => Promise<ImportedDeckResult>;
+  downloadColumnItems: (columnId: string) => number;
   loadDeckSnapshots: (deckId: string) => Promise<DeckSnapshotMeta[]>;
   restoreDeckSnapshot: (snapshotId: number) => Promise<ImportedDeckResult>;
 }
@@ -447,6 +448,62 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
   },
 
   exportDeck: (deckId) => serverExportDeck(deckId),
+
+  // Client-only — never round-trips the server. Pulls the column's cached
+  // items array straight out of the store, serializes to pretty-printed JSON,
+  // and drops a download via a synthetic <a download>. The filename embeds the
+  // column title (slugified) + UTC date so multiple exports of the same column
+  // across days don't collide in the user's Downloads folder.
+  //
+  // Returns the number of items written so the caller (column-card.tsx) can
+  // surface it in a toast — 0 means we deliberately did not trigger a download
+  // (no items cached yet; UI should disable the menu entry instead of letting
+  // the click through).
+  downloadColumnItems: (columnId) => {
+    if (typeof window === "undefined") return 0;
+    const col = get().columns[columnId];
+    if (!col || col.items.length === 0) return 0;
+
+    const payload = {
+      schema: "minitor.column-export.v1",
+      exportedAt: new Date().toISOString(),
+      column: {
+        id: col.id,
+        typeId: col.typeId,
+        title: col.title,
+      },
+      itemCount: col.items.length,
+      items: col.items,
+    };
+
+    const slug =
+      col.title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 64) || "column";
+    const date = new Date().toISOString().slice(0, 10);
+    const filename = `${slug}-${date}.json`;
+
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    try {
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    } finally {
+      // Revoke immediately — the click has already started the save dialog
+      // by this point, and holding the URL alive leaks the blob for the
+      // lifetime of the tab.
+      URL.revokeObjectURL(url);
+    }
+    return col.items.length;
+  },
 
   importDeck: async (json) => {
     const result = await serverImportDeck(json);


### PR DESCRIPTION
## What
Adds a "Download items (JSON)" entry to every column's More-menu dropdown. Click it and the column's cached items array is serialized to pretty-printed JSON and saved via the browser's native download dialog — no server round-trip, no new schema, no migration.

## Why
- Repo-actions idea #5 from 2026-05-30
- 47+ column types now ship (crypto prices, GitHub signals, social feeds, news, DeFi TVL). Power users and analysts using minitor as a monitoring hub frequently want the raw fetched data for spreadsheets, re-processing, archiving, or sharing — but there was no export path. Data was effectively trapped in the browser.
- Zero infrastructure cost: items are already in the Zustand store, the export is pure client-side blob → object URL → synthetic `<a download>` click.

## Changes
- `lib/store/use-deck-store.ts` (+58):
  - New `downloadColumnItems(columnId: string): number` store action — reads `columns[columnId].items` from store state, serializes a versioned envelope (`schema: "minitor.column-export.v1"`, `exportedAt`, `column: {id, typeId, title}`, `itemCount`, `items`), creates a Blob with `application/json`, triggers a synthetic download, revokes the object URL immediately after the click. Returns the item count so the caller can surface a toast.
  - Returns `0` when there are no cached items — the menu entry should be disabled in that case (column-card.tsx does this), but the store guards against an unexpected call anyway.
  - SSR-safe: bails immediately if `typeof window === "undefined"`.
- `components/column/column-card.tsx` (+17):
  - Added `Download` icon import from lucide-react.
  - Added `downloadColumnItems` selector + `hasItems` derived flag.
  - New `<DropdownMenuItem>` between Rename and Delete: disabled when `!hasItems` (label reads "No items loaded yet" in that state, "Download items (JSON)" otherwise), triggers a success toast on download.

## Filename format
`{title-slug}-{YYYY-MM-DD}.json` — e.g. `defillama-tvl-2026-05-31.json`. Slug is the column title lowercased, non-alphanumerics collapsed to `-`, trimmed, capped at 64 chars; falls back to `column` for titles that slug to empty.

## What's NOT in this PR
- CSV export — the FeedItem shape is plug-in-specific (`meta?: TMeta`), so a generic CSV flattener would either drop meta or smear shapes. JSON-first lets the existing items round-trip losslessly; CSV is a follow-up when there's a concrete use case naming a specific plugin.
- Schema validation on re-import — this is a one-way export. Reading exports back in is a separate (and more dangerous) story; deliberately out of scope.

---
*Built autonomously by Aeon — feature skill, 2026-05-31*
