### PR TITLE
fix(deck): stand down keyboard nav during an active dnd-kit keyboard drag

### DIFF
--- a/components/deck/deck-board.tsx
+++ b/components/deck/deck-board.tsx
@@ -45,6 +45,12 @@ export function DeckBoard({ deckId }: { deckId: string }) {
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
+  // True while a dnd-kit drag (pointer or keyboard) is in progress. The
+  // window-level keyboard-nav listener reads this to stand down during a
+  // keyboard drag, so the arrows/Escape that dnd-kit's KeyboardSensor uses to
+  // move and drop a column aren't also consumed as column navigation.
+  const draggingRef = useRef(false);
+
   // Build the unique, stable list of tab groups present in this deck. Sorted
   // by the column position they first appear in, so the operator's reorder is
   // the visual order of the tabs. Recomputed only when the deck's column list
@@ -132,6 +138,10 @@ export function DeckBoard({ deckId }: { deckId: string }) {
       // Modifier keys belong to the browser/OS (Ctrl-J = downloads, ⌘K = …),
       // so let those through and only act on plain key presses.
       if (e.ctrlKey || e.metaKey || e.altKey) return;
+      // A dnd-kit keyboard drag is active: its drag handle is a <button>, not
+      // a text field, so the text-editable guard below wouldn't catch it. Let
+      // the KeyboardSensor own the arrows/Escape until the drag drops or cancels.
+      if (draggingRef.current) return;
       const target = e.target as HTMLElement | null;
       if (target) {
         const tag = target.tagName;
@@ -240,6 +250,7 @@ export function DeckBoard({ deckId }: { deckId: string }) {
   }
 
   function handleDragEnd(ev: DragEndEvent) {
+    draggingRef.current = false;
     if (!deck) return;
     const { active, over } = ev;
     if (!over || active.id === over.id) return;
@@ -297,7 +308,13 @@ export function DeckBoard({ deckId }: { deckId: string }) {
             sensors={sensors}
             collisionDetection={closestCenter}
             modifiers={[restrictToHorizontalAxis]}
+            onDragStart={() => {
+              draggingRef.current = true;
+            }}
             onDragEnd={handleDragEnd}
+            onDragCancel={() => {
+              draggingRef.current = false;
+            }}
           >
             <SortableContext
               items={visibleColumnIds}


### PR DESCRIPTION
## Problem
PR #66 added window-level keyboard navigation (`j`/`k`/`c`/`/`/`Esc`) for deck columns. Its handler bails when a **text field** (input/textarea/select/contentEditable) is focused. But the drag-to-reorder from PR #65 uses dnd-kit's `KeyboardSensor`, whose drag is driven from a `<button>` drag handle — **not** a text field. So during an *active keyboard drag*, `ArrowLeft`/`ArrowRight`/`Escape` were consumed by **both** dnd-kit's sensor (to move/cancel the drag) and the column-nav handler (to move focus / clear focus) on the same keypress.

## Fix
Track active-drag state in a `draggingRef`:
- set `true` on `DndContext` `onDragStart`
- cleared on `onDragEnd` and `onDragCancel`
- the window key handler bails early while `draggingRef.current` is true

So during a keyboard reorder, the `KeyboardSensor` exclusively owns arrows/Escape until the column drops or the drag cancels. A merely-*focused* (not dragging) handle still allows nav, because arrows don't start a dnd-kit drag — only Space/Enter does — so there's no over-suppression.

## Verification
- `tsc --noEmit`: zero errors in `deck-board.tsx` (only the pre-existing `lib/integrations/pypi.ts` errors remain, untouched).
- `eslint components/deck/deck-board.tsx`: clean (exit 0).
- Ref-based, so the keydown `useEffect` dependency array is unchanged (no re-bind, no stale closure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)