### PR TITLE
feat(columns): per-column quick-search input — ephemeral substring filter on top of include/exclude

### DIFF
--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -16,8 +16,10 @@ import {
   MoreHorizontal,
   Pencil,
   RefreshCw,
+  Search,
   Settings2,
   Trash2,
+  X,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -40,6 +42,7 @@ import { useMinDuration } from "@/hooks/use-min-duration";
 import { BEAM_MIN_DURATION_MS } from "@/lib/columns/constants";
 import {
   itemMatchesAlertKeywords,
+  itemMatchesSearchQuery,
   parseAlertKeywords,
 } from "@/lib/columns/keyword-match";
 import type { Column } from "@/lib/columns/types";
@@ -57,6 +60,10 @@ export function ColumnCard({ column }: { column: Column }) {
   const isAutoFetchingRaw = useDeckStore((s) => s.autoFetchingIds.has(column.id));
   const isCollapsed = useDeckStore((s) => s.collapsedColumnIds.has(column.id));
   const toggleColumnCollapsed = useDeckStore((s) => s.toggleColumnCollapsed);
+  const searchQuery = useDeckStore((s) => s.searchByColumn[column.id] ?? "");
+  const setColumnSearch = useDeckStore((s) => s.setColumnSearch);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   const [isFetchingRaw, setIsFetching] = useState(false);
   const isFetching = useMinDuration(isFetchingRaw, BEAM_MIN_DURATION_MS);
@@ -118,7 +125,7 @@ export function ColumnCard({ column }: { column: Column }) {
   // exclude wins when an item matches both. Reuses the alert-keyword matcher so
   // filter semantics (author + content + url, case-insensitive substring) stay
   // identical to the highlight behaviour operators already know.
-  const visibleItems = useMemo(() => {
+  const filteredItems = useMemo(() => {
     if (!filtersActive) return column.items;
     return column.items.filter((it) => {
       if (includeTerms.length > 0 && !itemMatchesAlertKeywords(it, includeTerms))
@@ -129,6 +136,17 @@ export function ColumnCard({ column }: { column: Column }) {
     });
   }, [filtersActive, column.items, includeTerms, excludeTerms]);
 
+  // Quick-search runs on top of include/exclude — view-state-only narrowing.
+  // Empty query passes through, so a closed search bar has zero cost. Search
+  // never widens past the persisted-filter results, matching the operator's
+  // mental model: filters decide what the column *contains*, search decides
+  // what they're looking at *right now* inside that subset.
+  const searchActive = searchQuery.trim().length > 0;
+  const visibleItems = useMemo(() => {
+    if (!searchActive) return filteredItems;
+    return filteredItems.filter((it) => itemMatchesSearchQuery(it, searchQuery));
+  }, [filteredItems, searchActive, searchQuery]);
+
   const matchedItemIds = useMemo(() => {
     if (alertTerms.length === 0) return new Set<string>();
     const out = new Set<string>();
@@ -138,6 +156,19 @@ export function ColumnCard({ column }: { column: Column }) {
     return out;
   }, [alertTerms, visibleItems]);
   const matchCount = matchedItemIds.size;
+
+  // Auto-open the search row when a query already exists on mount — covers
+  // the case where the operator collapsed/expanded a column or switched tabs
+  // and the search state was preserved in-session. Closing collapses the row
+  // visually but never clears the query, so re-opening shows what they last
+  // typed (until they reload or manually clear).
+  useEffect(() => {
+    if (searchActive && !searchOpen) setSearchOpen(true);
+    // intentionally only react to searchActive flipping true — don't auto-
+    // close when the operator clears the query mid-type; let them keep the
+    // input visible to keep typing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchActive]);
 
   // Auto-refresh tick — useRef snapshots so the interval closure always reads
   // the latest typeId/config without forcing a tear-down on every config edit.
@@ -313,6 +344,12 @@ export function ColumnCard({ column }: { column: Column }) {
               className="size-3 animate-spin text-muted-foreground"
             />
           )}
+          {searchActive && (
+            <Search
+              aria-label={`Search active: "${searchQuery}"`}
+              className="size-3 text-emerald-600 dark:text-emerald-400"
+            />
+          )}
           {matchCount > 0 && (
             <span
               aria-label={`${matchCount} alert match${matchCount === 1 ? "" : "es"}`}
@@ -406,22 +443,38 @@ export function ColumnCard({ column }: { column: Column }) {
           {filtersActive && (
             <Tooltip>
               <TooltipTrigger
-                aria-label={`Filtered: showing ${visibleItems.length} of ${column.items.length} items`}
+                aria-label={`Filtered: showing ${filteredItems.length} of ${column.items.length} items`}
                 className="inline-flex shrink-0 items-center gap-1 rounded-full bg-sky-400/15 px-2 py-0.5 text-[11px] font-medium text-sky-700 ring-1 ring-sky-400/40 dark:text-sky-300"
               >
                 <Filter className="size-3" strokeWidth={2.5} />
                 <span className="tabular-nums">
-                  {visibleItems.length}/{column.items.length}
+                  {filteredItems.length}/{column.items.length}
                 </span>
               </TooltipTrigger>
               <TooltipContent side="bottom">
-                Showing {visibleItems.length} of {column.items.length}
+                Showing {filteredItems.length} of {column.items.length}
                 {includeTerms.length > 0 && (
                   <> · only: {includeTerms.join(", ")}</>
                 )}
                 {excludeTerms.length > 0 && (
                   <> · hiding: {excludeTerms.join(", ")}</>
                 )}
+              </TooltipContent>
+            </Tooltip>
+          )}
+          {searchActive && (
+            <Tooltip>
+              <TooltipTrigger
+                aria-label={`Search: ${visibleItems.length} of ${filteredItems.length} match "${searchQuery}"`}
+                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-emerald-400/15 px-2 py-0.5 text-[11px] font-medium text-emerald-700 ring-1 ring-emerald-400/40 dark:text-emerald-300"
+              >
+                <Search className="size-3" strokeWidth={2.5} />
+                <span className="tabular-nums">
+                  {visibleItems.length}/{filteredItems.length}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {visibleItems.length} match{visibleItems.length === 1 ? "" : "es"} for &ldquo;{searchQuery}&rdquo;
               </TooltipContent>
             </Tooltip>
           )}
@@ -444,6 +497,34 @@ export function ColumnCard({ column }: { column: Column }) {
                 </TooltipContent>
               </Tooltip>
             )}
+          <Tooltip>
+            <TooltipTrigger
+              onClick={() => {
+                setSearchOpen((open) => {
+                  const next = !open;
+                  if (next) {
+                    // Focus on next tick so the input mounts before we ask
+                    // for focus. requestAnimationFrame is the cheapest hook
+                    // for "after this render commits".
+                    requestAnimationFrame(() => searchInputRef.current?.focus());
+                  }
+                  return next;
+                });
+              }}
+              title="Search items"
+              aria-label={searchOpen ? "Close search" : "Search items"}
+              aria-pressed={searchOpen}
+              className={cn(
+                "inline-flex size-8 items-center justify-center rounded-full transition-colors hover:bg-surface hover:text-[color:var(--brand-hover)]",
+                searchActive
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-muted-foreground",
+              )}
+            >
+              <Search className="size-4" />
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Search items</TooltipContent>
+          </Tooltip>
           <Tooltip>
             <TooltipTrigger
               onClick={onRefresh}
@@ -511,6 +592,50 @@ export function ColumnCard({ column }: { column: Column }) {
           </DropdownMenu>
         </div>
 
+        {searchOpen && (
+          <div className="flex items-center gap-1.5 border-b border-border bg-surface/40 px-2 py-1.5">
+            <Search className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setColumnSearch(column.id, e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  setColumnSearch(column.id, "");
+                  setSearchOpen(false);
+                }
+              }}
+              placeholder="Find in column…"
+              aria-label="Search items in this column"
+              maxLength={256}
+              className="flex-1 min-w-0 bg-transparent text-[12.5px] text-foreground placeholder:text-muted-foreground focus:outline-none"
+            />
+            {searchActive && (
+              <button
+                type="button"
+                onClick={() => {
+                  setColumnSearch(column.id, "");
+                  searchInputRef.current?.focus();
+                }}
+                aria-label="Clear search"
+                className="inline-flex size-5 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-surface hover:text-foreground"
+              >
+                <X className="size-3" />
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => setSearchOpen(false)}
+              aria-label="Close search"
+              className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10.5px] font-medium text-muted-foreground transition-colors hover:bg-surface hover:text-foreground"
+            >
+              Esc
+            </button>
+          </div>
+        )}
+
         <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain">
           {column.items.length === 0 ? (
             isFetching || isAutoFetching ? (
@@ -521,7 +646,17 @@ export function ColumnCard({ column }: { column: Column }) {
           ) : (
             <div>
               {visibleItems.length === 0 ? (
-                <FilteredEmptyState totalCount={column.items.length} />
+                searchActive ? (
+                  <SearchEmptyState
+                    query={searchQuery}
+                    onClear={() => {
+                      setColumnSearch(column.id, "");
+                      searchInputRef.current?.focus();
+                    }}
+                  />
+                ) : (
+                  <FilteredEmptyState totalCount={column.items.length} />
+                )
               ) : (
                 visibleItems.map((item) =>
                   matchedItemIds.has(item.id) ? (
@@ -623,6 +758,31 @@ function FilteredEmptyState({ totalCount }: { totalCount: number }) {
         {totalCount} item{totalCount === 1 ? "" : "s"} hidden. Adjust the
         column&rsquo;s filters in Configure.
       </div>
+    </div>
+  );
+}
+
+function SearchEmptyState({
+  query,
+  onClear,
+}: {
+  query: string;
+  onClear: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+      <Search className="size-5 text-muted-foreground/60" />
+      <div className="text-sm font-medium">No matches for &ldquo;{query}&rdquo;</div>
+      <div className="text-xs text-muted-foreground">
+        Search is a view-only narrowing on top of the column&rsquo;s filters.
+      </div>
+      <button
+        type="button"
+        onClick={onClear}
+        className="mt-1 text-xs font-medium text-emerald-700 underline-offset-2 hover:underline dark:text-emerald-300"
+      >
+        Clear search
+      </button>
     </div>
   );
 }

--- a/lib/columns/keyword-match.ts
+++ b/lib/columns/keyword-match.ts
@@ -51,6 +51,30 @@ export function itemMatchesAlertKeywords(
 }
 
 /**
+ * Single-string substring match — case-insensitive, scans the same haystack as
+ * `itemMatchesAlertKeywords` (content + author name + author handle + url).
+ * Returns true when `query` is non-empty and appears as a substring.
+ *
+ * Used by the per-column quick-search input. Distinct from `parseAlertKeywords`
+ * which splits a config string into a list of OR-combined terms — the search
+ * input is one literal query, not a keyword list, so split semantics would just
+ * confuse "rust foo" → "rust" OR "foo" when the operator meant the phrase.
+ */
+export function itemMatchesSearchQuery(item: FeedItem, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return false;
+  const haystack = [
+    item.content,
+    item.author?.name ?? "",
+    item.author?.handle ?? "",
+    item.url ?? "",
+  ]
+    .join("\n")
+    .toLowerCase();
+  return haystack.includes(q);
+}
+
+/**
  * Like `itemMatchesAlertKeywords`, but returns the subset of `terms` that
  * actually matched (in their original order). Empty array = no match. Used to
  * tell a webhook consumer *which* keywords fired for each item.

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -59,10 +59,21 @@ interface DeckState {
    * the standard 360px column.
    */
   collapsedColumnIds: Set<string>;
+  /**
+   * Per-column quick-search query. NOT persisted — view state only, clears on
+   * reload. Distinct from `filterKeywords` / `excludeKeywords` (those are saved
+   * column config that survive reload and travel with the deck on export); this
+   * is the ephemeral "type to find" input rendered inline below the column
+   * header. Absent or empty string = search inactive. Substring match runs on
+   * top of include/exclude — search narrows what's already visible, never
+   * widens past what the persisted filters allow.
+   */
+  searchByColumn: Record<string, string>;
 
   hydrate: (snapshot: Snapshot) => void;
   setSelectedTab: (deckId: string, tab: string) => void;
   toggleColumnCollapsed: (columnId: string) => void;
+  setColumnSearch: (columnId: string, query: string) => void;
 
   addDeck: (name: string) => string;
   renameDeck: (deckId: string, name: string) => void;
@@ -160,6 +171,7 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
   autoFetchingIds: new Set<string>(),
   selectedTabByDeck: {},
   collapsedColumnIds: new Set<string>(),
+  searchByColumn: {},
 
   hydrate: (snapshot) =>
     set((s) => ({
@@ -184,6 +196,21 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
       if (next.has(columnId)) next.delete(columnId);
       else next.add(columnId);
       return { collapsedColumnIds: next };
+    }),
+
+  setColumnSearch: (columnId, query) =>
+    set((s) => {
+      // Trim and cap so a runaway paste can't slow the substring scan or blow
+      // up the rendered input. 256 chars is far more than any realistic
+      // operator query — anything longer is almost certainly accidental.
+      const trimmed = query.slice(0, 256);
+      const next = { ...s.searchByColumn };
+      if (trimmed.length === 0) {
+        delete next[columnId];
+      } else {
+        next[columnId] = trimmed;
+      }
+      return { searchByColumn: next };
     }),
 
   addDeck: (name) => {
@@ -219,12 +246,15 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
       if (activeDeckId === deckId) activeDeckId = deckOrder[0] ?? null;
       const collapsed = new Set(s.collapsedColumnIds);
       for (const cid of deck.columnIds) collapsed.delete(cid);
+      const searchByColumn = { ...s.searchByColumn };
+      for (const cid of deck.columnIds) delete searchByColumn[cid];
       return {
         decks,
         columns: cols,
         deckOrder,
         activeDeckId,
         collapsedColumnIds: collapsed,
+        searchByColumn,
       };
     });
     fireAndLog("deleteDeck", serverDeleteDeck(deckId));
@@ -401,7 +431,9 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
       }
       const collapsed = new Set(s.collapsedColumnIds);
       collapsed.delete(columnId);
-      return { columns: cols, decks, collapsedColumnIds: collapsed };
+      const searchByColumn = { ...s.searchByColumn };
+      delete searchByColumn[columnId];
+      return { columns: cols, decks, collapsedColumnIds: collapsed, searchByColumn };
     });
     fireAndLog("deleteColumn", serverDeleteColumn(columnId));
   },


### PR DESCRIPTION
## What

Adds a per-column **quick-search** input to every column. Click the new search icon in the column header (between the alert/filter/refresh-interval badges and the Refresh button) and a thin input row drops beneath the header. Type to narrow the visible items live; Esc clears + closes the input; the small `×` button clears without closing.

Substring match is case-insensitive and scans the same haystack the alert-keyword highlighter uses (item content + author name + author handle + URL), so search semantics are identical to the rules operators already know.

## Why

Minitor now ships 47+ column types and operators frequently keep deep-scrolling columns open (Hacker News, github-issues, github-discussions, npm/pypi/crates, polymarket, etc.). The existing **include / exclude keyword filters** are persistent column config — they survive reloads, travel with deck exports, fire webhooks on new matches. They're the right answer for "always keep this column tuned to X."

But they're the wrong shape for *"I have 200 items in this column and I'm looking for the one that mentions postgres."* That's an ephemeral, view-only narrowing — the operator doesn't want to reconfigure the column, they just want to find something in the current items. Quick-search is that view.

Search is layered: it never widens past include/exclude, it just narrows what's already visible. So an operator who configured `exclude: spam` still won't see spam when they search — the include/exclude rules decide what the column *contains*; search decides what they're *looking at right now* inside that subset.

## Changes

- `lib/store/use-deck-store.ts` (+34/-3) — new `searchByColumn: Record<columnId, string>` view-state map (NOT persisted, same lifetime as `autoFetchingIds` / `selectedTabByDeck` / `collapsedColumnIds`), `setColumnSearch(columnId, query)` action with trim + 256-char cap + empty-string-deletes, cleanup keys on `deleteColumn` and `deleteDeck` so a long session can't accumulate stale entries.
- `lib/columns/keyword-match.ts` (+24/-0) — new `itemMatchesSearchQuery(item, query)` helper. Single literal substring (no comma/semicolon split — search is one query, not a keyword list), scans the same content + author + url haystack as `itemMatchesAlertKeywords` so the match rules stay consistent.
- `components/column/column-card.tsx` (+170/-7):
  - Renamed `visibleItems` flow to two stages: `filteredItems` (after include/exclude) → `visibleItems` (after search). Filter tooltip now reflects `filteredItems / column.items`; new green search tooltip reflects `visibleItems / filteredItems`.
  - Alert-match highlighting (`matchedItemIds`) derives from `visibleItems` so alerts only highlight what the operator can currently see.
  - Search button in the header toggles the input row. `aria-pressed` + emerald accent when a query is active.
  - Input row sits between the header and the items list, `Esc` clears + closes, `×` button clears in place.
  - `useEffect` auto-opens the search row when a column re-renders with a non-empty `searchQuery` already in store (e.g. operator collapses then expands a column mid-search — the query persists in-session).
  - New `SearchEmptyState` rendered when search active + zero matches, with a one-click clear-search button.
  - **Collapsed strip: small emerald `Search` icon when search is active**, so an operator who collapsed a column mid-search still sees that the in-session filter is on (otherwise the match-count badge would silently undercount and look like a refresh problem).

## Design decisions

- **View-state only, never persisted.** Searches don't survive a reload, don't export with the deck, don't fire webhooks. That's the line that separates this from include/exclude — the same line `collapsedColumnIds` and `selectedTabByDeck` already sit on.
- **Search narrows; never widens.** Search runs on top of include/exclude, never against the raw `column.items`. An operator who set `exclude: spam` and then searches for `discount` won't be shown spam-with-the-word-discount — the persisted filter wins.
- **Single literal substring, not a parsed keyword list.** Reusing `parseAlertKeywords` would split `rust foo` into `["rust", "foo"]` OR-combined; the operator typing `rust foo` almost certainly means the phrase. Search and keyword config are intentionally different shapes.
- **Same haystack as alert keywords.** Operators already know what the alert highlighter scans — using the same fields keeps the mental model consistent.
- **256-char cap on the query.** Defensive — no operator types a 200-char query, but a runaway paste shouldn't make the substring scan slow.
- **Auto-open on render when a query exists.** Covers the cross-tab / cross-collapse case: an operator searching one column then switching to another tab should see the search bar reappear when they come back, because the state survived.
- **Collapsed search indicator.** A column collapsed mid-search would otherwise hide the active filter. The small emerald icon on the strip is the cheapest possible "hey, this column has a search on it" signal — no count, no text, just presence.
- **No DB schema, no migration, no server round-trip, no plugin contract touched.** Pure view-state work — drizzle isn't involved.

## Test plan

- [ ] Open any column, click the search icon, type a substring — items narrow live; the green search badge in the header shows `matches/filtered`.
- [ ] Press Esc inside the input — clears the query and closes the row.
- [ ] Click the `×` button — clears in place, input stays open and focused.
- [ ] Search + include/exclude combined: column with `exclude: foo` set; search for `bar`. Items containing `foo` never appear even if they mention `bar`.
- [ ] Search + alert keywords: alert-keyword highlighting only fires on items still visible after the search; matchCount badge shrinks as search narrows.
- [ ] Collapse a column with active search — the strip shows a small emerald Search icon. Expand — search bar reappears with the same query.
- [ ] Delete a column with active search — no orphaned key remains in `searchByColumn` (no functional bug; just internal hygiene check).
- [ ] Deck export / import — the exported JSON does NOT contain search state, and importing a deck does NOT restore search state.
- [ ] Type-check could NOT run locally (Next 16 offline sandbox) — manual review against the structurally-similar `collapsedColumnIds` / `autoFetchingIds` flows.

---
*Built autonomously by Aeon.*