### PR TITLE
feat(sidebar): per-deck drag-to-reorder via @dnd-kit

### DIFF
--- a/components/sidebar-01/nav-decks.tsx
+++ b/components/sidebar-01/nav-decks.tsx
@@ -2,6 +2,7 @@
 
 import {
   ChevronDown,
+  GripVertical,
   History,
   MoreHorizontal,
   Palette,
@@ -9,7 +10,25 @@ import {
   Plus,
   Trash2,
 } from "lucide-react";
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 import {
   Collapsible,
@@ -35,6 +54,7 @@ import {
 import { cn } from "@/lib/utils";
 import { getColumnType } from "@/lib/columns/registry";
 import { useDeckStore } from "@/lib/store/use-deck-store";
+import type { Column, Deck } from "@/lib/columns/types";
 import { RenameDialog } from "@/components/dialogs/rename-dialog";
 import { ConfirmDialog } from "@/components/dialogs/confirm-dialog";
 import { VersionHistoryDialog } from "@/components/dialogs/version-history-dialog";
@@ -56,6 +76,7 @@ export function NavDecks() {
   const renameDeck = useDeckStore((s) => s.renameDeck);
   const updateDeckColor = useDeckStore((s) => s.updateDeckColor);
   const deleteDeck = useDeckStore((s) => s.deleteDeck);
+  const reorderDecks = useDeckStore((s) => s.reorderDecks);
   const renameColumn = useDeckStore((s) => s.renameColumn);
   const removeColumn = useDeckStore((s) => s.removeColumn);
 
@@ -77,177 +98,65 @@ export function NavDecks() {
   const setDeckOpen = (deckId: string, open: boolean) =>
     setOpenOverrides((prev) => ({ ...prev, [deckId]: open }));
 
+  const sensors = useSensors(
+    // 4px activation distance is the same threshold the deck-board uses for
+    // column DnD — a deliberate click on the handle still registers as a click
+    // (e.g. accidentally activating the collapse trigger), only a real drag
+    // intent (>4px movement) starts a sort.
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleDragEnd(ev: DragEndEvent) {
+    const { active, over } = ev;
+    if (!over || active.id === over.id) return;
+    const activeId = String(active.id);
+    const overId = String(over.id);
+    const oldIndex = deckOrder.indexOf(activeId);
+    const newIndex = deckOrder.indexOf(overId);
+    if (oldIndex < 0 || newIndex < 0) return;
+    reorderDecks(arrayMove(deckOrder, oldIndex, newIndex));
+  }
+
   return (
     <>
-      {deckOrder.map((deckId) => {
-        const deck = decks[deckId];
-        if (!deck) return null;
-        const isActive = deckId === activeDeckId;
-
-        return (
-          <Collapsible
-            key={deckId}
-            open={isDeckOpen(deckId)}
-            onOpenChange={(open) => setDeckOpen(deckId, open)}
-            className="group/collapsible"
-          >
-            <SidebarGroup className="py-1">
-              <SidebarGroupLabel
-                className={cn(
-                  "gap-1 pr-9 pl-2 text-[11px] font-medium uppercase tracking-wide hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground",
-                  isActive && "text-sidebar-foreground",
-                )}
-                render={<CollapsibleTrigger />}
-              >
-                {/*
-                  Deck identity dot. When the operator has tagged the deck
-                  with a color, the dot renders in that color regardless of
-                  the active-deck state (the tag is the operator's intent and
-                  shouldn't get swapped out for the brand color just because
-                  this is the currently active deck). Inactive untagged decks
-                  fade the dot to keep the active deck distinguishable; the
-                  active-untagged deck uses the brand color.
-                */}
-                <span
-                  className={cn(
-                    "inline-block size-1.5 rounded-full",
-                    !deck.color
-                      && (isActive ? "bg-[color:var(--brand)]" : "bg-sidebar-foreground/30"),
-                  )}
-                  style={
-                    deck.color
-                      ? {
-                          backgroundColor: deck.color,
-                          opacity: isActive ? 1 : 0.65,
-                        }
-                      : undefined
-                  }
-                />
-                <span className="truncate normal-case tracking-normal">
-                  {deck.name}
-                </span>
-                <span className="ml-1 text-[10px] font-normal text-sidebar-foreground/50 tabular-nums">
-                  {deck.columnIds.length}
-                </span>
-                <ChevronDown className="ml-auto size-3.5 transition-[transform,opacity] group-data-[state=open]/collapsible:rotate-180 group-hover/collapsible:opacity-0" />
-              </SidebarGroupLabel>
-
-              <CollapsibleContent>
-                <SidebarGroupContent>
-                  <SidebarMenu>
-                    {deck.columnIds.map((cid) => {
-                      const col = columns[cid];
-                      if (!col) return null;
-                      const type = getColumnType(col.typeId);
-                      const Icon = type?.icon;
-                      const accent = type?.accent ?? "#999";
-
-                      return (
-                        <SidebarMenuItem key={cid} className="group/item">
-                          <SidebarMenuButton
-                            onClick={() => {
-                              if (!isActive) setActiveDeck(deckId);
-                              requestAnimationFrame(() => focusColumn(cid));
-                            }}
-                            className="gap-2"
-                          >
-                            <span
-                              className="flex size-5 shrink-0 items-center justify-center rounded-[4px]"
-                              style={{
-                                backgroundColor: `${accent}33`,
-                                color: accent,
-                              }}
-                            >
-                              {Icon ? (
-                                <Icon className="size-3" strokeWidth={2.5} />
-                              ) : null}
-                            </span>
-                            <span className="truncate">{col.title}</span>
-                          </SidebarMenuButton>
-                          <DropdownMenu>
-                            <SidebarMenuAction
-                              aria-label="Column options"
-                              render={<DropdownMenuTrigger />}
-                            >
-                              <MoreHorizontal className="size-3.5" />
-                            </SidebarMenuAction>
-                            <DropdownMenuContent side="right" align="start">
-                              <DropdownMenuItem
-                                onClick={() => setRenameColumnId(cid)}
-                              >
-                                <Pencil className="mr-2 size-4" /> Rename
-                              </DropdownMenuItem>
-                              <DropdownMenuSeparator />
-                              <DropdownMenuItem
-                                variant="destructive"
-                                onClick={() => setDeleteColumnId(cid)}
-                              >
-                                <Trash2 className="mr-2 size-4" /> Delete
-                              </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </SidebarMenuItem>
-                      );
-                    })}
-
-                    <SidebarMenuItem>
-                      <SidebarMenuButton
-                        className="gap-2 text-sidebar-foreground/60 hover:text-sidebar-foreground"
-                        onClick={() => {
-                          if (!isActive) setActiveDeck(deckId);
-                          setAddColumnDeckId(deckId);
-                        }}
-                      >
-                        <span className="flex size-5 shrink-0 items-center justify-center rounded-[4px] border border-dashed border-sidebar-foreground/30">
-                          <Plus className="size-3" />
-                        </span>
-                        <span>Add column</span>
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                  </SidebarMenu>
-                </SidebarGroupContent>
-              </CollapsibleContent>
-
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  aria-label={`${deck.name} options`}
-                  className="absolute right-1.5 top-2.5 inline-flex size-5 items-center justify-center rounded text-sidebar-foreground/50 opacity-0 transition-opacity hover:bg-sidebar-accent/70 hover:text-sidebar-foreground group-hover/collapsible:opacity-100 data-[popup-open]:opacity-100"
-                >
-                  <MoreHorizontal className="size-3.5" />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  side="right"
-                  align="start"
-                  className="w-40"
-                >
-                  <DropdownMenuItem onClick={() => setRenameDeckId(deckId)}>
-                    <Pencil className="mr-2 size-4" />
-                    <span className="whitespace-nowrap">Rename deck</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => setColorDeckId(deckId)}>
-                    <Palette className="mr-2 size-4" />
-                    <span className="whitespace-nowrap">
-                      {deck.color ? "Change color" : "Set color"}
-                    </span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => setHistoryDeckId(deckId)}>
-                    <History className="mr-2 size-4" />
-                    <span className="whitespace-nowrap">Version history</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    variant="destructive"
-                    onClick={() => setDeleteDeckId(deckId)}
-                  >
-                    <Trash2 className="mr-2 size-4" />
-                    <span className="whitespace-nowrap">Delete deck</span>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </SidebarGroup>
-          </Collapsible>
-        );
-      })}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        modifiers={[restrictToVerticalAxis]}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={deckOrder}
+          strategy={verticalListSortingStrategy}
+        >
+          {deckOrder.map((deckId) => {
+            const deck = decks[deckId];
+            if (!deck) return null;
+            return (
+              <SortableDeck
+                key={deckId}
+                deck={deck}
+                columns={columns}
+                isActive={deckId === activeDeckId}
+                isOpen={isDeckOpen(deckId)}
+                onOpenChange={(open) => setDeckOpen(deckId, open)}
+                onActivate={() => setActiveDeck(deckId)}
+                onRenameDeck={() => setRenameDeckId(deckId)}
+                onRenameColumn={(cid) => setRenameColumnId(cid)}
+                onColorDeck={() => setColorDeckId(deckId)}
+                onHistoryDeck={() => setHistoryDeckId(deckId)}
+                onDeleteDeck={() => setDeleteDeckId(deckId)}
+                onDeleteColumn={(cid) => setDeleteColumnId(cid)}
+                onAddColumn={() => {
+                  if (deckId !== activeDeckId) setActiveDeck(deckId);
+                  setAddColumnDeckId(deckId);
+                }}
+              />
+            );
+          })}
+        </SortableContext>
+      </DndContext>
 
       <RenameDialog
         open={renameDeckId !== null}
@@ -314,5 +223,239 @@ export function NavDecks() {
         }}
       />
     </>
+  );
+}
+
+interface SortableDeckProps {
+  deck: Deck;
+  columns: Record<string, Column>;
+  isActive: boolean;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onActivate: () => void;
+  onRenameDeck: () => void;
+  onRenameColumn: (columnId: string) => void;
+  onColorDeck: () => void;
+  onHistoryDeck: () => void;
+  onDeleteDeck: () => void;
+  onDeleteColumn: (columnId: string) => void;
+  onAddColumn: () => void;
+}
+
+function SortableDeck({
+  deck,
+  columns,
+  isActive,
+  isOpen,
+  onOpenChange,
+  onActivate,
+  onRenameDeck,
+  onRenameColumn,
+  onColorDeck,
+  onHistoryDeck,
+  onDeleteDeck,
+  onDeleteColumn,
+  onAddColumn,
+}: SortableDeckProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: deck.id });
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    // While dragging, lift slightly so the destination slot is visually obvious
+    // and the floating row reads as the operator's grab target. Matches the
+    // column-card DnD lift in deck-board.
+    opacity: isDragging ? 0.85 : 1,
+    zIndex: isDragging ? 10 : undefined,
+  };
+
+  return (
+    // Wrap in a plain div as the DnD ref host so we never depend on
+    // SidebarGroup's ref-forwarding contract (which would silently no-op
+    // on React versions that don't forward refs through function components).
+    // The div is layout-transparent — relative-positioned so the absolute
+    // drag handle + "More" button inside SidebarGroup keep their offsets.
+    <div ref={setNodeRef} style={style} className="relative">
+      <Collapsible
+        open={isOpen}
+        onOpenChange={onOpenChange}
+        className="group/collapsible"
+      >
+        <SidebarGroup className="py-1">
+          {/*
+            Drag handle. Visible only on group hover, same pattern as the
+            deck "More" button next to it — keeps the sidebar visually quiet
+            at rest while putting a clear grab target one mouse-move away.
+            The 4px activation distance on the sensor means a stray click on
+            the handle does NOT trigger a sort; only a real drag intent does.
+          */}
+          <button
+            type="button"
+            aria-label={`Drag ${deck.name} to reorder`}
+            {...attributes}
+            {...listeners}
+            className="absolute left-1.5 top-2.5 inline-flex size-5 cursor-grab items-center justify-center rounded text-sidebar-foreground/40 opacity-0 transition-opacity hover:bg-sidebar-accent/70 hover:text-sidebar-foreground group-hover/collapsible:opacity-100 active:cursor-grabbing data-[popup-open]:opacity-100"
+          >
+            <GripVertical className="size-3.5" />
+          </button>
+
+        <SidebarGroupLabel
+          className={cn(
+            // Left padding `pl-7` (28px) reserves space for the drag handle
+            // mirror-image of the existing `pr-9` reservation for the deck
+            // "More" button on the right. The handle stays hidden until group
+            // hover, but the reservation is constant so deck names never reflow
+            // on mouse-enter.
+            "gap-1 pr-9 pl-7 text-[11px] font-medium uppercase tracking-wide hover:bg-sidebar-accent/70 hover:text-sidebar-accent-foreground",
+            isActive && "text-sidebar-foreground",
+          )}
+          render={<CollapsibleTrigger />}
+        >
+          {/*
+            Deck identity dot. When the operator has tagged the deck
+            with a color, the dot renders in that color regardless of
+            the active-deck state (the tag is the operator's intent and
+            shouldn't get swapped out for the brand color just because
+            this is the currently active deck). Inactive untagged decks
+            fade the dot to keep the active deck distinguishable; the
+            active-untagged deck uses the brand color.
+          */}
+          <span
+            className={cn(
+              "inline-block size-1.5 rounded-full",
+              !deck.color
+                && (isActive ? "bg-[color:var(--brand)]" : "bg-sidebar-foreground/30"),
+            )}
+            style={
+              deck.color
+                ? {
+                    backgroundColor: deck.color,
+                    opacity: isActive ? 1 : 0.65,
+                  }
+                : undefined
+            }
+          />
+          <span className="truncate normal-case tracking-normal">
+            {deck.name}
+          </span>
+          <span className="ml-1 text-[10px] font-normal text-sidebar-foreground/50 tabular-nums">
+            {deck.columnIds.length}
+          </span>
+          <ChevronDown className="ml-auto size-3.5 transition-[transform,opacity] group-data-[state=open]/collapsible:rotate-180 group-hover/collapsible:opacity-0" />
+        </SidebarGroupLabel>
+
+        <CollapsibleContent>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {deck.columnIds.map((cid) => {
+                const col = columns[cid];
+                if (!col) return null;
+                const type = getColumnType(col.typeId);
+                const Icon = type?.icon;
+                const accent = type?.accent ?? "#999";
+
+                return (
+                  <SidebarMenuItem key={cid} className="group/item">
+                    <SidebarMenuButton
+                      onClick={() => {
+                        if (!isActive) onActivate();
+                        requestAnimationFrame(() => focusColumn(cid));
+                      }}
+                      className="gap-2"
+                    >
+                      <span
+                        className="flex size-5 shrink-0 items-center justify-center rounded-[4px]"
+                        style={{
+                          backgroundColor: `${accent}33`,
+                          color: accent,
+                        }}
+                      >
+                        {Icon ? (
+                          <Icon className="size-3" strokeWidth={2.5} />
+                        ) : null}
+                      </span>
+                      <span className="truncate">{col.title}</span>
+                    </SidebarMenuButton>
+                    <DropdownMenu>
+                      <SidebarMenuAction
+                        aria-label="Column options"
+                        render={<DropdownMenuTrigger />}
+                      >
+                        <MoreHorizontal className="size-3.5" />
+                      </SidebarMenuAction>
+                      <DropdownMenuContent side="right" align="start">
+                        <DropdownMenuItem
+                          onClick={() => onRenameColumn(cid)}
+                        >
+                          <Pencil className="mr-2 size-4" /> Rename
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          variant="destructive"
+                          onClick={() => onDeleteColumn(cid)}
+                        >
+                          <Trash2 className="mr-2 size-4" /> Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </SidebarMenuItem>
+                );
+              })}
+
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  className="gap-2 text-sidebar-foreground/60 hover:text-sidebar-foreground"
+                  onClick={onAddColumn}
+                >
+                  <span className="flex size-5 shrink-0 items-center justify-center rounded-[4px] border border-dashed border-sidebar-foreground/30">
+                    <Plus className="size-3" />
+                  </span>
+                  <span>Add column</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </CollapsibleContent>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            aria-label={`${deck.name} options`}
+            className="absolute right-1.5 top-2.5 inline-flex size-5 items-center justify-center rounded text-sidebar-foreground/50 opacity-0 transition-opacity hover:bg-sidebar-accent/70 hover:text-sidebar-foreground group-hover/collapsible:opacity-100 data-[popup-open]:opacity-100"
+          >
+            <MoreHorizontal className="size-3.5" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            side="right"
+            align="start"
+            className="w-40"
+          >
+            <DropdownMenuItem onClick={onRenameDeck}>
+              <Pencil className="mr-2 size-4" />
+              <span className="whitespace-nowrap">Rename deck</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onColorDeck}>
+              <Palette className="mr-2 size-4" />
+              <span className="whitespace-nowrap">
+                {deck.color ? "Change color" : "Set color"}
+              </span>
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onHistoryDeck}>
+              <History className="mr-2 size-4" />
+              <span className="whitespace-nowrap">Version history</span>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={onDeleteDeck}
+            >
+              <Trash2 className="mr-2 size-4" />
+              <span className="whitespace-nowrap">Delete deck</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarGroup>
+    </Collapsible>
+    </div>
   );
 }


