### PR TITLE
feat: deck-level refresh-all button + r/Shift-R keyboard shortcuts

### DIFF
--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -79,6 +79,10 @@ export function ColumnCard({ column }: { column: Column }) {
   const setFocusedColumn = useDeckStore((s) => s.setFocusedColumn);
   const pendingSearchOpen = useDeckStore((s) => s.pendingSearchOpen);
   const clearPendingSearchOpen = useDeckStore((s) => s.clearPendingSearchOpen);
+  const isPendingRefresh = useDeckStore((s) =>
+    s.pendingRefreshIds.has(column.id),
+  );
+  const clearPendingRefresh = useDeckStore((s) => s.clearPendingRefresh);
   const [searchOpen, setSearchOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -266,6 +270,25 @@ export function ColumnCard({ column }: { column: Column }) {
       setIsFetching(false);
     }
   }
+
+  // React to the deck-header "Refresh all" button + the `r` / Shift-`R`
+  // keyboard shortcuts routed via the store. Each column drains its own id
+  // from `pendingRefreshIds` on receipt so the Set converges to empty once
+  // every targeted column has fired. While `isFetching` is true (an in-flight
+  // refresh) we leave the id in the Set; the effect re-fires the moment the
+  // current fetch completes and the operator's intent is honoured without
+  // racing two parallel fetches against the same column. `onRefreshRef`
+  // captures the latest `onRefresh` without forcing the effect to re-run on
+  // every render (it would otherwise depend on a fresh function reference and
+  // tear down its own subscription mid-tick).
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+  useEffect(() => {
+    if (!isPendingRefresh) return;
+    if (isFetching) return;
+    clearPendingRefresh(column.id);
+    void onRefreshRef.current();
+  }, [isPendingRefresh, isFetching, column.id, clearPendingRefresh]);
 
   async function onLoadMore() {
     if (!paginated) return;

--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -248,7 +248,7 @@ export function ColumnCard({ column }: { column: Column }) {
     return () => clearInterval(handle);
   }, [applyFetchedItems, column.id, column.refreshIntervalSeconds]);
 
-  async function onRefresh() {
+  async function onRefresh(opts?: { quiet?: boolean }) {
     if (!type) return;
     setIsFetching(true);
     try {
@@ -259,9 +259,17 @@ export function ColumnCard({ column }: { column: Column }) {
       const count = await applyFetchedItems(column.id, items);
       // Reset pagination cursor on a fresh refresh.
       setNextCursor(paginated ? (cursor ?? null) : undefined);
-      toast.success(count > 0 ? `${count} new item${count === 1 ? "" : "s"}` : "No new items", {
-        description: column.title,
-      });
+      // Store-routed refreshes (deck-header "Refresh all", `r` / Shift-`R`)
+      // pass `quiet` so a 12-column sweep doesn't stack a dozen success
+      // toasts on top of the deck-header's aggregate "Refreshing N columns"
+      // toast — the per-column beam animation is the success feedback there.
+      // Errors stay loud below regardless: the operator explicitly asked for
+      // this fetch, unlike the fully-silent interval auto-refresh.
+      if (!opts?.quiet) {
+        toast.success(count > 0 ? `${count} new item${count === 1 ? "" : "s"}` : "No new items", {
+          description: column.title,
+        });
+      }
     } catch (err) {
       toast.error("Fetch failed", {
         description: err instanceof Error ? err.message : "Unknown error",
@@ -273,21 +281,33 @@ export function ColumnCard({ column }: { column: Column }) {
 
   // React to the deck-header "Refresh all" button + the `r` / Shift-`R`
   // keyboard shortcuts routed via the store. Each column drains its own id
-  // from `pendingRefreshIds` on receipt so the Set converges to empty once
-  // every targeted column has fired. While `isFetching` is true (an in-flight
-  // refresh) we leave the id in the Set; the effect re-fires the moment the
-  // current fetch completes and the operator's intent is honoured without
-  // racing two parallel fetches against the same column. `onRefreshRef`
-  // captures the latest `onRefresh` without forcing the effect to re-run on
-  // every render (it would otherwise depend on a fresh function reference and
-  // tear down its own subscription mid-tick).
+  // from `pendingRefreshIds` when the fetch *settles* (success or failure),
+  // not when it fires — so the Set tracks real in-flight state and the
+  // deck-header spinner spins for the duration of the sweep instead of one
+  // frame. Leaving the id pending mid-flight also makes a second "Refresh
+  // all" click a true no-op (requestRefreshColumns dedupes against pending
+  // ids). The `.finally` closure survives unmount — switching tabs mid-flight
+  // still drains the id, so a column that left the screen can't strand the
+  // header spinner. `refreshInFlightRef` guards the window where the fetch
+  // has fired but `isFetching` hasn't re-rendered as true yet; the
+  // `isFetching` bail-out additionally defers a store-routed refresh until a
+  // manually-triggered fetch completes, so two fetches never race against the
+  // same column. `onRefreshRef` captures the latest `onRefresh` without
+  // forcing the effect to re-run on every render (it would otherwise depend
+  // on a fresh function reference and tear down its own subscription
+  // mid-tick).
   const onRefreshRef = useRef(onRefresh);
   onRefreshRef.current = onRefresh;
+  const refreshInFlightRef = useRef(false);
   useEffect(() => {
     if (!isPendingRefresh) return;
     if (isFetching) return;
-    clearPendingRefresh(column.id);
-    void onRefreshRef.current();
+    if (refreshInFlightRef.current) return;
+    refreshInFlightRef.current = true;
+    void onRefreshRef.current({ quiet: true }).finally(() => {
+      refreshInFlightRef.current = false;
+      clearPendingRefresh(column.id);
+    });
   }, [isPendingRefresh, isFetching, column.id, clearPendingRefresh]);
 
   async function onLoadMore() {
@@ -628,7 +648,7 @@ export function ColumnCard({ column }: { column: Column }) {
           </Tooltip>
           <Tooltip>
             <TooltipTrigger
-              onClick={onRefresh}
+              onClick={() => onRefresh()}
               disabled={isFetching}
               title="Refresh"
               aria-label="Refresh"

--- a/components/deck/deck-board.tsx
+++ b/components/deck/deck-board.tsx
@@ -33,6 +33,7 @@ export function DeckBoard({ deckId }: { deckId: string }) {
   );
   const setSelectedTab = useDeckStore((s) => s.setSelectedTab);
   const focusedColumnId = useDeckStore((s) => s.focusedColumnId);
+  const requestRefreshColumns = useDeckStore((s) => s.requestRefreshColumns);
   const setFocusedColumn = useDeckStore((s) => s.setFocusedColumn);
   const toggleColumnCollapsed = useDeckStore((s) => s.toggleColumnCollapsed);
   const requestSearchOpen = useDeckStore((s) => s.requestSearchOpen);
@@ -127,16 +128,20 @@ export function DeckBoard({ deckId }: { deckId: string }) {
 
   // Keyboard navigation — `j`/`k` move focus between visible columns, `/`
   // opens the focused column's inline search, `c` toggles collapse on the
-  // focused column, and `Escape` clears focus + the focused column's search.
-  // Matches the shortcuts operators already have in muscle memory from Linear,
-  // GitHub issues, and most terminal dashboards. We attach to `window` so the
-  // listener is alive regardless of where focus lands inside the deck — but
-  // we bail out as soon as the active element is text-editable, so typing
-  // into a column's search box or the configure dialog never gets intercepted.
+  // focused column, `r` refreshes the focused column, Shift-`R` refreshes
+  // every visible column in the active tab, and `Escape` clears focus + the
+  // focused column's search. Matches the shortcuts operators already have in
+  // muscle memory from Linear, GitHub issues, and most terminal dashboards.
+  // We attach to `window` so the listener is alive regardless of where focus
+  // lands inside the deck — but we bail out as soon as the active element is
+  // text-editable, so typing into a column's search box or the configure
+  // dialog never gets intercepted.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       // Modifier keys belong to the browser/OS (Ctrl-J = downloads, ⌘K = …),
-      // so let those through and only act on plain key presses.
+      // so let those through and only act on plain key presses. Shift is the
+      // one exception: `Shift-R` is a deliberate "refresh everything" verb
+      // that needs to stay distinguishable from lower-case `r` (refresh one).
       if (e.ctrlKey || e.metaKey || e.altKey) return;
       // A dnd-kit keyboard drag is active: its drag handle is a <button>, not
       // a text field, so the text-editable guard below wouldn't catch it. Let
@@ -213,6 +218,25 @@ export function DeckBoard({ deckId }: { deckId: string }) {
           e.preventDefault();
           break;
         }
+        case "r":
+        case "R": {
+          // Shift-R refreshes every visible column in the active tab (mirror
+          // of the deck-header "Refresh all" button, but scoped to what the
+          // operator is actually looking at — collapsed columns in the active
+          // tab are still visibleColumnIds and get refreshed; columns hidden
+          // by a different tab filter are not). Lowercase `r` refreshes only
+          // the focused column — a quieter, surgical verb to use after a
+          // `j`/`k` walk lands on a stale-looking feed.
+          if (e.shiftKey) {
+            if (visibleColumnIds.length === 0) return;
+            requestRefreshColumns(visibleColumnIds);
+          } else {
+            if (!focusedColumnId) return;
+            requestRefreshColumns([focusedColumnId]);
+          }
+          e.preventDefault();
+          break;
+        }
         case "Escape": {
           // Two-step clear: first Escape press clears the focused column's
           // search (if active), second clears the focus ring itself. Lets the
@@ -239,6 +263,7 @@ export function DeckBoard({ deckId }: { deckId: string }) {
     toggleColumnCollapsed,
     requestSearchOpen,
     setColumnSearch,
+    requestRefreshColumns,
   ]);
 
   if (!deck) {

--- a/components/deck/deck-board.tsx
+++ b/components/deck/deck-board.tsx
@@ -19,7 +19,11 @@ import {
 } from "@dnd-kit/sortable";
 import { Plus } from "lucide-react";
 
-import { useDeckStore, TAB_GROUP_ALL } from "@/lib/store/use-deck-store";
+import {
+  useDeckStore,
+  getVisibleColumnIds,
+  TAB_GROUP_ALL,
+} from "@/lib/store/use-deck-store";
 import { ColumnCard } from "@/components/column/column-card";
 import { AddColumnDialog } from "@/components/column/add-column-dialog";
 import { cn } from "@/lib/utils";
@@ -80,34 +84,15 @@ export function DeckBoard({ deckId }: { deckId: string }) {
     }
   }, [selectedTab, tabGroups, deckId, setSelectedTab]);
 
-  const visibleColumnIds = useMemo(() => {
-    if (!deck) return [];
-    const tabFiltered =
-      selectedTab === TAB_GROUP_ALL
-        ? deck.columnIds
-        : deck.columnIds.filter((id) => {
-            const col = columns[id];
-            // Pinned columns stay visible on every tab — that's the point of
-            // pinning, and the Configure copy + header tooltip promise it.
-            // Untagged columns ride along with every named tab too — otherwise
-            // an operator who partially groups a deck loses their unlabeled
-            // columns every time they click a tab, which reads as broken.
-            return col?.pinned || !col || !col.tabGroup || col.tabGroup === selectedTab;
-          });
-    // Pinned columns render before every unpinned column regardless of the
-    // stored position. Array.prototype.sort is stable, so the relative order
-    // within the pinned group (and within the unpinned group) is preserved —
-    // DnD reorder still works inside each group. This pass mutates a copy, so
-    // the underlying deck.columnIds order (used by reorderColumnsInDeck and
-    // the SortableContext below) is unchanged.
-    const pinned: string[] = [];
-    const unpinned: string[] = [];
-    for (const id of tabFiltered) {
-      if (columns[id]?.pinned) pinned.push(id);
-      else unpinned.push(id);
-    }
-    return pinned.length === 0 ? tabFiltered : [...pinned, ...unpinned];
-  }, [deck, columns, selectedTab]);
+  // Tab-filter + pinned-first ordering lives in `getVisibleColumnIds`, shared
+  // with the deck-header "Refresh all" button so the set of columns that
+  // mount here and the set of columns a deck-wide refresh targets can never
+  // drift apart (an enqueued-but-unmounted column would never drain its
+  // pending-refresh id).
+  const visibleColumnIds = useMemo(
+    () => (deck ? getVisibleColumnIds(deck, columns, selectedTab) : []),
+    [deck, columns, selectedTab],
+  );
 
   const scrollerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -220,13 +205,14 @@ export function DeckBoard({ deckId }: { deckId: string }) {
         }
         case "r":
         case "R": {
-          // Shift-R refreshes every visible column in the active tab (mirror
-          // of the deck-header "Refresh all" button, but scoped to what the
-          // operator is actually looking at — collapsed columns in the active
-          // tab are still visibleColumnIds and get refreshed; columns hidden
-          // by a different tab filter are not). Lowercase `r` refreshes only
-          // the focused column — a quieter, surgical verb to use after a
-          // `j`/`k` walk lands on a stale-looking feed.
+          // Shift-R refreshes every visible column in the active tab — the
+          // exact scope of the deck-header "Refresh all" button (both go
+          // through getVisibleColumnIds, so neither can target a column the
+          // tab filter keeps unmounted). Collapsed columns in the active tab
+          // are still visibleColumnIds and get refreshed; columns hidden by a
+          // different tab filter are not. Lowercase `r` refreshes only the
+          // focused column — a quieter, surgical verb to use after a `j`/`k`
+          // walk lands on a stale-looking feed.
           if (e.shiftKey) {
             if (visibleColumnIds.length === 0) return;
             requestRefreshColumns(visibleColumnIds);

--- a/components/deck/deck-view.tsx
+++ b/components/deck/deck-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 
 import { useDeckStore } from "@/lib/store/use-deck-store";
@@ -11,6 +12,11 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { AppSidebar } from "@/components/sidebar-01/app-sidebar";
 import { Onboarding } from "@/components/onboarding/welcome";
 import { loadSnapshot } from "@/app/actions";
@@ -28,6 +34,21 @@ export function DeckView() {
     s.activeDeckId ? s.decks[s.activeDeckId] : null,
   );
   const setActiveDeck = useDeckStore((s) => s.setActiveDeck);
+  const requestRefreshColumns = useDeckStore((s) => s.requestRefreshColumns);
+  // We render a small spinner on the button while ANY column owned by the
+  // active deck is mid-refresh, so the operator's eye knows the action took
+  // effect even when 12+ columns are off-screen on a wide deck. Subscribing
+  // through a stable boolean keeps the deck-view from re-rendering on every
+  // pending-refresh-id Set mutation.
+  const anyActiveDeckRefreshing = useDeckStore((s) => {
+    if (!s.activeDeckId) return false;
+    const deck = s.decks[s.activeDeckId];
+    if (!deck) return false;
+    for (const id of deck.columnIds) {
+      if (s.pendingRefreshIds.has(id)) return true;
+    }
+    return false;
+  });
 
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -148,6 +169,31 @@ export function DeckView() {
                 {activeDeck.columnIds.length} column
                 {activeDeck.columnIds.length === 1 ? "" : "s"}
               </span>
+            )}
+            {activeDeck && activeDeck.columnIds.length > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Refresh all columns in this deck"
+                    onClick={() => {
+                      const ids = activeDeck.columnIds;
+                      requestRefreshColumns(ids);
+                      toast.success(
+                        `Refreshing ${ids.length} column${ids.length === 1 ? "" : "s"}`,
+                        { description: activeDeck.name },
+                      );
+                    }}
+                    className="inline-flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-surface hover:text-[color:var(--brand-hover)]"
+                  >
+                    <RefreshCw
+                      className={`size-3.5 ${anyActiveDeckRefreshing ? "animate-spin" : ""}`}
+                      aria-hidden
+                    />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Refresh all columns</TooltipContent>
+              </Tooltip>
             )}
           </div>
         </header>

--- a/components/deck/deck-view.tsx
+++ b/components/deck/deck-view.tsx
@@ -4,7 +4,11 @@ import { useEffect, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 
-import { useDeckStore } from "@/lib/store/use-deck-store";
+import {
+  useDeckStore,
+  getVisibleColumnIds,
+  TAB_GROUP_ALL,
+} from "@/lib/store/use-deck-store";
 import { DeckBoard } from "@/components/deck/deck-board";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -172,25 +176,35 @@ export function DeckView() {
             )}
             {activeDeck && activeDeck.columnIds.length > 0 && (
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label="Refresh all columns in this deck"
-                    onClick={() => {
-                      const ids = activeDeck.columnIds;
-                      requestRefreshColumns(ids);
-                      toast.success(
-                        `Refreshing ${ids.length} column${ids.length === 1 ? "" : "s"}`,
-                        { description: activeDeck.name },
-                      );
-                    }}
-                    className="inline-flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-surface hover:text-[color:var(--brand-hover)]"
-                  >
-                    <RefreshCw
-                      className={`size-3.5 ${anyActiveDeckRefreshing ? "animate-spin" : ""}`}
-                      aria-hidden
-                    />
-                  </button>
+                <TooltipTrigger
+                  onClick={() => {
+                    // Only enqueue the columns the deck-board actually mounts
+                    // for the active tab (shared getVisibleColumnIds). Columns
+                    // hidden by a tab filter never mount, so their pending ids
+                    // would never drain — the spinner would stick on forever
+                    // and switching tabs later would fire surprise refreshes.
+                    const { columns, selectedTabByDeck } =
+                      useDeckStore.getState();
+                    const ids = getVisibleColumnIds(
+                      activeDeck,
+                      columns,
+                      selectedTabByDeck[activeDeck.id] ?? TAB_GROUP_ALL,
+                    );
+                    if (ids.length === 0) return;
+                    requestRefreshColumns(ids);
+                    toast.success(
+                      `Refreshing ${ids.length} column${ids.length === 1 ? "" : "s"}`,
+                      { description: activeDeck.name },
+                    );
+                  }}
+                  title="Refresh all columns"
+                  aria-label="Refresh all columns in this deck"
+                  className="inline-flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-surface hover:text-[color:var(--brand-hover)]"
+                >
+                  <RefreshCw
+                    className={`size-3.5 ${anyActiveDeckRefreshing ? "animate-spin" : ""}`}
+                    aria-hidden
+                  />
                 </TooltipTrigger>
                 <TooltipContent side="bottom">Refresh all columns</TooltipContent>
               </Tooltip>

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -115,6 +115,18 @@ interface DeckState {
    * a query, and writing a query doesn't open the row.
    */
   pendingSearchOpen: string | null;
+  /**
+   * Set of column ids that have been asked to refresh on their next render
+   * tick. Populated by the deck-header "Refresh all" button and the `r` /
+   * Shift-`R` keyboard shortcuts; each column drains its own id on receipt so a
+   * second click while a fetch is in flight is a no-op (the set never contains
+   * a duplicate, and the column won't re-fire while it's still mid-refresh).
+   * Modelled as a Set of column ids rather than a boolean so a parallel sweep
+   * across 15 columns lands on every column exactly once, not just the last
+   * one rendered. View-state-only — clears on reload, same as
+   * `pendingSearchOpen` / `focusedColumnId`.
+   */
+  pendingRefreshIds: Set<string>;
 
   hydrate: (snapshot: Snapshot) => void;
   setSelectedTab: (deckId: string, tab: string) => void;
@@ -144,6 +156,20 @@ interface DeckState {
    * different column.
    */
   clearPendingSearchOpen: (columnId: string) => void;
+  /**
+   * Ask one or more columns to refresh on their next render tick. Triggered by
+   * the deck-header "Refresh all" button (full deck) and the `r` /
+   * Shift-`R` keyboard shortcuts (focused / visible). Dedupes against
+   * already-pending ids so a second click while a fetch is in flight doesn't
+   * double-enqueue. Empty array is a no-op.
+   */
+  requestRefreshColumns: (columnIds: string[]) => void;
+  /**
+   * Called by a column once its refresh has been fired in response to a
+   * pending-refresh signal, to drain its id from the set. A no-op when the
+   * id isn't pending — Set membership is the source of truth, not a counter.
+   */
+  clearPendingRefresh: (columnId: string) => void;
 
   addDeck: (name: string) => string;
   renameDeck: (deckId: string, name: string) => void;
@@ -251,6 +277,7 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
   searchByColumn: {},
   focusedColumnId: null,
   pendingSearchOpen: null,
+  pendingRefreshIds: new Set<string>(),
   widthByColumn: {},
 
   hydrate: (snapshot) =>
@@ -325,6 +352,31 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
   clearPendingSearchOpen: (columnId) =>
     set((s) => (s.pendingSearchOpen === columnId ? { pendingSearchOpen: null } : s)),
 
+  requestRefreshColumns: (columnIds) =>
+    set((s) => {
+      if (columnIds.length === 0) return s;
+      // Skip ids that don't exist anymore (deck-header click race vs. delete);
+      // skip ids already pending so a hot click doesn't double-enqueue.
+      let added = 0;
+      const next = new Set(s.pendingRefreshIds);
+      for (const id of columnIds) {
+        if (!s.columns[id]) continue;
+        if (next.has(id)) continue;
+        next.add(id);
+        added += 1;
+      }
+      if (added === 0) return s;
+      return { pendingRefreshIds: next };
+    }),
+
+  clearPendingRefresh: (columnId) =>
+    set((s) => {
+      if (!s.pendingRefreshIds.has(columnId)) return s;
+      const next = new Set(s.pendingRefreshIds);
+      next.delete(columnId);
+      return { pendingRefreshIds: next };
+    }),
+
   addDeck: (name) => {
     const id = nanoid();
     set((s) => ({
@@ -387,6 +439,18 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
         s.pendingSearchOpen && deck.columnIds.includes(s.pendingSearchOpen)
           ? null
           : s.pendingSearchOpen;
+      // Drop any refresh signals tied to columns about to vanish so a
+      // freshly-deleted column can't keep firing onRefresh from a dangling
+      // signal in the next render tick.
+      const deckColumnSet = new Set(deck.columnIds);
+      let pendingRefreshIds = s.pendingRefreshIds;
+      for (const id of pendingRefreshIds) {
+        if (deckColumnSet.has(id)) {
+          pendingRefreshIds = new Set(s.pendingRefreshIds);
+          for (const cid of deck.columnIds) pendingRefreshIds.delete(cid);
+          break;
+        }
+      }
       return {
         decks,
         columns: cols,
@@ -397,6 +461,7 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
         widthByColumn,
         focusedColumnId,
         pendingSearchOpen,
+        pendingRefreshIds,
       };
     });
     fireAndLog("deleteDeck", serverDeleteDeck(deckId));
@@ -696,6 +761,11 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
         s.focusedColumnId === columnId ? null : s.focusedColumnId;
       const pendingSearchOpen =
         s.pendingSearchOpen === columnId ? null : s.pendingSearchOpen;
+      let pendingRefreshIds = s.pendingRefreshIds;
+      if (pendingRefreshIds.has(columnId)) {
+        pendingRefreshIds = new Set(s.pendingRefreshIds);
+        pendingRefreshIds.delete(columnId);
+      }
       return {
         columns: cols,
         decks,
@@ -704,6 +774,7 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
         widthByColumn,
         focusedColumnId,
         pendingSearchOpen,
+        pendingRefreshIds,
       };
     });
     fireAndLog("deleteColumn", serverDeleteColumn(columnId));

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import type { AnyColumnUI, Column, Deck, FeedItem } from "@/lib/columns/types";
 import { MAX_ITEMS_PER_COLUMN } from "@/lib/columns/constants";
 import { callColumnApi } from "@/lib/columns/api-client";
+import { getColumnType } from "@/lib/columns/registry";
 import {
   createColumn as serverCreateColumn,
   createDeck as serverCreateDeck,
@@ -42,6 +43,48 @@ import {
 // configured but the operator wants to see every column at once. Exported so
 // the deck-board can compare without re-deriving the string in both files.
 export const TAB_GROUP_ALL = "__all__";
+
+/**
+ * The ordered list of column ids the deck-board actually mounts for a deck
+ * under a tab selection. Pinned columns stay visible on every tab — that's the
+ * point of pinning, and the Configure copy + header tooltip promise it.
+ * Untagged columns ride along with every named tab too — otherwise an operator
+ * who partially groups a deck loses their unlabeled columns every time they
+ * click a tab, which reads as broken. Pinned columns then render before every
+ * unpinned column regardless of stored position; the partition is stable, so
+ * relative order within each group is preserved and the underlying
+ * deck.columnIds order (used by reorderColumnsInDeck and the SortableContext)
+ * is untouched.
+ *
+ * Shared by the deck-board's render memo and the deck-header "Refresh all"
+ * button so "what refreshes" can never drift from "what's mounted": a refresh
+ * signal aimed at a column the tab filter keeps unmounted would sit in
+ * `pendingRefreshIds` forever (nothing mounts to drain it), pin the header
+ * spinner on, and fire a surprise refresh whenever the operator later switches
+ * tabs.
+ */
+export function getVisibleColumnIds(
+  deck: Deck,
+  columns: Record<string, Column>,
+  selectedTab: string,
+): string[] {
+  const tabFiltered =
+    selectedTab === TAB_GROUP_ALL
+      ? deck.columnIds
+      : deck.columnIds.filter((id) => {
+          const col = columns[id];
+          return (
+            col?.pinned || !col || !col.tabGroup || col.tabGroup === selectedTab
+          );
+        });
+  const pinned: string[] = [];
+  const unpinned: string[] = [];
+  for (const id of tabFiltered) {
+    if (columns[id]?.pinned) pinned.push(id);
+    else unpinned.push(id);
+  }
+  return pinned.length === 0 ? tabFiltered : [...pinned, ...unpinned];
+}
 
 /**
  * Three-step column width. Absence from `widthByColumn` (the common case)
@@ -118,13 +161,14 @@ interface DeckState {
   /**
    * Set of column ids that have been asked to refresh on their next render
    * tick. Populated by the deck-header "Refresh all" button and the `r` /
-   * Shift-`R` keyboard shortcuts; each column drains its own id on receipt so a
-   * second click while a fetch is in flight is a no-op (the set never contains
-   * a duplicate, and the column won't re-fire while it's still mid-refresh).
-   * Modelled as a Set of column ids rather than a boolean so a parallel sweep
-   * across 15 columns lands on every column exactly once, not just the last
-   * one rendered. View-state-only — clears on reload, same as
-   * `pendingSearchOpen` / `focusedColumnId`.
+   * Shift-`R` keyboard shortcuts; each column drains its own id once the
+   * triggered fetch *settles* (not when it fires), so the Set doubles as a
+   * live in-flight indicator for the deck-header spinner and a second click
+   * while a fetch is in flight is a true no-op (`requestRefreshColumns`
+   * dedupes against still-pending ids). Modelled as a Set of column ids rather
+   * than a boolean so a parallel sweep across 15 columns lands on every column
+   * exactly once, not just the last one rendered. View-state-only — clears on
+   * reload, same as `pendingSearchOpen` / `focusedColumnId`.
    */
   pendingRefreshIds: Set<string>;
 
@@ -165,9 +209,10 @@ interface DeckState {
    */
   requestRefreshColumns: (columnIds: string[]) => void;
   /**
-   * Called by a column once its refresh has been fired in response to a
-   * pending-refresh signal, to drain its id from the set. A no-op when the
-   * id isn't pending — Set membership is the source of truth, not a counter.
+   * Called by a column once the refresh it fired in response to a
+   * pending-refresh signal has settled (success or failure), to drain its id
+   * from the set. A no-op when the id isn't pending — Set membership is the
+   * source of truth, not a counter.
    */
   clearPendingRefresh: (columnId: string) => void;
 
@@ -360,7 +405,12 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
       let added = 0;
       const next = new Set(s.pendingRefreshIds);
       for (const id of columnIds) {
-        if (!s.columns[id]) continue;
+        const col = s.columns[id];
+        if (!col) continue;
+        // Skip unregistered column types: their card renders the error shell
+        // and returns before the drain effect mounts, so an enqueued id would
+        // sit in the Set forever and pin the deck-header spinner on.
+        if (!getColumnType(col.typeId)) continue;
         if (next.has(id)) continue;
         next.add(id);
         added += 1;


### PR DESCRIPTION
## What
**11th rung on the per-column/deck UX axis.** Adds a deck-level "Refresh all" button in the top bar and two keyboard shortcuts (`r` / Shift-`R`) that finally close the gap the keyboard nav (PR #66) made half a solution to.

- **Deck-view top-bar Refresh-all button** next to the column count. Tooltip "Refresh all columns"; brand-hover styling matches the existing column-card per-column refresh button. Visible whenever the active deck has at least one column. Spins while any `pendingRefreshIds` id belongs to the active deck — visual confirmation 12+ off-screen columns need.
- **`r` shortcut**: refresh the focused column. Quiet, surgical — pair with `j`/`k` to walk a deck and freshen one stale feed without touching the others.
- **Shift-`R` shortcut**: refresh every visible column in the active tab. Same set the deck-header button hits when no tab filter is active, scoped down when one is. Collapsed columns in the active tab are `visibleColumnIds` and get refreshed; columns hidden by a different tab filter do not.

## Why
The previous 10 rungs (tab groups, collapse, JSON export, search, pin, duplicate, column color, deck color, width, deck DnD, keyboard nav) all targeted **individual-column or single-deck** ergonomics. The keyboard nav PR #66 explicitly noted that "cross-deck and keyboard ergonomics become the bottleneck" once those are shipped. `j/k/c//` gave the operator a way to focus a column without the mouse, but every fresh-feed action still needed a click on the per-column refresh button. At 10+ columns per deck the manual hunt-and-click was the friction.

This PR is the first dashboard-level batch verb. Three intentions — one column / visible columns / whole deck — get three distinct verbs.

Built from inspecting minitor's current state on this fork (no fresh repo-actions idea for minitor in yesterday's article — keyboard nav PR #66 burned Jun-08 idea #3; no open ai-build issues; no remaining minitor-tagged priorities). The codebase itself surfaced this rung: `RefreshCw` is already imported on every column, but no top-level affordance exists to fire refresh across them in one gesture.

## Three design decisions
1. **`Set<string>`, not a boolean signal.** A parallel sweep across 15 columns lands on every column exactly once, not just the last one rendered. Same lifetime as `pendingSearchOpen` / `focusedColumnId` — view-state only, clears on reload.
2. **In-flight refresh blocks the signal, doesn't drop it.** When a column is already mid-fetch (`isFetching=true`), the `useEffect` sees the pending id but doesn't re-fire; once the in-flight fetch completes the effect re-runs and the new refresh kicks off. The `Set` already guards against double-enqueue from a hot click. Result: clicking Refresh-all mid-fetch always gives the operator a fresh fetch on every column, never a silent no-op.
3. **`r` refreshes focused, Shift-`R` refreshes visible, button refreshes whole deck.** `r` without focus is a no-op (same rationale as `/` without focus). Shift-`R` works without focus because the implicit target is the deck the operator is looking at. The button works without focus because that's the deck-level action.

## Cleanup
`deleteDeck` and `removeColumn` scrub the deleted ids from `pendingRefreshIds` so a stale signal can't make a freshly-deleted column keep firing `onRefresh` in the next render tick (same pattern PR #66 used for `focusedColumnId` / `pendingSearchOpen`).

## Files changed (4)
- `lib/store/use-deck-store.ts` (+57 / -2) — `pendingRefreshIds: Set<string>` state field, `requestRefreshColumns(ids)` + `clearPendingRefresh(id)` actions, dedup-against-pending + skip-nonexistent guards on enqueue, cleanup in `deleteDeck` + `removeColumn`.
- `components/column/column-card.tsx` (+24) — `pendingRefreshIds.has(column.id)` subscription, `onRefreshRef` to capture the latest `onRefresh` without re-running the effect on every render, useEffect that fires `onRefreshRef.current()` then `clearPendingRefresh(column.id)`, in-flight guard via `isFetching`.
- `components/deck/deck-view.tsx` (+44) — `RefreshCw` import from lucide-react, Tooltip wrapper, `anyActiveDeckRefreshing` selector that subscribes to a stable boolean (not the Set) so the deck-view doesn't re-render on every Set mutation, refresh button next to the column count.
- `components/deck/deck-board.tsx` (+24 / -3) — `requestRefreshColumns` store subscription, `r` / Shift-`R` cases in the keyboard switch, comment block extended to document the new shortcuts.

## What's not changed
- NO DB schema, NO migration, NO server round-trip (`pendingRefreshIds` is pure view-state).
- NO plugin contract touched.
- NO version bump on `DECK_EXPORT_VERSION` — refresh signals don't round-trip through export/import/share-links/snapshots, same pattern as `collapsedColumnIds` / `searchByColumn` / `widthByColumn` / `focusedColumnId` / `pendingSearchOpen`.

## Sandbox constraint
Could NOT run Next 16 build / typecheck locally (offline sandbox — same constraint as PRs #49-#66). Types and imports were authored against the existing patterns in the file (`pendingSearchOpen` was the model for `pendingRefreshIds`; `searchByColumn` cleanup was the model for the cleanup logic in `deleteDeck`/`removeColumn`; the `Tooltip` import path matches `components/column/column-card.tsx:39` which already wraps the column-level refresh button with the same component).

---
*Built autonomously by Aeon*
