### PR TITLE
feat: per-deck color labels

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -78,7 +78,12 @@ export async function loadSnapshot(): Promise<Snapshot> {
   const decksById: Record<string, Deck> = {};
   const deckOrder: string[] = [];
   for (const d of deckRows) {
-    decksById[d.id] = { id: d.id, name: d.name, columnIds: [] };
+    decksById[d.id] = {
+      id: d.id,
+      name: d.name,
+      columnIds: [],
+      color: d.color ?? undefined,
+    };
     deckOrder.push(d.id);
   }
 
@@ -132,6 +137,24 @@ export async function createDeck(id: string, name: string): Promise<void> {
 
 export async function renameDeck(id: string, name: string): Promise<void> {
   await db.update(decks).set({ name }).where(eq(decks.id, id));
+}
+
+/**
+ * Persist a deck's color label. Pass an empty string or an invalid hex to
+ * clear (the normalizer treats both the same way — the UI validates before
+ * calling). Validation is server-authoritative so a hand-edited payload
+ * can never bypass the hex check. Mirrors `updateColumnColor` exactly —
+ * the deck-level analog of the column color labels from PR #61.
+ */
+export async function updateDeckColor(
+  id: string,
+  color: string,
+): Promise<void> {
+  // Same hex shape as columns — reuse the canonical column normalizer so
+  // the two label surfaces (deck-level + per-column) can never drift on
+  // case-folding or shorthand acceptance.
+  const normalized = normalizeColumnColor(color);
+  await db.update(decks).set({ color: normalized }).where(eq(decks.id, id));
 }
 
 export async function deleteDeck(id: string): Promise<void> {
@@ -535,6 +558,12 @@ const importedColumnSchema = z.object({
 const importedDeckSchema = z.object({
   version: z.literal(DECK_EXPORT_VERSION),
   deckName: z.string().min(1).max(128),
+  // Optional deck-level color label (6-char hex `#rrggbb`). Additive to v1 —
+  // exports created before deck color labels existed simply omit this field
+  // and import as a deck with `color = null`. Same drop-not-fail contract
+  // as column color: a malformed value is dropped to null in importDeck via
+  // `normalizeColumnColor`, never aborts the entire deck import.
+  deckColor: z.string().max(64).optional(),
   exportedAt: z.string().optional(),
   columns: z.array(importedColumnSchema).max(64),
 });
@@ -577,6 +606,7 @@ export async function exportDeck(deckId: string): Promise<string> {
   const payload: DeckExport = {
     version: DECK_EXPORT_VERSION,
     deckName: deck.name,
+    ...(deck.color ? { deckColor: deck.color } : {}),
     exportedAt: new Date().toISOString(),
     columns: cols.map((c) => ({
       typeId: c.typeId,
@@ -614,6 +644,14 @@ export interface ImportedDeckColumn {
 export interface ImportedDeckResult {
   deckId: string;
   deckName: string;
+  /**
+   * Color label applied to the freshly created deck during import — present
+   * when the export payload included a valid `deckColor`, absent otherwise.
+   * The store reads this to seed the optimistic deck-row insert so the
+   * sidebar dot renders the imported deck's color immediately, without
+   * waiting for the next loadSnapshot round-trip.
+   */
+  deckColor?: string;
   columns: ImportedDeckColumn[];
 }
 
@@ -646,16 +684,26 @@ export async function importDeck(
   const deckId = nanoid();
   const deckName = `${data.deckName} (${nameSuffix})`;
   const created: ImportedDeckColumn[] = [];
+  // Hoisted out of the transaction so the post-tx return shape can carry it
+  // back to the client store without an extra round-trip.
+  let deckColorPersisted: string | null = null;
 
   await db.transaction(async (tx) => {
     const [{ maxDeckPos }] = await tx
       .select({ maxDeckPos: sql<number>`coalesce(max(${decks.position}), -1)` })
       .from(decks);
 
+    // Re-validate any imported deck color through the same hex normalizer the
+    // server action uses for direct writes — drops non-`#rrggbb` strings to
+    // null rather than aborting the entire import (same drop-not-fail contract
+    // as the column-level color field).
+    deckColorPersisted = normalizeColumnColor(data.deckColor ?? null);
+
     await tx.insert(decks).values({
       id: deckId,
       name: deckName,
       position: maxDeckPos + 1,
+      color: deckColorPersisted,
     });
 
     for (let i = 0; i < data.columns.length; i++) {
@@ -738,7 +786,12 @@ export async function importDeck(
   // which route through this same path). Fire-and-forget — never fails import.
   await captureDeckSnapshot(deckId);
 
-  return { deckId, deckName, columns: created };
+  return {
+    deckId,
+    deckName,
+    ...(deckColorPersisted ? { deckColor: deckColorPersisted } : {}),
+    columns: created,
+  };
 }
 
 const DECK_SNAPSHOT_CAP = 5;

--- a/components/deck/deck-view.tsx
+++ b/components/deck/deck-view.tsx
@@ -129,6 +129,14 @@ export function DeckView() {
           <SidebarTrigger className="size-8 shrink-0" />
           <div className="h-5 w-px shrink-0 bg-border" />
           <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3.5">
+            {activeDeck?.color ? (
+              <span
+                aria-hidden
+                title={`Deck color: ${activeDeck.color}`}
+                className="inline-block size-2.5 shrink-0 rounded-full ring-1 ring-black/10"
+                style={{ backgroundColor: activeDeck.color }}
+              />
+            ) : null}
             <span
               className="pb-1 font-serif text-[18px] leading-[1.2] italic text-foreground sm:text-[20px]"
               style={{ letterSpacing: "-0.01em" }}

--- a/components/dialogs/deck-color-dialog.tsx
+++ b/components/dialogs/deck-color-dialog.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState } from "react";
+import { Palette } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+// Same 6-hex rule the server enforces (`COLOR_HEX_RE` in app/actions.ts).
+// Matched client-side so the Save button can light up only when the input
+// is in canonical form — the server is still authoritative.
+const COLOR_HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+function normalizeHexColor(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (!COLOR_HEX_RE.test(trimmed)) return null;
+  return trimmed.toLowerCase();
+}
+
+// Same eight presets as the column-color picker (configure-column-dialog.tsx)
+// — keeps the two color surfaces visually coherent so an operator marking a
+// "DeFi" deck orange picks the same orange they'd use to color a DeFi column.
+const COLOR_SWATCHES: { value: string; label: string }[] = [
+  { value: "#f97316", label: "Orange" },
+  { value: "#22c55e", label: "Green" },
+  { value: "#3b82f6", label: "Blue" },
+  { value: "#a855f7", label: "Purple" },
+  { value: "#ec4899", label: "Pink" },
+  { value: "#eab308", label: "Yellow" },
+  { value: "#06b6d4", label: "Cyan" },
+  { value: "#94a3b8", label: "Slate" },
+];
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  deckName: string;
+  initialColor: string | undefined;
+  onSubmit: (color: string) => void;
+}
+
+export function DeckColorDialog({
+  open,
+  onOpenChange,
+  deckName,
+  initialColor,
+  onSubmit,
+}: Props) {
+  const [draft, setDraft] = useState<string>(initialColor ?? "");
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) setDraft(initialColor ?? "");
+  }
+
+  const previewColor =
+    draft.trim().length === 0 ? "" : (normalizeHexColor(draft) ?? draft);
+  const colorInputInvalid =
+    draft.trim().length > 0 && normalizeHexColor(draft) === null;
+  const initialNormalized = normalizeHexColor(initialColor ?? "") ?? "";
+  const draftNormalized = normalizeHexColor(draft) ?? "";
+  // Save lights up either when the operator picks a different valid color, or
+  // when they explicitly clear (initial had a color, draft is now empty).
+  const cleared = draft.trim().length === 0 && initialNormalized.length > 0;
+  const changedToValid =
+    draftNormalized.length > 0 && draftNormalized !== initialNormalized;
+  const canSave = cleared || changedToValid;
+
+  function commit() {
+    if (!canSave) return;
+    // Empty string is the canonical "clear" payload — the server's
+    // `normalizeColumnColor` treats both empty and invalid as "clear".
+    onSubmit(cleared ? "" : draftNormalized);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            commit();
+          }}
+          className="contents"
+        >
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Palette className="size-4" />
+              Color {deckName}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="grid gap-1.5">
+            <Label htmlFor="deck-color" className="text-xs font-medium">
+              Deck color label
+              <span className="ml-1.5 text-[11px] font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </Label>
+            <div className="flex flex-wrap items-center gap-1.5">
+              {COLOR_SWATCHES.map((swatch) => {
+                const isSelected = previewColor === swatch.value;
+                return (
+                  <button
+                    key={swatch.value}
+                    type="button"
+                    aria-label={swatch.label}
+                    aria-pressed={isSelected}
+                    title={swatch.label}
+                    onClick={() => setDraft(swatch.value)}
+                    className={cn(
+                      "size-7 shrink-0 rounded-full ring-1 ring-black/10 transition-transform hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand)] focus-visible:ring-offset-2 focus-visible:ring-offset-card",
+                      isSelected
+                        && "ring-2 ring-[color:var(--brand)] ring-offset-2 ring-offset-card",
+                    )}
+                    style={{ backgroundColor: swatch.value }}
+                  />
+                );
+              })}
+              <button
+                type="button"
+                onClick={() => setDraft("")}
+                aria-pressed={previewColor === ""}
+                title="No color"
+                className={cn(
+                  "ml-1 inline-flex h-7 items-center justify-center rounded-full border border-border bg-surface/40 px-2.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand)] focus-visible:ring-offset-2 focus-visible:ring-offset-card",
+                  previewColor === ""
+                    && "ring-1 ring-[color:var(--brand)] text-foreground",
+                )}
+              >
+                Clear
+              </button>
+            </div>
+            <Input
+              id="deck-color"
+              placeholder="#f97316"
+              value={draft}
+              maxLength={7}
+              onChange={(e) => setDraft(e.target.value)}
+              aria-invalid={colorInputInvalid}
+              className={cn(
+                colorInputInvalid
+                  && "border-destructive focus-visible:ring-destructive",
+              )}
+            />
+            <p className="text-xs text-muted-foreground">
+              {colorInputInvalid ? (
+                <span className="text-destructive">
+                  Enter a 6-digit hex color (e.g. <code>#f97316</code>) or
+                  pick a preset above.
+                </span>
+              ) : (
+                <>
+                  Tag this deck with a color you can spot at a glance in the
+                  sidebar and top bar. Same palette as column color labels.
+                </>
+              )}
+            </p>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!canSave}>
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/sidebar-01/nav-decks.tsx
+++ b/components/sidebar-01/nav-decks.tsx
@@ -4,6 +4,7 @@ import {
   ChevronDown,
   History,
   MoreHorizontal,
+  Palette,
   Pencil,
   Plus,
   Trash2,
@@ -37,6 +38,7 @@ import { useDeckStore } from "@/lib/store/use-deck-store";
 import { RenameDialog } from "@/components/dialogs/rename-dialog";
 import { ConfirmDialog } from "@/components/dialogs/confirm-dialog";
 import { VersionHistoryDialog } from "@/components/dialogs/version-history-dialog";
+import { DeckColorDialog } from "@/components/dialogs/deck-color-dialog";
 import { AddColumnDialog } from "@/components/column/add-column-dialog";
 
 export function focusColumn(columnId: string) {
@@ -52,6 +54,7 @@ export function NavDecks() {
   const columns = useDeckStore((s) => s.columns);
   const setActiveDeck = useDeckStore((s) => s.setActiveDeck);
   const renameDeck = useDeckStore((s) => s.renameDeck);
+  const updateDeckColor = useDeckStore((s) => s.updateDeckColor);
   const deleteDeck = useDeckStore((s) => s.deleteDeck);
   const renameColumn = useDeckStore((s) => s.renameColumn);
   const removeColumn = useDeckStore((s) => s.removeColumn);
@@ -62,6 +65,7 @@ export function NavDecks() {
   const [deleteDeckId, setDeleteDeckId] = useState<string | null>(null);
   const [deleteColumnId, setDeleteColumnId] = useState<string | null>(null);
   const [historyDeckId, setHistoryDeckId] = useState<string | null>(null);
+  const [colorDeckId, setColorDeckId] = useState<string | null>(null);
 
   // Per-deck explicit open overrides. Decks not in this map fall back to
   // "open if active". Once the user toggles a deck, the override sticks.
@@ -95,11 +99,29 @@ export function NavDecks() {
                 )}
                 render={<CollapsibleTrigger />}
               >
+                {/*
+                  Deck identity dot. When the operator has tagged the deck
+                  with a color, the dot renders in that color regardless of
+                  the active-deck state (the tag is the operator's intent and
+                  shouldn't get swapped out for the brand color just because
+                  this is the currently active deck). Inactive untagged decks
+                  fade the dot to keep the active deck distinguishable; the
+                  active-untagged deck uses the brand color.
+                */}
                 <span
                   className={cn(
                     "inline-block size-1.5 rounded-full",
-                    isActive ? "bg-[color:var(--brand)]" : "bg-sidebar-foreground/30",
+                    !deck.color
+                      && (isActive ? "bg-[color:var(--brand)]" : "bg-sidebar-foreground/30"),
                   )}
+                  style={
+                    deck.color
+                      ? {
+                          backgroundColor: deck.color,
+                          opacity: isActive ? 1 : 0.65,
+                        }
+                      : undefined
+                  }
                 />
                 <span className="truncate normal-case tracking-normal">
                   {deck.name}
@@ -202,6 +224,12 @@ export function NavDecks() {
                     <Pencil className="mr-2 size-4" />
                     <span className="whitespace-nowrap">Rename deck</span>
                   </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setColorDeckId(deckId)}>
+                    <Palette className="mr-2 size-4" />
+                    <span className="whitespace-nowrap">
+                      {deck.color ? "Change color" : "Set color"}
+                    </span>
+                  </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => setHistoryDeckId(deckId)}>
                     <History className="mr-2 size-4" />
                     <span className="whitespace-nowrap">Version history</span>
@@ -275,6 +303,15 @@ export function NavDecks() {
         deckId={historyDeckId}
         open={historyDeckId !== null}
         onOpenChange={(o) => !o && setHistoryDeckId(null)}
+      />
+      <DeckColorDialog
+        open={colorDeckId !== null}
+        onOpenChange={(o) => !o && setColorDeckId(null)}
+        deckName={colorDeckId ? (decks[colorDeckId]?.name ?? "deck") : "deck"}
+        initialColor={colorDeckId ? decks[colorDeckId]?.color : undefined}
+        onSubmit={(next) => {
+          if (colorDeckId) updateDeckColor(colorDeckId, next);
+        }}
       />
     </>
   );

--- a/drizzle/0009_deck_color.sql
+++ b/drizzle/0009_deck_color.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "decks" ADD COLUMN "color" text;

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,371 @@
+{
+  "id": "b9c2e3f4-5d6a-8283-4b5c-9051cd0d0009",
+  "prevId": "a7b8c9d1-2e3f-7172-3a4b-8f41bdfc0008",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.columns": {
+      "name": "columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "alert_keywords": {
+          "name": "alert_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_interval_seconds": {
+          "name": "refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notify_webhook_url": {
+          "name": "notify_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter_keywords": {
+          "name": "filter_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_keywords": {
+          "name": "exclude_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tab_group": {
+          "name": "tab_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "columns_deck_id_decks_id_fk": {
+          "name": "columns_deck_id_decks_id_fk",
+          "tableFrom": "columns",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deck_snapshots": {
+      "name": "deck_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_json": {
+          "name": "snapshot_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deck_snapshots_deck_captured_idx": {
+          "name": "deck_snapshots_deck_captured_idx",
+          "columns": [
+            {
+              "expression": "deck_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deck_snapshots_deck_id_decks_id_fk": {
+          "name": "deck_snapshots_deck_id_decks_id_fk",
+          "tableFrom": "deck_snapshots",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decks": {
+      "name": "decks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feed_items": {
+      "name": "feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feed_items_column_created_idx": {
+          "name": "feed_items_column_created_idx",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feed_items_column_id_columns_id_fk": {
+          "name": "feed_items_column_id_columns_id_fk",
+          "tableFrom": "feed_items",
+          "tableTo": "columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "feed_items_column_id_id_pk": {
+          "name": "feed_items_column_id_id_pk",
+          "columns": [
+            "column_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1780099200000,
       "tag": "0008_column_color",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1780185600000,
+      "tag": "0009_deck_color",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/columns/types.ts
+++ b/lib/columns/types.ts
@@ -219,4 +219,18 @@ export interface Deck {
   id: string;
   name: string;
   columnIds: string[];
+  /**
+   * Optional 6-char hex color label (e.g. `#f97316`). When set, the deck
+   * renders a colored dot in the sidebar header (replacing the brand
+   * active/inactive dot) and in the deck-view top bar — letting operators
+   * apply a group-level color code at the deck level for at-a-glance
+   * identification across a long sidebar (markets orange, dev blue,
+   * social purple, etc.). The deck-level analog of `Column.color`
+   * (column color labels, PR #61). Round-trips through deck export /
+   * import / share links / version-history snapshots as the optional
+   * `deckColor` field of the v1 schema (additive — old exports omit it
+   * and import as null). Server-validated to `/^#[0-9a-f]{6}$/i` and
+   * normalized to lowercase; anything that doesn't match is dropped.
+   */
+  color?: string;
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -14,6 +14,7 @@ export const decks = pgTable("decks", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   position: integer("position").notNull().default(0),
+  color: text("color"),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
 });
 

--- a/lib/deck-templates.ts
+++ b/lib/deck-templates.ts
@@ -58,6 +58,13 @@ export interface DeckTemplateColumn {
 export interface DeckTemplatePayload {
   version: typeof DECK_TEMPLATE_VERSION;
   deckName: string;
+  // Optional deck-level color label (6-char hex `#rrggbb`). Let a multi-category
+  // starter template ship pre-tagged with a deck-identity color (e.g. the
+  // markets pack ships orange, the dev pack ships blue) so the sidebar dot
+  // is meaningful from first import. Round-trips through importDeck — the
+  // same hex normalizer used for the per-column color drops it to null if
+  // the template ships a malformed value, never aborts the import.
+  deckColor?: string;
   columns: DeckTemplateColumn[];
 }
 

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -17,6 +17,7 @@ import {
   persistFetchedItems as serverPersistItems,
   renameColumn as serverRenameColumn,
   renameDeck as serverRenameDeck,
+  updateDeckColor as serverUpdateDeckColor,
   reorderColumnsInDeck as serverReorderColumns,
   reorderDecks as serverReorderDecks,
   updateColumnAlertKeywords as serverUpdateAlertKeywords,
@@ -81,6 +82,7 @@ interface DeckState {
 
   addDeck: (name: string) => string;
   renameDeck: (deckId: string, name: string) => void;
+  updateDeckColor: (deckId: string, color: string) => void;
   deleteDeck: (deckId: string) => void;
   reorderDecks: (order: string[]) => void;
   setActiveDeck: (deckId: string) => void;
@@ -157,6 +159,7 @@ function importedDeckPatch(
         id: result.deckId,
         name: result.deckName,
         columnIds: result.columns.map((c) => c.id),
+        color: result.deckColor,
       },
     },
     deckOrder: [...s.deckOrder, result.deckId],
@@ -240,6 +243,23 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
       return { decks: { ...s.decks, [deckId]: { ...deck, name } } };
     });
     fireAndLog("renameDeck", serverRenameDeck(deckId, name));
+  },
+
+  updateDeckColor: (deckId, color) => {
+    // Mirror the server normalizer client-side so the optimistic write
+    // and the persisted write agree: empty/invalid → undefined (cleared);
+    // valid hex → canonical lowercased `#rrggbb`. Reuses the same
+    // `normalizeColumnColor` import the column color action uses so the
+    // two surfaces can never drift on case-folding or shorthand acceptance.
+    const normalized = normalizeColumnColor(color) ?? undefined;
+    set((s) => {
+      const deck = s.decks[deckId];
+      if (!deck) return s;
+      return {
+        decks: { ...s.decks, [deckId]: { ...deck, color: normalized } },
+      };
+    });
+    fireAndLog("updateDeckColor", serverUpdateDeckColor(deckId, color));
   },
 
   deleteDeck: (deckId) => {


### PR DESCRIPTION
## What

Per-deck color labels — operators can tag a deck with a 6-hex color (`#f97316` orange, `#3b82f6` blue, etc.) and the color renders as:

- The identity dot in the sidebar deck header (replaces the brand active/inactive dot when set; the tag is the operator's intent, so it stays in their color regardless of active state — only the opacity dips for inactive decks)
- A 10px dot next to the deck name in the top bar of the deck-view header

Same 8-swatch preset palette as column color labels (PR #61) plus a freeform hex input with server-authoritative `/^#[0-9a-f]{6}$/i` normalization. Server drops anything that doesn't match — a hand-edited export or share-link payload can never smuggle a non-canonical color into the DB.

Round-trips through deck export, import, share links, and version-history snapshots as an additive `deckColor` field on the v1 export schema. Old exports created before this feature simply omit the field and import as a deck with no color; no version bump needed.

## Why

The 7-rung per-column UX axis (tab groups → collapse → JSON export → quick-search → pin → duplicate → column color labels) is now well-covered. The next orthogonal surface — flagged in the Jun-04 repo-actions article — is visual organization at the **deck** level. At 5+ decks per operator, the sidebar's identical-looking deck headers become a scan-time bottleneck; a Markets deck and a Dev deck should look different at a glance, not just by name.

Color is the deck-level analog of the per-column work: same palette, same normalization, same drop-not-fail import contract — so an operator who learned "DeFi = orange" from column labels can apply the same convention at the deck level and the two surfaces stay coherent.

## Changes

- `drizzle/0009_deck_color.sql` + `drizzle/meta/0009_snapshot.json` + journal entry: additive nullable `color text` column on `decks` — no churn on existing rows.
- `lib/db/schema.ts`: `color: text("color")` on the `decks` table.
- `lib/columns/types.ts`: `Deck.color?: string` with inline doc on sidebar/top-bar rendering, round-trip behavior, and the link to PR #61's column color analog.
- `app/actions.ts`: `updateDeckColor` server action reusing the column-level `normalizeColumnColor` so the two surfaces never drift; `loadSnapshot` reads `decks.color` through to the wire shape; `importedDeckSchema` gains optional `deckColor`; `exportDeck` emits it when set (`...(deck.color ? { deckColor: deck.color } : {})`); `importDeck` re-validates through the same normalizer and persists; `ImportedDeckResult.deckColor` propagates the persisted color to the optimistic client store so the sidebar dot lights up immediately on import without a snapshot round-trip.
- `lib/store/use-deck-store.ts`: `updateDeckColor` action mirroring `renameDeck`'s optimistic-then-fire pattern; `importedDeckPatch` carries `deckColor` through; new `serverUpdateDeckColor` import.
- `lib/deck-templates.ts`: `DeckTemplatePayload.deckColor?: string` so starter templates can ship pre-colored.
- `components/dialogs/deck-color-dialog.tsx`: new dialog with the same 8 preset swatches + Clear button + freeform hex input + live invalid-hex error as the column color picker. Save lights up only on a meaningful change (cleared, or switched to a different valid color).
- `components/sidebar-01/nav-decks.tsx`: new "Set color" / "Change color" menu item between Rename and Version history; tagged-deck dot renders in the operator's color (full opacity active, 65% inactive); untagged decks keep the prior brand-vs-faded behavior.
- `components/deck/deck-view.tsx`: 10px circular color dot rendered next to the deck name in the top bar when `activeDeck.color` is set.

## Design decisions

- **Reuses the column color palette + normalizer.** Same `normalizeColumnColor`, same 8 swatches, same regex. An operator marking DeFi things orange uses one color across both surfaces. Forking the implementation would invite the two to drift on case-folding, shorthand acceptance, or palette choices.
- **Operator color overrides the active-deck brand color.** When a deck is tagged, the dot stays in its color even when the deck is active. Swapping it for the brand color on active would erase the operator's intent. Inactive tagged decks dip the opacity to 65% so the active deck still reads as primary.
- **Color clears explicitly, not on every save.** The dialog's Save button only enables when the value would actually change (cleared from a tagged deck, or swapped to a different valid color) — so opening and closing the dialog without touching anything is a no-op.
- **Schema is additive, not v2.** Old exports omit `deckColor` and import as `color = null`. The Zod schema accepts unknown-but-absent fields; no version bump needed and old share-links continue to work.
- **No snapshot capture on color change.** Renames don't snapshot either — color is metadata, not a structural mutation. Version history covers structural changes (add/remove column, reorder, duplicate, import, restore), not cosmetic ones.

Could NOT run Next 16 build/typecheck (offline sandbox — established constraint from PRs #49/#50/#51/#52/#53/#55/#56/#58/#59/#60/#61). Manual review only.

---
*Built autonomously by Aeon*