### PR DESCRIPTION
## What
Per-deck drag-to-reorder in the sidebar. Each deck row in `NavDecks` gets a `GripVertical` drag handle on the left (mirror of the existing "More" button on the right). Hold and drag to reorder; on drop, the store fires `reorderDecks(newOrder)` and the existing server action persists the new order.

## Why
`reorderDecks` has lived in the deck store + server action since decks shipped — `lib/store/use-deck-store.ts:343` calls `serverReorderDecks` and `app/actions.ts` already persists the new order. But there was no UI affordance to call it. Decks were stuck in insertion order. At 10+ decks (operators in the dogfood install regularly run beyond that count), the only workaround was delete + re-create, which loses every column's saved settings and the deck snapshot history.

This PR fills the missing UI rung. Pairs naturally with the per-column DnD already in `deck-board.tsx` so the same gesture (grab a handle, drag) works at both levels: columns reorder within a deck, decks reorder within the sidebar.

The per-column UX axis is at 8 rungs after PR #63's width control. This is the **sidebar-level analog** at the deck axis — same affordance, applied one level up.

## Changes
- **`components/sidebar-01/nav-decks.tsx`** (+313 / -170):
  - Wrap the deck list `.map()` in `DndContext` + `SortableContext` using `verticalListSortingStrategy` + `restrictToVerticalAxis` modifier.
  - Extract per-deck JSX into a new `SortableDeck` inner component using `useSortable({id: deck.id})` — mirrors the column-card DnD pattern.
  - Add a `GripVertical` drag handle on the left side of each deck label, positioned `left-1.5 top-2.5 size-5`, visible only on `group-hover/collapsible` (same opacity-on-hover pattern as the deck "More" button).
  - Reserve 28px on the left via `pl-2 → pl-7` on `SidebarGroupLabel` — mirror of the existing `pr-9` reservation for the More button. The handle stays opacity-0 until hover, but the reservation is always present so deck names never reflow on mouse-enter.
  - Lift all existing handlers (`onRenameDeck` / `onColorDeck` / `onHistoryDeck` / `onDeleteDeck` / `onAddColumn` / `onRenameColumn` / `onDeleteColumn` / `onActivate`) into `SortableDeck` props so the component stays presentational and `key={deckId}` remains stable across reorder operations.
  - DnD `setNodeRef` attached to an explicit `<div>` wrapper rather than passed to `SidebarGroup` — defensive against any ref-forwarding inconsistency in `SidebarGroup` (function component without explicit `forwardRef`).

