### PR TITLE
fix(defillama): add minimum-TVL floor to gainers mode

### DIFF
--- a/lib/columns/plugins/defillama/client.tsx
+++ b/lib/columns/plugins/defillama/client.tsx
@@ -21,6 +21,7 @@ import { meta, type DefillamaConfig, type DefillamaMeta } from "./plugin";
 
 function ConfigForm({ value, onChange }: ConfigFormProps<DefillamaConfig>) {
   const chainsMode = value.mode === "chains";
+  const gainersMode = value.mode === "gainers";
   return (
     <div className="grid gap-3">
       <div className="grid gap-1.5">
@@ -61,6 +62,34 @@ function ConfigForm({ value, onChange }: ConfigFormProps<DefillamaConfig>) {
             <code>lending</code> matches both <code>Lending</code> and{" "}
             <code>Cross-Chain Lending</code>). Leave empty to see every
             category.
+          </p>
+        </div>
+      )}
+      {gainersMode && (
+        <div className="grid gap-1.5">
+          <Label htmlFor="dl-min-tvl">Minimum TVL (USD)</Label>
+          <Input
+            id="dl-min-tvl"
+            type="number"
+            inputMode="numeric"
+            min={0}
+            step={100000}
+            value={value.minTvlUsd}
+            onChange={(e) => {
+              const raw = e.target.value;
+              const n = raw === "" ? 0 : Number(raw);
+              onChange({
+                ...value,
+                minTvlUsd: Number.isFinite(n) && n >= 0 ? n : 0,
+              });
+            }}
+          />
+          <p className="text-xs text-muted-foreground">
+            Drops protocols below this TVL before sorting — without a floor, a
+            $500 microcap that doubled overnight reads as +100% and outranks a
+            $1B protocol that grew 5%. Default <code>$1M</code> mirrors
+            DeFiLlama&apos;s own gainers page. Set <code>0</code> to include
+            every protocol.
           </p>
         </div>
       )}

--- a/lib/columns/plugins/defillama/plugin.ts
+++ b/lib/columns/plugins/defillama/plugin.ts
@@ -5,6 +5,12 @@ import type { PluginMeta } from "@/lib/columns/types";
 export const schema = z.object({
   mode: z.enum(["top", "gainers", "chains"]).default("top"),
   category: z.string().default(""),
+  // Gainers mode only: drop any protocol with TVL below this floor before
+  // sorting by 24h % change. Without a floor, a $500 microcap that doubled
+  // overnight reads as +100% and crowds out a $1B protocol that grew 5%.
+  // Default $1M mirrors the threshold DeFiLlama applies on its own gainers
+  // leaderboard. `0` disables the floor (every protocol included).
+  minTvlUsd: z.number().nonnegative().default(1_000_000),
 });
 
 export type DefillamaConfig = z.infer<typeof schema>;

--- a/lib/columns/plugins/defillama/server.ts
+++ b/lib/columns/plugins/defillama/server.ts
@@ -18,6 +18,7 @@ const fetch: ServerFetcher<DefillamaConfig, DefillamaMeta> = async (
     config.category,
     PAGE_SIZE,
     page,
+    config.minTvlUsd,
   );
   return {
     items: r.items,

--- a/lib/integrations/defillama.ts
+++ b/lib/integrations/defillama.ts
@@ -188,6 +188,7 @@ export async function fetchDefillamaPage(
   category: string,
   limit: number,
   page: number,
+  minTvlUsd = 0,
 ): Promise<{ items: FeedItem<DefillamaMeta>[]; hasMore: boolean }> {
   const cat = parseCategoryFilter(category);
 
@@ -212,10 +213,20 @@ export async function fetchDefillamaPage(
     .filter((a): a is FeedItem<DefillamaMeta> => a !== null)
     .filter((a) => matchesCategory(a, cat));
 
+  // Gainers mode only: apply a TVL floor before sorting. /protocols ships
+  // every entry DeFiLlama has ever indexed, including ~$50 microcaps; without
+  // a floor a doubling-from-noise protocol shows as +100% and outranks real
+  // movers like a $1B chain that grew 5%. Top mode keeps the full list (it's
+  // a TVL leaderboard — small entries naturally sort to later pages).
+  const filtered =
+    mode === "gainers" && minTvlUsd > 0
+      ? mapped.filter((a) => (a.meta?.tvlUsd ?? 0) >= minTvlUsd)
+      : mapped;
+
   if (mode === "gainers") {
     // Sort by 24h TVL change desc. Ties broken by absolute TVL so a $50M
     // protocol jumping 20% ranks above a $50k protocol jumping 20%.
-    mapped.sort((a, b) => {
+    filtered.sort((a, b) => {
       const da = a.meta?.tvlChange24h ?? 0;
       const db = b.meta?.tvlChange24h ?? 0;
       if (db !== da) return db - da;
@@ -224,11 +235,11 @@ export async function fetchDefillamaPage(
   } else {
     // top mode — sort by TVL desc. The endpoint is normally pre-sorted but the
     // category filter can reorder pages if categories don't sort identically.
-    mapped.sort((a, b) => (b.meta?.tvlUsd ?? 0) - (a.meta?.tvlUsd ?? 0));
+    filtered.sort((a, b) => (b.meta?.tvlUsd ?? 0) - (a.meta?.tvlUsd ?? 0));
   }
 
   const perPage = Math.max(limit, 30);
   const start = page * perPage;
-  const slice = mapped.slice(start, start + perPage);
-  return { items: slice.slice(0, limit), hasMore: mapped.length > start + perPage };
+  const slice = filtered.slice(start, start + perPage);
+  return { items: slice.slice(0, limit), hasMore: filtered.length > start + perPage };
 }


### PR DESCRIPTION
## Summary

The DeFiLlama `gainers` mode pulls every protocol DeFiLlama has ever indexed (~3000 entries) and sorts by 24h % TVL change. Without a floor, a $500 microcap that doubled overnight reads as +100% and crowds out a $1B protocol that grew 5%. The leaderboard ends up dominated by sub-$1k noise instead of real movers.

This adds a per-column `minTvlUsd` floor — applied **only in gainers mode**, default **$1M**, which mirrors the threshold DeFiLlama's own [Top Gainers/Losers](https://defillama.com/topGainersAndLosers) page uses. Set to `0` to keep the previous behavior and include every protocol.

`Top` mode is unchanged (it's a pure TVL leaderboard — small entries naturally sort to later pages). `Chains` mode is unchanged (finite ~200-entry set, no noise problem).

## Changes

- `lib/columns/plugins/defillama/plugin.ts` — add `minTvlUsd` to the zod schema with a `nonnegative()` constraint and `1_000_000` default.
- `lib/columns/plugins/defillama/server.ts` — pass `config.minTvlUsd` through to the integration.
- `lib/columns/plugins/defillama/client.tsx` — add a `type="number"` input under the mode select, visible only when `mode === "gainers"`, with copy explaining the floor.
- `lib/integrations/defillama.ts` — add `minTvlUsd = 0` parameter to `fetchDefillamaPage`; filter `mapped` by `tvlUsd >= minTvlUsd` before sorting in gainers mode.

## Context

Caught reading `lib/integrations/defillama.ts` after PR #45 added the column. The bug is latent — only visible once you actually switch the mode to `gainers` and notice the top of the list is microcap protocols swinging wildly.

Verified: `npx tsc --noEmit` clean on changed files (the pre-existing `pypi.ts` errors are upstream and not introduced here); `npx eslint` clean on the diff.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)