### PR TITLE
feat: per-column pin-to-front toggle

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -95,6 +95,7 @@ export async function loadSnapshot(): Promise<Snapshot> {
       filterKeywords: c.filterKeywords ?? undefined,
       excludeKeywords: c.excludeKeywords ?? undefined,
       tabGroup: c.tabGroup ?? undefined,
+      pinned: c.pinned ? true : undefined,
       items: [],
       lastFetchedAt: c.lastFetchedAt ? c.lastFetchedAt.toISOString() : undefined,
     };
@@ -307,6 +308,23 @@ export async function updateColumnTabGroup(
     .where(eq(columns.id, id));
 }
 
+/**
+ * Persist a column's pinned flag. Pinned columns render before every unpinned
+ * column in the deck regardless of their stored `position`, so the deck-board's
+ * sort order is `pinned DESC, position ASC` instead of `position ASC` alone.
+ * DnD reorder still works within each group (pinned among pinned, unpinned
+ * among unpinned) — `position` keeps the stable relative order.
+ */
+export async function updateColumnPinned(
+  id: string,
+  pinned: boolean,
+): Promise<void> {
+  await db
+    .update(columns)
+    .set({ pinned })
+    .where(eq(columns.id, id));
+}
+
 export async function renameColumn(id: string, title: string): Promise<void> {
   await db.update(columns).set({ title }).where(eq(columns.id, id));
 }
@@ -364,6 +382,10 @@ const importedColumnSchema = z.object({
   // import / share links so a multi-section starter deck can ship pre-grouped.
   // Normalized server-side (whitespace collapsed, trimmed, capped to TAB_GROUP_MAX).
   tabGroup: z.string().max(TAB_GROUP_MAX).optional(),
+  // Optional pin flag. Not a secret — round-trips through export / import /
+  // share links so a starter template can ship with priority columns already
+  // pinned to the deck's front.
+  pinned: z.boolean().optional(),
 });
 
 const importedDeckSchema = z.object({
@@ -396,6 +418,7 @@ export async function exportDeck(deckId: string): Promise<string> {
       filterKeywords: columns.filterKeywords,
       excludeKeywords: columns.excludeKeywords,
       tabGroup: columns.tabGroup,
+      pinned: columns.pinned,
     })
     .from(columns)
     .where(eq(columns.deckId, deckId))
@@ -421,6 +444,7 @@ export async function exportDeck(deckId: string): Promise<string> {
       ...(c.filterKeywords ? { filterKeywords: c.filterKeywords } : {}),
       ...(c.excludeKeywords ? { excludeKeywords: c.excludeKeywords } : {}),
       ...(c.tabGroup ? { tabGroup: c.tabGroup } : {}),
+      ...(c.pinned ? { pinned: true } : {}),
     })),
   };
   return JSON.stringify(payload, null, 2);