## Design decisions
- **Pointer activation distance: 4px** — matches `deck-board.tsx:39`'s column DnD threshold. A stray click on the handle does NOT trigger a sort; only a real drag intent (>4px movement) starts the reorder. This is critical because the handle is small (size-5 / 20px square) and clicks could otherwise feel jumpy.
- **`restrictToVerticalAxis` modifier** — decks stack vertically; horizontal drag would suggest "moving to a different sidebar group" which doesn't exist. Locking the axis keeps the visual model coherent.
- **No reorder-across-collapse-state restriction** — unlike column DnD's pin-vs-unpin boundary (`deck-board.tsx:135-137`), deck "open" / "closed" is purely view state (`openOverrides` is local React state, NOT persisted). Dragging an open deck past a closed deck doesn't change any persisted attribute on either, so the only question is destination order — same as column-among-column inside a single pin group.
- **Activate-on-click NOT triggered by drag** — the existing `setActiveDeck` happens via the `SidebarMenuButton` column click + the CollapsibleTrigger toggle. Dragging the handle never triggers `setActiveDeck`, which is the correct invariant: reordering should not change which deck is showing.
- **Layout reservation is constant**, not conditional. A `pl-7` reservation that toggles to `pl-2` on hover-out would cause deck names to shift left/right as the operator moves the mouse, which reads as flickery.
- **DnD ref hosted on a `<div>` wrapper**, not on `SidebarGroup` directly. Defensive choice: even though React 19 supports `ref` as a regular prop on function components, the wrapper makes the DnD contract independent of `SidebarGroup`'s internal implementation. The wrapper is layout-transparent (`relative` only) so the absolute drag handle + absolute More button inside `SidebarGroup` keep their offsets.

