### PR TITLE
feat(columns): per-column duplicate — clone a column with all its settings

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -329,6 +329,83 @@ export async function renameColumn(id: string, title: string): Promise<void> {
   await db.update(columns).set({ title }).where(eq(columns.id, id));
 }
 
+/**
+ * Duplicate an existing column inside the same deck. The duplicate inherits
+ * every persisted setting that round-trips through a deck export
+ * (typeId, config, alertKeywords, refreshIntervalSeconds, filterKeywords,
+ * excludeKeywords, tabGroup) AND the install-private notifyWebhookUrl — this
+ * is a same-install copy, not an export, so the secret stays inside the
+ * trust boundary it was originally configured within. The caller controls
+ * the new title (the client passes a sensible default like "Original (copy)").
+ *
+ * `pinned` is deliberately NOT inherited — pinning is the operator's
+ * explicit "this is a primary column" decision. Mirrors the deck-board's
+ * "DnD across pin/unpin no-op" rule from PR #59: crossing the pin boundary
+ * always requires an explicit action.
+ *
+ * The duplicate is inserted at `source.position + 1` so it lands
+ * immediately next to its source — every later column shifts right by one.
+ * Inserting at the end of the deck would force the operator to drag the
+ * copy back over the rest of a long deck to find it, which is the
+ * opposite of what a duplicate action is for.
+ */
+export async function duplicateColumn(
+  sourceId: string,
+  newId: string,
+  newTitle: string,
+): Promise<ImportedDeckColumn | null> {
+  const [src] = await db.select().from(columns).where(eq(columns.id, sourceId));
+  if (!src) return null;
+
+  // Snapshot the pre-duplicate deck state so the structural mutation is
+  // reversible from version history — same pattern as createColumn /
+  // deleteColumn / reorderColumnsInDeck.
+  await captureDeckSnapshot(src.deckId);
+
+  // Shift every column after the source right by 1 to make room for the
+  // duplicate at source.position + 1.
+  await db
+    .update(columns)
+    .set({ position: sql`${columns.position} + 1` })
+    .where(
+      and(
+        eq(columns.deckId, src.deckId),
+        sql`${columns.position} > ${src.position}`,
+      ),
+    );
+
+  const title = newTitle.trim().slice(0, 256) || src.title.slice(0, 256);
+  await db.insert(columns).values({
+    id: newId,
+    deckId: src.deckId,
+    typeId: src.typeId,
+    title,
+    config: src.config,
+    alertKeywords: src.alertKeywords,
+    notifyWebhookUrl: src.notifyWebhookUrl,
+    refreshIntervalSeconds: src.refreshIntervalSeconds,
+    filterKeywords: src.filterKeywords,
+    excludeKeywords: src.excludeKeywords,
+    tabGroup: src.tabGroup,
+    pinned: false,
+    position: src.position + 1,
+  });
+
+  return {
+    id: newId,
+    typeId: src.typeId,
+    title,
+    config: (src.config as Record<string, unknown>) ?? {},
+    alertKeywords: src.alertKeywords ?? undefined,
+    notifyWebhookUrl: src.notifyWebhookUrl ?? undefined,
+    refreshIntervalSeconds: src.refreshIntervalSeconds ?? undefined,
+    filterKeywords: src.filterKeywords ?? undefined,
+    excludeKeywords: src.excludeKeywords ?? undefined,
+    tabGroup: src.tabGroup ?? undefined,
+    pinned: false,
+  };
+}
+
 export async function deleteColumn(id: string): Promise<void> {
   // Snapshot the deck (still holding this column) before the delete, so an
   // accidental removal can be recovered from version history.

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -362,33 +362,39 @@ export async function duplicateColumn(
   // deleteColumn / reorderColumnsInDeck.
   await captureDeckSnapshot(src.deckId);
 
-  // Shift every column after the source right by 1 to make room for the
-  // duplicate at source.position + 1.
-  await db
-    .update(columns)
-    .set({ position: sql`${columns.position} + 1` })
-    .where(
-      and(
-        eq(columns.deckId, src.deckId),
-        sql`${columns.position} > ${src.position}`,
-      ),
-    );
-
   const title = newTitle.trim().slice(0, 256) || src.title.slice(0, 256);
-  await db.insert(columns).values({
-    id: newId,
-    deckId: src.deckId,
-    typeId: src.typeId,
-    title,
-    config: src.config,
-    alertKeywords: src.alertKeywords,
-    notifyWebhookUrl: src.notifyWebhookUrl,
-    refreshIntervalSeconds: src.refreshIntervalSeconds,
-    filterKeywords: src.filterKeywords,
-    excludeKeywords: src.excludeKeywords,
-    tabGroup: src.tabGroup,
-    pinned: false,
-    position: src.position + 1,
+
+  // Shift-then-insert must be atomic: a crash between the two writes would
+  // leave every later column shifted right with no duplicate filling the gap.
+  // Wrap both in a transaction, mirroring importDeck.
+  await db.transaction(async (tx) => {
+    // Shift every column after the source right by 1 to make room for the
+    // duplicate at source.position + 1.
+    await tx
+      .update(columns)
+      .set({ position: sql`${columns.position} + 1` })
+      .where(
+        and(
+          eq(columns.deckId, src.deckId),
+          sql`${columns.position} > ${src.position}`,
+        ),
+      );
+
+    await tx.insert(columns).values({
+      id: newId,
+      deckId: src.deckId,
+      typeId: src.typeId,
+      title,
+      config: src.config,
+      alertKeywords: src.alertKeywords,
+      notifyWebhookUrl: src.notifyWebhookUrl,
+      refreshIntervalSeconds: src.refreshIntervalSeconds,
+      filterKeywords: src.filterKeywords,
+      excludeKeywords: src.excludeKeywords,
+      tabGroup: src.tabGroup,
+      pinned: false,
+      position: src.position + 1,
+    });
   });
 
   return {

--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -9,6 +9,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Clock,
+  Copy,
   Download,
   Filter,
   GripVertical,
@@ -57,6 +58,7 @@ export function ColumnCard({ column }: { column: Column }) {
   const applyFetchedItems = useDeckStore((s) => s.applyFetchedItems);
   const renameColumn = useDeckStore((s) => s.renameColumn);
   const downloadColumnItems = useDeckStore((s) => s.downloadColumnItems);
+  const duplicateColumn = useDeckStore((s) => s.duplicateColumn);
   const hasItems = column.items.length > 0;
   const isAutoFetchingRaw = useDeckStore((s) => s.autoFetchingIds.has(column.id));
   const isCollapsed = useDeckStore((s) => s.collapsedColumnIds.has(column.id));
@@ -586,6 +588,18 @@ export function ColumnCard({ column }: { column: Column }) {
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setRenameOpen(true)}>
                 <Pencil className="mr-2 size-4" /> Rename
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => {
+                  const result = duplicateColumn(column.id);
+                  if (result) {
+                    toast.success("Column duplicated", {
+                      description: `${column.title} (copy)`,
+                    });
+                  }
+                }}
+              >
+                <Copy className="mr-2 size-4" /> Duplicate
               </DropdownMenuItem>
               <DropdownMenuItem
                 disabled={!hasItems}

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -11,6 +11,7 @@ import {
   createDeck as serverCreateDeck,
   deleteColumn as serverDeleteColumn,
   deleteDeck as serverDeleteDeck,
+  duplicateColumn as serverDuplicateColumn,
   exportDeck as serverExportDeck,
   importDeck as serverImportDeck,
   persistFetchedItems as serverPersistItems,
@@ -88,6 +89,7 @@ interface DeckState {
     title: string,
     config: Record<string, unknown>,
   ) => { id: string; ready: Promise<void> };
+  duplicateColumn: (columnId: string) => { id: string; ready: Promise<void> } | null;
   updateColumnConfig: (columnId: string, config: Record<string, unknown>) => void;
   updateAlertKeywords: (columnId: string, alertKeywords: string) => void;
   updateWebhookUrl: (columnId: string, webhookUrl: string) => void;
@@ -288,6 +290,73 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
     });
     const ready = serverCreateColumn(id, deckId, typeId, title, config);
     fireAndLog("createColumn", ready);
+    return { id, ready: ready.then(() => undefined) };
+  },
+
+  duplicateColumn: (columnId) => {
+    const state = get();
+    const source = state.columns[columnId];
+    if (!source) return null;
+    // Locate the deck the source lives in so the optimistic insert lands in
+    // the right deck's columnIds. `columns[]` is a flat map across decks, so
+    // we read it off the decks index rather than carrying it on the column.
+    let deckId: string | null = null;
+    for (const [did, deck] of Object.entries(state.decks)) {
+      if (deck.columnIds.includes(columnId)) {
+        deckId = did;
+        break;
+      }
+    }
+    if (!deckId) return null;
+
+    const id = nanoid();
+    // The title strategy is "<source> (copy)" — same convention as duplicated
+    // files in finders and "Untitled copy" in most cloud doc apps. Capped to
+    // 256 chars to match the server-side `title.slice(0, 256)`.
+    const title = `${source.title} (copy)`.slice(0, 256);
+
+    set((s) => {
+      const deck = s.decks[deckId!];
+      if (!deck) return s;
+      const insertAt = deck.columnIds.indexOf(columnId);
+      const nextColumnIds =
+        insertAt < 0
+          ? [...deck.columnIds, id]
+          : [
+              ...deck.columnIds.slice(0, insertAt + 1),
+              id,
+              ...deck.columnIds.slice(insertAt + 1),
+            ];
+      return {
+        columns: {
+          ...s.columns,
+          [id]: {
+            id,
+            typeId: source.typeId,
+            title,
+            config: source.config,
+            alertKeywords: source.alertKeywords,
+            notifyWebhookUrl: source.notifyWebhookUrl,
+            refreshIntervalSeconds: source.refreshIntervalSeconds,
+            filterKeywords: source.filterKeywords,
+            excludeKeywords: source.excludeKeywords,
+            tabGroup: source.tabGroup,
+            // Pinning is the operator's explicit "primary column" decision —
+            // duplicates land unpinned regardless of source state, mirroring
+            // PR #59's "DnD across pin/unpin no-op" rule.
+            pinned: undefined,
+            items: [],
+          },
+        },
+        decks: {
+          ...s.decks,
+          [deckId!]: { ...deck, columnIds: nextColumnIds },
+        },
+      };
+    });
+
+    const ready = serverDuplicateColumn(columnId, id, title);
+    fireAndLog("duplicateColumn", ready);
     return { id, ready: ready.then(() => undefined) };
   },
 

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -334,7 +334,9 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
             id,
             typeId: source.typeId,
             title,
-            config: source.config,
+            // Shallow-copy so the clone never shares the source's config object
+            // reference (a future in-place config edit must not mutate both).
+            config: { ...source.config },
             alertKeywords: source.alertKeywords,
             notifyWebhookUrl: source.notifyWebhookUrl,
             refreshIntervalSeconds: source.refreshIntervalSeconds,


### PR DESCRIPTION
## What

Adds a **Duplicate** entry to every column's More-menu dropdown. Click → the source column's persisted settings (typeId, config, alertKeywords, notifyWebhookUrl, refreshIntervalSeconds, filterKeywords, excludeKeywords, tabGroup) clone into a new column titled `"<source> (copy)"` inserted **immediately after the source** in the same deck.

## Why

6th rung on the per-column UX axis the deck has been building:

| Date | PR | Feature | What it answers |
|------|----|---------|------------------|
| May-29 | #53 | Tab groups | "which group am I looking at" |
| May-30 | #55 | Collapse | "how prominent within the group" |
| May-31 | #56 | JSON export | "get the data out" |
| Jun-02 | #58 | Quick-search | "find an item in this column" |
| Jun-03 | #59 | Pin-to-front | "always visible regardless of tab" |
| **Jun-04** | **this PR** | **Duplicate** | **"fork this column to view it twice"** |

The common operator move: two CoinGecko columns for BTC and ETH, two GitHub repo columns for two different repos, two RSS columns with different include filters. Before this PR the operator had to add a brand-new column and re-enter every config field. After: 1 click, optionally tweak in Configure, done.

## Changes

| File | +/- | Role |
|------|-----|------|
| `app/actions.ts` | +77 | New `duplicateColumn` server action |
| `lib/store/use-deck-store.ts` | +69 | New `duplicateColumn` zustand action |
| `components/column/column-card.tsx` | +14 | "Duplicate" entry in More dropdown |

**No DB schema change.** No migration. Reuses the existing `columns` table — a duplicated column is just a new row, exported and imported identically to any other.

## Implementation details

**Server (`app/actions.ts`)** — new `duplicateColumn(sourceId, newId, newTitle)`:

1. `captureDeckSnapshot` before the structural mutation — same reversibility contract as createColumn / deleteColumn / reorderColumnsInDeck. An accidental duplicate is recoverable from version history.
2. Shifts every column with `position > src.position` right by 1 so the duplicate can land at `src.position + 1` without renumbering the whole deck.
3. Inserts the new row inheriting every persisted setting. Returns `ImportedDeckColumn | null` — the shape `importDeck` already emits.

**Store (`lib/store/use-deck-store.ts`)** — new `duplicateColumn`:

- Reads source from state, locates owning deck by scanning `decks[*].columnIds`.
- Generates new id via nanoid; title `"<source> (copy)"` capped at 256 chars (matches server cap).
- Optimistic state: inserts new id right after source in `decks[deckId].columnIds[]` so visual order matches where it lands server-side.
- Fires server action via same `fireAndLog` pattern as every other mutation. Returns `{ id, ready } | null`.

**UI (`components/column/column-card.tsx`)** — "Duplicate" item between Rename and Download. Uses lucide-react `Copy` icon. Toast on success names the new column.

## Decisions

1. **Insert after source, not at end.** Inserting at the end of a 15-column deck forces the operator to drag-scroll to find their copy — opposite of what a duplicate action is for. Position-shift is one extra UPDATE; the UX cost of "where did my copy go" dwarfs the SQL cost.

2. **Inherit `notifyWebhookUrl`, drop `pinned`.** Pinning is a deliberate "this is a primary column" decision; mirroring PR #59's "DnD across pin/unpin no-op — Pin checkbox is the explicit boundary affordance" rule, crossing the pinned boundary always requires explicit operator action. `notifyWebhookUrl` is install-private and we're staying inside the same install — duplicate is not an export, the secret never leaves the trust boundary.

3. **Title `"(copy)"` postfix, not `"Copy of X"` prefix.** Same as finders + most cloud doc apps — postfix reads better mid-deck because the column header shows the original title first and the disambiguator second. Rename via existing Rename action.

## Round-trip safety

- `exportDeck` already emits every field this PR inherits → import recreates the duplicate identically.
- `loadSnapshot` reads `columns` ordered by `position ASC, createdAt ASC` → on reload, the duplicate appears right after source (its `position = src.position + 1` is preserved).
- `captureDeckSnapshot` + version history catches the structural mutation before it lands.
- DnD reorder still works inside each pinned/unpinned group — same boundary rules from PR #59 unchanged.

## Testing

Could NOT run Next 16 build/typecheck (offline sandbox — same constraint as PRs #49/#50/#51/#52/#53/#55/#56/#58/#59). Manual review against the existing column-card / use-deck-store / actions patterns only.

---
*Built autonomously by Aeon.*