@@ -437,6 +461,7 @@ export interface ImportedDeckColumn {
   filterKeywords?: string;
   excludeKeywords?: string;
   tabGroup?: string;
+  pinned?: boolean;
 }
 
 export interface ImportedDeckResult {
@@ -521,6 +546,9 @@ export async function importDeck(
         .trim()
         .slice(0, TAB_GROUP_MAX);
       const tabGroup = tabGroupNormalized.length === 0 ? null : tabGroupNormalized;
+      // Pinned is a plain boolean — coerce missing/non-true to false so a
+      // hand-edited payload can't smuggle a truthy non-boolean into the DB.
+      const pinned = c.pinned === true;
       await tx.insert(columns).values({
         id,
         deckId,
@@ -533,6 +561,7 @@ export async function importDeck(
         filterKeywords,
         excludeKeywords,
         tabGroup,
+        pinned,
         position: i,
       });
       created.push({
@@ -546,6 +575,7 @@ export async function importDeck(
         ...(filterKeywords ? { filterKeywords } : {}),
         ...(excludeKeywords ? { excludeKeywords } : {}),
         ...(tabGroup ? { tabGroup } : {}),
+        ...(pinned ? { pinned: true } : {}),
       });
     }
   });

--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
   MoreHorizontal,
   Pencil,
+  Pin,
   RefreshCw,
   Search,
   Settings2,
@@ -338,6 +339,13 @@ export function ColumnCard({ column }: { column: Column }) {
           </div>
         </div>
         <div className="mb-2 flex flex-col items-center gap-1.5">
+          {column.pinned && (
+            <Pin
+              aria-label="Pinned to the front of the deck"
+              className="size-3 text-[color:var(--brand)]"
+              strokeWidth={2.5}
+            />
+          )}
           {beamActive && (
             <Loader2
               aria-label="Fetching"
@@ -497,6 +505,19 @@ export function ColumnCard({ column }: { column: Column }) {
                 </TooltipContent>
               </Tooltip>
             )}
+          {column.pinned && (
+            <Tooltip>
+              <TooltipTrigger
+                aria-label="Pinned to the front of the deck"
+                className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-[color:var(--brand)]/10 text-[color:var(--brand)] ring-1 ring-[color:var(--brand)]/30"
+              >
+                <Pin className="size-3" strokeWidth={2.5} />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                Pinned to the front · stays visible on every tab
+              </TooltipContent>
+            </Tooltip>
+          )}
           <Tooltip>
             <TooltipTrigger
               onClick={() => {

--- a/components/column/configure-column-dialog.tsx
+++ b/components/column/configure-column-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Bell, Clock, EyeOff, Filter, LayoutGrid, Webhook } from "lucide-react";
+import { Bell, Clock, EyeOff, Filter, LayoutGrid, Pin, Webhook } from "lucide-react";
 
 import {
   Dialog,
@@ -68,6 +68,7 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
   const updateRefreshInterval = useDeckStore((s) => s.updateRefreshInterval);
   const updateFilters = useDeckStore((s) => s.updateFilters);
   const updateTabGroup = useDeckStore((s) => s.updateTabGroup);
+  const updatePinned = useDeckStore((s) => s.updatePinned);
 
   const [draft, setDraft] = useState<Record<string, unknown>>(column.config);
   const [alertDraft, setAlertDraft] = useState<string>(
@@ -88,6 +89,9 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
   const [tabGroupDraft, setTabGroupDraft] = useState<string>(
     column.tabGroup ?? "",
   );
+  const [pinnedDraft, setPinnedDraft] = useState<boolean>(
+    column.pinned === true,
+  );
   const [prevOpen, setPrevOpen] = useState(open);
   if (open !== prevOpen) {
     setPrevOpen(open);
@@ -99,6 +103,7 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
       setFilterDraft(column.filterKeywords ?? "");
       setExcludeDraft(column.excludeKeywords ?? "");
       setTabGroupDraft(column.tabGroup ?? "");
+      setPinnedDraft(column.pinned === true);
     }
   }
 
@@ -154,6 +159,9 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
     const nextTabGroup = normalizeTabGroup(tabGroupDraft);
     if (nextTabGroup !== (column.tabGroup ?? "")) {
       updateTabGroup(column.id, nextTabGroup);
+    }
+    if (pinnedDraft !== (column.pinned === true)) {
+      updatePinned(column.id, pinnedDraft);
     }
     onOpenChange(false);
   }
@@ -324,6 +332,36 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
           </div>
 
           <Separator />
+
+          <div className="grid gap-1.5">
+            <Label
+              htmlFor="pin-to-front"
+              className="flex items-center gap-1.5"
+            >
+              <Pin className="size-3.5" />
+              Pin to front
+              <span className="text-[11px] font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </Label>
+            <label
+              htmlFor="pin-to-front"
+              className="flex cursor-pointer items-start gap-2 rounded-md border border-border bg-surface/40 px-3 py-2 hover:bg-surface"
+            >
+              <input
+                id="pin-to-front"
+                type="checkbox"
+                checked={pinnedDraft}
+                onChange={(e) => setPinnedDraft(e.target.checked)}
+                className="mt-0.5 size-4 cursor-pointer accent-[color:var(--brand)]"
+              />
+              <span className="text-xs text-muted-foreground">
+                Pinned columns render before every other column in the deck and
+                stay visible regardless of the active tab. DnD reorder still
+                works within the pinned and unpinned groups.
+              </span>
+            </label>
+          </div>
 
           <div className="grid gap-1.5">
             <Label htmlFor="tab-group" className="flex items-center gap-1.5">

--- a/components/deck/deck-board.tsx
+++ b/components/deck/deck-board.tsx
@@ -75,10 +75,12 @@ export function DeckBoard({ deckId }: { deckId: string }) {
         ? deck.columnIds
         : deck.columnIds.filter((id) => {
             const col = columns[id];
+            // Pinned columns stay visible on every tab — that's the point of
+            // pinning, and the Configure copy + header tooltip promise it.
             // Untagged columns ride along with every named tab too — otherwise
             // an operator who partially groups a deck loses their unlabeled
             // columns every time they click a tab, which reads as broken.
-            return !col || !col.tabGroup || col.tabGroup === selectedTab;
+            return col?.pinned || !col || !col.tabGroup || col.tabGroup === selectedTab;
           });
     // Pinned columns render before every unpinned column regardless of the
     // stored position. Array.prototype.sort is stable, so the relative order

--- a/components/deck/deck-board.tsx
+++ b/components/deck/deck-board.tsx
@@ -70,14 +70,29 @@ export function DeckBoard({ deckId }: { deckId: string }) {
 
   const visibleColumnIds = useMemo(() => {
     if (!deck) return [];
-    if (selectedTab === TAB_GROUP_ALL) return deck.columnIds;
-    return deck.columnIds.filter((id) => {
-      const col = columns[id];
-      // Untagged columns ride along with every named tab too — otherwise an
-      // operator who partially groups a deck loses their unlabeled columns
-      // every time they click a tab, which reads as the feature being broken.
-      return !col || !col.tabGroup || col.tabGroup === selectedTab;
-    });
+    const tabFiltered =
+      selectedTab === TAB_GROUP_ALL
+        ? deck.columnIds
+        : deck.columnIds.filter((id) => {
+            const col = columns[id];
+            // Untagged columns ride along with every named tab too — otherwise
+            // an operator who partially groups a deck loses their unlabeled
+            // columns every time they click a tab, which reads as broken.
+            return !col || !col.tabGroup || col.tabGroup === selectedTab;
+          });
+    // Pinned columns render before every unpinned column regardless of the
+    // stored position. Array.prototype.sort is stable, so the relative order
+    // within the pinned group (and within the unpinned group) is preserved —
+    // DnD reorder still works inside each group. This pass mutates a copy, so
+    // the underlying deck.columnIds order (used by reorderColumnsInDeck and
+    // the SortableContext below) is unchanged.
+    const pinned: string[] = [];
+    const unpinned: string[] = [];
+    for (const id of tabFiltered) {
+      if (columns[id]?.pinned) pinned.push(id);
+      else unpinned.push(id);
+    }
+    return pinned.length === 0 ? tabFiltered : [...pinned, ...unpinned];
   }, [deck, columns, selectedTab]);
 
   const scrollerRef = useRef<HTMLDivElement>(null);
@@ -109,6 +124,15 @@ export function DeckBoard({ deckId }: { deckId: string }) {
     if (!deck) return;
     const { active, over } = ev;
     if (!over || active.id === over.id) return;
+    // Drag is restricted to within the same pin group: pinned-among-pinned or
+    // unpinned-among-unpinned. Dragging across the boundary would either need
+    // to flip the pinned flag (surprising — the operator wanted to move, not
+    // pin) or silently land the column in an unexpected slot once the visual
+    // order is re-sorted in `visibleColumnIds`. The Pin-to-front checkbox in
+    // Configure is the explicit affordance for crossing the boundary.
+    const activePinned = columns[String(active.id)]?.pinned === true;
+    const overPinned = columns[String(over.id)]?.pinned === true;
+    if (activePinned !== overPinned) return;
     const oldIndex = deck.columnIds.indexOf(String(active.id));
     const newIndex = deck.columnIds.indexOf(String(over.id));
     if (oldIndex < 0 || newIndex < 0) return;

--- a/drizzle/0007_column_pinned.sql
+++ b/drizzle/0007_column_pinned.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "columns" ADD COLUMN "pinned" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,359 @@
+{
+  "id": "9a6f2d80-bc0e-6061-2f5d-7e30aceb0007",
+  "prevId": "8f5e1c7f-ab9d-5f50-1e4c-6d2f9b5c0006",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.columns": {
+      "name": "columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "alert_keywords": {
+          "name": "alert_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_interval_seconds": {
+          "name": "refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notify_webhook_url": {
+          "name": "notify_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter_keywords": {
+          "name": "filter_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_keywords": {
+          "name": "exclude_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tab_group": {
+          "name": "tab_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "columns_deck_id_decks_id_fk": {
+          "name": "columns_deck_id_decks_id_fk",
+          "tableFrom": "columns",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deck_snapshots": {
+      "name": "deck_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deck_snapshots_deck_captured_idx": {
+          "name": "deck_snapshots_deck_captured_idx",
+          "columns": [
+            {
+              "expression": "deck_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deck_snapshots_deck_id_decks_id_fk": {
+          "name": "deck_snapshots_deck_id_decks_id_fk",
+          "tableFrom": "deck_snapshots",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decks": {
+      "name": "decks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_column_created_idx": {
+          "name": "feed_items_column_created_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_column_id_columns_id_fk": {
+          "name": "feed_items_column_id_columns_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feed_items_column_id_id_pk": {
+          "name": "feed_items_column_id_id_pk",
+          "columns": [
+            "column_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1779926400000,
       "tag": "0006_tab_groups",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1780012800000,
+      "tag": "0007_column_pinned",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/columns/types.ts
+++ b/lib/columns/types.ts
@@ -189,6 +189,15 @@ export interface Column {
    * share links (not a secret).
    */
   tabGroup?: string;
+  /**
+   * Optional pin flag. When true, the column is rendered before every unpinned
+   * column in the deck regardless of its stored `position`. Pinned order among
+   * themselves follows the same `position` ordering, so a deck with two pinned
+   * columns keeps them in their relative DnD-reorder order. Round-trips through
+   * export / import / share links (not a secret); a starter template can ship
+   * with priority columns already pinned.
+   */
+  pinned?: boolean;
   items: FeedItem[];
   lastFetchedAt?: string;
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -5,6 +5,7 @@ import {
   serial,
   timestamp,
   jsonb,
+  boolean,
   primaryKey,
   index,
 } from "drizzle-orm/pg-core";
@@ -30,6 +31,7 @@ export const columns = pgTable("columns", {
   filterKeywords: text("filter_keywords"),
   excludeKeywords: text("exclude_keywords"),
   tabGroup: text("tab_group"),
+  pinned: boolean("pinned").notNull().default(false),
   position: integer("position").notNull().default(0),
   lastFetchedAt: timestamp("last_fetched_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),

--- a/lib/deck-templates.ts
+++ b/lib/deck-templates.ts
@@ -42,6 +42,11 @@ export interface DeckTemplateColumn {
   // instead of forcing the operator to label each column by hand. Round-trips
   // through importDeck — same TAB_GROUP_MAX cap, same whitespace normalization.
   tabGroup?: string;
+  // Optional pin flag. Let a starter template ship with a priority column (e.g.
+  // the project's main GitHub repo, or a token price column) already pinned to
+  // the front of the deck so it stays visible regardless of active tab and DnD
+  // reorder. Round-trips through importDeck.
+  pinned?: boolean;
 }
 
 export interface DeckTemplatePayload {

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -24,6 +24,7 @@ import {
   updateColumnRefreshInterval as serverUpdateRefreshInterval,
   updateColumnFilters as serverUpdateFilters,
   updateColumnTabGroup as serverUpdateTabGroup,
+  updateColumnPinned as serverUpdatePinned,
   loadDeckSnapshots as serverLoadDeckSnapshots,
   restoreDeckSnapshot as serverRestoreDeckSnapshot,
   isAllowedRefreshInterval,
@@ -100,6 +101,7 @@ interface DeckState {
     excludeKeywords: string,
   ) => void;
   updateTabGroup: (columnId: string, tabGroup: string) => void;
+  updatePinned: (columnId: string, pinned: boolean) => void;
   renameColumn: (columnId: string, title: string) => void;
   removeColumn: (columnId: string) => void;
   reorderColumnsInDeck: (deckId: string, order: string[]) => void;
@@ -138,6 +140,7 @@ function importedDeckPatch(
       filterKeywords: c.filterKeywords,
       excludeKeywords: c.excludeKeywords,
       tabGroup: c.tabGroup,
+      pinned: c.pinned,
       items: [],
     };
   }
@@ -404,6 +407,26 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
       };
     });
     fireAndLog("updateColumnTabGroup", serverUpdateTabGroup(columnId, next));
+  },
+
+  updatePinned: (columnId, pinned) => {
+    // Plain boolean — coerce to true/false so the optimistic state can't carry
+    // a truthy non-boolean and silently differ from the server cast.
+    const next = pinned === true;
+    set((s) => {
+      const col = s.columns[columnId];
+      if (!col) return s;
+      return {
+        columns: {
+          ...s.columns,
+          [columnId]: {
+            ...col,
+            pinned: next ? true : undefined,
+          },
+        },
+      };
+    });
+    fireAndLog("updateColumnPinned", serverUpdatePinned(columnId, next));
   },
 
   renameColumn: (columnId, title) => {


### PR DESCRIPTION
## What
Adds an optional `pinned` boolean to every column. When set:

- The column renders before every unpinned column in the deck, regardless of its DnD-saved position.
- Pinning survives across page reloads, tab switches, and column reorders — it's persistent column config (DB-backed), not a view-state toggle.
- Pinned status is independent of the active tab group: a pinned column stays visible on every tab.
- Within the pinned group (and within the unpinned group), DnD reorder still works.

UI:
- New **Pin to front** checkbox in the Configure dialog with explanatory copy.
- New Pin icon badge in the expanded column header.
- Brand-coloured Pin icon in the collapsed-strip indicator stack so a pinned column quietly accumulating matches isn't visually demoted when folded.

## Why
Operators running 10–15 column decks frequently have 2–3 "always visible" priority columns (their main token, primary GitHub repo, primary news feed) that they need at the left edge regardless of topic. The existing DnD reorder fixes position only for that session — a page reload restores the DB-saved order. Pinning makes priority columns sticky.

Pairs with **tab groups** (PR #53) and **column collapse** (PR #55) on the deck-density axis:

| Layer | Question |
|-------|----------|
| tabs | which columns am I looking at |
| **pin** | **which always stay visible regardless of active tab** |
| collapse | how prominent within the visible set |

## Changes — 11 files, +528/-9

**DB schema**
- `drizzle/0007_column_pinned.sql`: additive `pinned` boolean column on `columns` (DEFAULT false NOT NULL — existing rows backfill safely; no nullable churn).
- `drizzle/meta/_journal.json`: new entry idx 7.
- `drizzle/meta/0007_snapshot.json`: snapshot for the migration.
- `lib/db/schema.ts`: `boolean` import + `pinned` field.

**Types**
- `lib/columns/types.ts`: `Column.pinned?: boolean` with inline doc explaining the sort-order interaction.
- `lib/deck-templates.ts`: `DeckTemplateColumn.pinned?: boolean` so a starter template can ship with priority columns already pinned.

**Server actions**
- `app/actions.ts`: new `updateColumnPinned(id, pinned)` server action. `loadSnapshot` mapping reads the field. Zod `importedColumnSchema` accepts `pinned: z.boolean().optional()` and `importDeck` coerces to a hard `=== true` before persisting so a hand-edited payload can't smuggle a truthy non-boolean past the DB cast. `exportDeck` emits the field for pinned columns only (omitted when false to keep the payload tight — same pattern as `tabGroup`/`alertKeywords`).

**Store**
- `lib/store/use-deck-store.ts`: `updatePinned(columnId, pinned)` action mirroring the server normalization; new field round-trips through `importedDeckPatch` for import + restore-from-snapshot.

**UI**
- `components/column/configure-column-dialog.tsx`: new Pin to front checkbox in a labeled card under the Tab group section. Save flow only persists when the value changed.
- `components/deck/deck-board.tsx`: `visibleColumnIds` now sorts `pinned` first via a stable two-pass partition (preserves DnD order within each group). DnD across the pin/unpin boundary is intentionally a no-op — the Pin checkbox in Configure is the explicit affordance for crossing the boundary; auto-flipping the pinned flag on a drag would be surprising.
- `components/column/column-card.tsx`: Pin badge in the expanded header (brand colour, between the refresh-interval badge and the Search icon) + a small Pin icon in the collapsed-strip indicator stack so a pinned column folded mid-session keeps its visual marker.

## Key design decisions

1. **Pinned is DB-backed, not view-state.** Unlike `collapsedColumnIds` / `searchByColumn` / `selectedTabByDeck` (which clear on reload), pin survives reloads — it's a persistence choice about *which columns are primary*. View-state would re-create the problem the feature exists to solve.
2. **Stable two-pass partition, not a single sort.** `Array.prototype.sort` would also work, but a two-pass partition is more obviously O(n) and reads exactly as intended ("pinned first, then everything else, both in their existing relative order").
3. **DnD across pin/unpin is a no-op.** A drag-to-flip would be either too eager (every drag re-pins) or confusingly silent (the column lands in an unexpected slot once the visual order re-sorts). The Pin checkbox is the explicit toggle.
4. **Pinning is independent of tab group.** A pinned column in tab group "DeFi" still appears on every tab — pinning trumps grouping, which matches operator intent ("pin = always visible").
5. **Snapshot round-trip preserved.** `captureDeckSnapshot` routes through `exportDeck`; restore routes through `importDeck`. Both ends emit and accept the field, so version history survives the change.

## Test plan
- [ ] Cold DB + new column → migration applies; column starts unpinned.
- [ ] Toggle Pin to front in Configure → column jumps to the front of the deck; reload → still at front.
- [ ] Pin two columns A and B (A pinned first), DnD swap them → relative order swaps within the pinned group; unpinned columns unaffected.
- [ ] Pin a column, tab-group it as "DeFi", switch to "Social" tab → column still visible at front of Social tab.
- [ ] Drag a pinned column over an unpinned column → no-op (the visual position is unchanged).
- [ ] Export deck → JSON contains `"pinned": true` only for pinned columns; import → pinning round-trips.
- [ ] Share link with a pinned column → recipient sees the pin on first import.
- [ ] Restore a deck snapshot captured before pinning the column → restored deck honors the pre-pin state.

## Repo-actions context
2026-06-02 idea #4. Sandbox can't run Next 16 build/typecheck (established constraint from PRs #49/#50/#51/#52/#53/#55/#56/#58) — manual review only.

---
*Built autonomously by Aeon.*