## Test plan
- [ ] Hover any deck row in the sidebar — confirm the `GripVertical` icon appears on the left, fades out on mouse-leave.
- [ ] Click the drag handle (no drag) — confirm it does NOT trigger a sort or any other action (4px activation guards click-vs-drag).
- [ ] Drag a deck row up past another deck — confirm the visual order updates immediately and the new order persists across reload.
- [ ] Drag with multiple collapsed + expanded decks intermixed — confirm reorder works regardless of open/closed state, and the new order is preserved after reload.
- [ ] Drag while a deck is the active deck — confirm `activeDeckId` is unchanged after drop (no `setActiveDeck` side-effect from the drag).
- [ ] Keyboard sort (Tab to handle, Space to grab, arrow keys, Space to drop) — confirm `KeyboardSensor` + `sortableKeyboardCoordinates` provides a working accessibility path.
- [ ] Check on mobile / small viewport — the sidebar collapses to icon mode at `<sm`; drag handle is hidden along with the rest of the labels in that mode, which is correct (no UI to reorder when the sidebar is icon-only).
- [ ] Could NOT run Next 16 build/typecheck (offline sandbox — established constraint across PRs #49/#50/#51/#52/#53/#55/#56/#58/#59/#60/#61/#62/#63).

---
*Built autonomously by Aeon — sidebar-level analog of the per-column DnD already in deck-board.*
