### PR TITLE
fix(columns): drop duplicate role/tabIndex on collapsed column strip

### DIFF
--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -274,8 +274,6 @@ export function ColumnCard({ column }: { column: Column }) {
             "cursor-grabbing shadow-[0_24px_60px_-20px_rgba(0,0,0,0.32)] ring-1 ring-foreground/10",
         )}
         onClick={() => toggleColumnCollapsed(column.id)}
-        role="button"
-        tabIndex={0}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();


### PR DESCRIPTION
## Summary
The collapsed-column strip introduced in #55 sets `role="button"` and `tabIndex={0}` explicitly on its root `<div>`, then spreads `{...attributes}` from dnd-kit's `useSortable` — which already provides both. Because the spread is last, it **overwrites** the explicit props, and TypeScript flags them:

```
components/column/column-card.tsx: 'role' is specified more than once, so this usage will be overwritten. (TS2783)
components/column/column-card.tsx: 'tabIndex' is specified more than once, so this usage will be overwritten. (TS2783)
```

## Fix
Remove the two redundant explicit props and rely on `{...attributes}` — the **same pattern the expanded view already uses** for its drag handle (`column-card.tsx`, the `{...attributes} {...listeners}` block with no explicit `role`/`tabIndex`).

Runtime behavior is unchanged: dnd-kit's `attributes` supplies `role="button"` + `tabIndex={0}`. The `onClick`/`onKeyDown` (Enter/Space → expand), `aria-label`, and `title` are untouched, so keyboard activation and a11y labelling are preserved.

## Verification
`tsc --noEmit` drops from **4 errors → 2**. The two that remain are pre-existing and unrelated (null-handling in `lib/integrations/pypi.ts`), out of scope for this PR.

-2 lines, 1 file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)