### PR TITLE
feat: per-deck color-label filter toggle

### DIFF
--- a/components/deck/deck-board.tsx
+++ b/components/deck/deck-board.tsx
@@ -107,6 +107,19 @@ export function DeckBoard({ deckId }: { deckId: string }) {
     return ordered;
   }, [deck, columns]);
 
+  // Cheap rollup so the chips don't each re-walk the deck. Done before the
+  // render so the All count and per-color counts share the same single pass.
+  const colorCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    if (!deck) return counts;
+    for (const id of deck.columnIds) {
+      const c = columns[id]?.color;
+      if (!c) continue;
+      counts[c] = (counts[c] ?? 0) + 1;
+    }
+    return counts;
+  }, [deck, columns]);
+
   // If the active filter color is no longer present in any column (operator
   // recolored everything, or deleted the last column carrying that color),
   // clear it silently so the operator doesn't end up staring at the
@@ -325,18 +338,6 @@ export function DeckBoard({ deckId }: { deckId: string }) {
   // just be visual noise. Same rule of thumb as the tab row above: a single
   // implicit group is no group at all.
   const showColorFilter = usedColors.length >= 2;
-  // Cheap rollup so the chips don't each re-walk the deck. Done before the
-  // render so the All count and per-color counts share the same single pass.
-  const colorCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    if (!deck) return counts;
-    for (const id of deck.columnIds) {
-      const c = columns[id]?.color;
-      if (!c) continue;
-      counts[c] = (counts[c] ?? 0) + 1;
-    }
-    return counts;
-  }, [deck, columns]);
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">

--- a/components/deck/deck-board.tsx
+++ b/components/deck/deck-board.tsx
@@ -42,6 +42,10 @@ export function DeckBoard({ deckId }: { deckId: string }) {
   const toggleColumnCollapsed = useDeckStore((s) => s.toggleColumnCollapsed);
   const requestSearchOpen = useDeckStore((s) => s.requestSearchOpen);
   const setColumnSearch = useDeckStore((s) => s.setColumnSearch);
+  const activeColorFilter = useDeckStore(
+    (s) => s.activeColorFilter[deckId] ?? null,
+  );
+  const setColorFilter = useDeckStore((s) => s.setColorFilter);
 
   const [addOpen, setAddOpen] = useState(false);
 
@@ -84,14 +88,49 @@ export function DeckBoard({ deckId }: { deckId: string }) {
     }
   }, [selectedTab, tabGroups, deckId, setSelectedTab]);
 
-  // Tab-filter + pinned-first ordering lives in `getVisibleColumnIds`, shared
-  // with the deck-header "Refresh all" button so the set of columns that
-  // mount here and the set of columns a deck-wide refresh targets can never
-  // drift apart (an enqueued-but-unmounted column would never drain its
-  // pending-refresh id).
+  // Distinct column colors present in this deck, ordered by first appearance
+  // in `deck.columnIds` so the filter row is stable across renders and
+  // matches the visual order of the columns. Recomputed only when the deck's
+  // column list or any column's color changes. Used both to decide whether to
+  // show the filter row at all (`< 2` = hidden) and to render the chips.
+  const usedColors = useMemo(() => {
+    if (!deck) return [] as string[];
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const id of deck.columnIds) {
+      const col = columns[id];
+      const c = col?.color;
+      if (!c || seen.has(c)) continue;
+      seen.add(c);
+      ordered.push(c);
+    }
+    return ordered;
+  }, [deck, columns]);
+
+  // If the active filter color is no longer present in any column (operator
+  // recolored everything, or deleted the last column carrying that color),
+  // clear it silently so the operator doesn't end up staring at the
+  // zero-match placeholder for a filter they can no longer see in the row.
+  // Same shape as the tab-disappear fallback above — keep view-state honest
+  // when the data underneath shifts out from under it.
+  useEffect(() => {
+    if (!activeColorFilter) return;
+    if (!usedColors.includes(activeColorFilter)) {
+      setColorFilter(deckId, null);
+    }
+  }, [activeColorFilter, usedColors, deckId, setColorFilter]);
+
+  // Tab-filter + color-filter + pinned-first ordering lives in
+  // `getVisibleColumnIds`, shared with the deck-header "Refresh all" button so
+  // the set of columns that mount here and the set of columns a deck-wide
+  // refresh targets can never drift apart (an enqueued-but-unmounted column
+  // would never drain its pending-refresh id).
   const visibleColumnIds = useMemo(
-    () => (deck ? getVisibleColumnIds(deck, columns, selectedTab) : []),
-    [deck, columns, selectedTab],
+    () =>
+      deck
+        ? getVisibleColumnIds(deck, columns, selectedTab, activeColorFilter)
+        : [],
+    [deck, columns, selectedTab, activeColorFilter],
   );
 
   const scrollerRef = useRef<HTMLDivElement>(null);
@@ -281,6 +320,23 @@ export function DeckBoard({ deckId }: { deckId: string }) {
   }
 
   const hasTabs = tabGroups.length > 0;
+  // Hide the entire filter bar when there are fewer than two distinct colors
+  // in use — with 0 or 1 colors there's nothing to filter to, the row would
+  // just be visual noise. Same rule of thumb as the tab row above: a single
+  // implicit group is no group at all.
+  const showColorFilter = usedColors.length >= 2;
+  // Cheap rollup so the chips don't each re-walk the deck. Done before the
+  // render so the All count and per-color counts share the same single pass.
+  const colorCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    if (!deck) return counts;
+    for (const id of deck.columnIds) {
+      const c = columns[id]?.color;
+      if (!c) continue;
+      counts[c] = (counts[c] ?? 0) + 1;
+    }
+    return counts;
+  }, [deck, columns]);
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
@@ -307,6 +363,24 @@ export function DeckBoard({ deckId }: { deckId: string }) {
               />
             );
           })}
+        </div>
+      )}
+
+      {showColorFilter && (
+        <div className="flex shrink-0 flex-wrap items-center gap-1.5 border-b border-border bg-background/60 px-2 py-1.5 sm:px-3">
+          <ColorFilterPill
+            active={activeColorFilter === null}
+            onClick={() => setColorFilter(deck.id, null)}
+          />
+          {usedColors.map((color) => (
+            <ColorFilterPill
+              key={color}
+              color={color}
+              count={colorCounts[color] ?? 0}
+              active={activeColorFilter === color}
+              onClick={() => setColorFilter(deck.id, color)}
+            />
+          ))}
         </div>
       )}
 
@@ -338,6 +412,24 @@ export function DeckBoard({ deckId }: { deckId: string }) {
               })}
             </SortableContext>
           </DndContext>
+
+          {activeColorFilter !== null && visibleColumnIds.length === 0 && (
+            <div className="flex h-full w-[min(280px,calc(100vw-1rem))] shrink-0 snap-start flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-transparent px-4 text-center text-sm text-muted-foreground sm:w-[280px] sm:snap-none">
+              <span
+                aria-hidden
+                className="size-3 shrink-0 rounded-full ring-1 ring-border"
+                style={{ backgroundColor: activeColorFilter }}
+              />
+              <span>No columns match this color filter.</span>
+              <button
+                type="button"
+                onClick={() => setColorFilter(deck.id, null)}
+                className="text-xs font-medium text-[color:var(--brand)] underline-offset-2 hover:underline"
+              >
+                Clear filter
+              </button>
+            </div>
+          )}
 
           <button
             type="button"
@@ -390,6 +482,48 @@ function TabButton({ label, count, active, onClick }: TabButtonProps) {
       <span className="rounded bg-surface-elevated px-1 text-[10px] tabular-nums text-muted-foreground">
         {count}
       </span>
+    </button>
+  );
+}
+
+interface ColorFilterPillProps {
+  /** Absent = the "All" pill (no color dot, clears the filter). */
+  color?: string;
+  /** Absent for the "All" pill. */
+  count?: number;
+  active: boolean;
+  onClick: () => void;
+}
+
+function ColorFilterPill({ color, count, active, onClick }: ColorFilterPillProps) {
+  const isAll = color === undefined;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={isAll ? "Show all colors" : `Filter to ${color}`}
+      aria-pressed={active}
+      className={cn(
+        "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border px-2 text-xs font-medium transition-colors",
+        active
+          ? "border-transparent bg-[color:var(--brand)]/10 text-[color:var(--brand)] ring-2 ring-[color:var(--brand)]/60"
+          : "border-border text-muted-foreground hover:bg-surface hover:text-foreground",
+      )}
+    >
+      {isAll ? (
+        <span>All</span>
+      ) : (
+        <>
+          <span
+            aria-hidden
+            className="size-2.5 shrink-0 rounded-full ring-1 ring-border"
+            style={{ backgroundColor: color }}
+          />
+          <span className="rounded bg-surface-elevated px-1 text-[10px] tabular-nums text-muted-foreground">
+            {count ?? 0}
+          </span>
+        </>
+      )}
     </button>
   );
 }

--- a/components/deck/deck-view.tsx
+++ b/components/deck/deck-view.tsx
@@ -179,16 +179,18 @@ export function DeckView() {
                 <TooltipTrigger
                   onClick={() => {
                     // Only enqueue the columns the deck-board actually mounts
-                    // for the active tab (shared getVisibleColumnIds). Columns
-                    // hidden by a tab filter never mount, so their pending ids
-                    // would never drain — the spinner would stick on forever
-                    // and switching tabs later would fire surprise refreshes.
-                    const { columns, selectedTabByDeck } =
+                    // for the active tab AND the active color filter (shared
+                    // getVisibleColumnIds). Columns hidden by either filter
+                    // never mount, so their pending ids would never drain —
+                    // the spinner would stick on forever and toggling the
+                    // filter later would fire surprise refreshes.
+                    const { columns, selectedTabByDeck, activeColorFilter } =
                       useDeckStore.getState();
                     const ids = getVisibleColumnIds(
                       activeDeck,
                       columns,
                       selectedTabByDeck[activeDeck.id] ?? TAB_GROUP_ALL,
+                      activeColorFilter[activeDeck.id] ?? null,
                     );
                     if (ids.length === 0) return;
                     requestRefreshColumns(ids);

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -56,6 +56,18 @@ export const TAB_GROUP_ALL = "__all__";
  * deck.columnIds order (used by reorderColumnsInDeck and the SortableContext)
  * is untouched.
  *
+ * The optional `colorFilter` runs AFTER the tab partition and BEFORE the
+ * pinned/unpinned partition — the operator wants "show me orange columns
+ * within the active tab", not "show me orange columns across all tabs". The
+ * value is compared against the column's `color` field after passing both
+ * sides through `normalizeColumnColor`, so a hand-entered `#FF8800` chip
+ * matches a stored `#ff8800` column. Pinned columns are NOT exempt from the
+ * color filter — pinning is a routing decision (always visible on every tab),
+ * color is a label decision (show me what kind of column this is), so an
+ * orange-tagged pin survives a "show orange" filter and a blue-tagged pin
+ * does not. Same semantics as collapsing a pinned column: pinning trumps
+ * tab routing, not the operator's other view-state choices.
+ *
  * Shared by the deck-board's render memo and the deck-header "Refresh all"
  * button so "what refreshes" can never drift from "what's mounted": a refresh
  * signal aimed at a column the tab filter keeps unmounted would sit in
@@ -67,6 +79,7 @@ export function getVisibleColumnIds(
   deck: Deck,
   columns: Record<string, Column>,
   selectedTab: string,
+  colorFilter?: string | null,
 ): string[] {
   const tabFiltered =
     selectedTab === TAB_GROUP_ALL
@@ -77,13 +90,24 @@ export function getVisibleColumnIds(
             col?.pinned || !col || !col.tabGroup || col.tabGroup === selectedTab
           );
         });
+  const normalizedFilter = colorFilter
+    ? normalizeColumnColor(colorFilter)
+    : null;
+  const colorFiltered = normalizedFilter
+    ? tabFiltered.filter((id) => {
+        const col = columns[id];
+        if (!col) return false;
+        const colColor = normalizeColumnColor(col.color);
+        return colColor === normalizedFilter;
+      })
+    : tabFiltered;
   const pinned: string[] = [];
   const unpinned: string[] = [];
-  for (const id of tabFiltered) {
+  for (const id of colorFiltered) {
     if (columns[id]?.pinned) pinned.push(id);
     else unpinned.push(id);
   }
-  return pinned.length === 0 ? tabFiltered : [...pinned, ...unpinned];
+  return pinned.length === 0 ? colorFiltered : [...pinned, ...unpinned];
 }
 
 /**
@@ -138,6 +162,22 @@ interface DeckState {
    * collapse always shows. Width re-applies on expand from the in-memory map.
    */
   widthByColumn: Record<string, ColumnWidth>;
+  /**
+   * Per-deck active color filter. NOT persisted — same lifetime as
+   * `selectedTabByDeck`/`collapsedColumnIds`/`searchByColumn`, clears on
+   * reload. Keyed on deck id so each deck remembers its own filter for the
+   * session (an operator can hop between a "research" deck filtered to orange
+   * and a "social" deck filtered to blue without re-clicking the chip every
+   * time). Value is the canonical lowercase `#rrggbb` hex of the color in
+   * play; `null` or absent means "All" (no color filter active). The deck
+   * board's pill row writes this; `getVisibleColumnIds` consumes it.
+   *
+   * Why not exported: same rationale as `widthByColumn`. The deck's
+   * identity (decks/columns/configs) lives in the DB; "how the operator is
+   * reading it right now" lives in memory. Filter chips are reading-shape,
+   * not deck-shape — they don't belong in `DECK_EXPORT_VERSION`.
+   */
+  activeColorFilter: Record<string, string | null>;
   /**
    * Currently-focused column id for keyboard navigation. NOT persisted — same
    * lifetime as `collapsedColumnIds`/`searchByColumn`. `null` means no column
@@ -215,6 +255,14 @@ interface DeckState {
    * source of truth, not a counter.
    */
   clearPendingRefresh: (columnId: string) => void;
+  /**
+   * Set the active color filter for a deck. Pass `null` to clear (the "All"
+   * pill). Color strings are normalized through the same
+   * `normalizeColumnColor` the column action uses, so an invalid hex collapses
+   * to "no filter" rather than landing as a value that can never match
+   * anything. Setting the same value the deck already has is a no-op.
+   */
+  setColorFilter: (deckId: string, color: string | null) => void;
 
   addDeck: (name: string) => string;
   renameDeck: (deckId: string, name: string) => void;
@@ -324,6 +372,7 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
   pendingSearchOpen: null,
   pendingRefreshIds: new Set<string>(),
   widthByColumn: {},
+  activeColorFilter: {},
 
   hydrate: (snapshot) =>
     set((s) => ({
@@ -427,6 +476,27 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
       return { pendingRefreshIds: next };
     }),
 
+  setColorFilter: (deckId, color) =>
+    set((s) => {
+      // Mirror the column/deck normalizer so a chip that originated from a
+      // column's stored color matches the normalized comparison done in
+      // `getVisibleColumnIds`. Empty/invalid collapses to `null` — same
+      // shape as "All".
+      const normalized = color === null ? null : normalizeColumnColor(color);
+      const current = s.activeColorFilter[deckId] ?? null;
+      if (current === normalized) return s;
+      const next = { ...s.activeColorFilter };
+      if (normalized === null) {
+        // Match the absence-from-map convention used by
+        // `widthByColumn`/`searchByColumn` so the map only carries the
+        // non-default rows.
+        delete next[deckId];
+      } else {
+        next[deckId] = normalized;
+      }
+      return { activeColorFilter: next };
+    }),
+
   addDeck: (name) => {
     const id = nanoid();
     set((s) => ({
@@ -481,6 +551,10 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
       for (const cid of deck.columnIds) delete searchByColumn[cid];
       const widthByColumn = { ...s.widthByColumn };
       for (const cid of deck.columnIds) delete widthByColumn[cid];
+      // Drop this deck's color-filter entry — keyed on deck id, not column
+      // id, so the cleanup is a single delete rather than a per-column scrub.
+      const activeColorFilter = { ...s.activeColorFilter };
+      delete activeColorFilter[deckId];
       const focusedColumnId =
         s.focusedColumnId && deck.columnIds.includes(s.focusedColumnId)
           ? null
@@ -509,6 +583,7 @@ export const useDeckStore = create<DeckState>()((set, get) => ({
         collapsedColumnIds: collapsed,
         searchByColumn,
         widthByColumn,
+        activeColorFilter,
         focusedColumnId,
         pendingSearchOpen,
         pendingRefreshIds,


### PR DESCRIPTION
## What
Add a compact color-label filter pill row above the deck column grid. Operators with tagged columns can single-click to isolate one color group — same ergonomics as GitHub label filters.

## Why
Column color labels (PR #61) and deck color labels (PR #62) let operators visually group columns, but at 15+ columns per deck the tagged columns are still found by scrolling. No way to isolate a color group until now. From repo-actions-2026-06-10.md idea #5 — 11th rung on the per-column UX axis after width, keyboard nav, and refresh-all.

## Changes
- `lib/store/use-deck-store.ts`: added `activeColorFilter: Record<deckId, string | null>` view-state field, `setColorFilter(deckId, color | null)` action, `deleteDeck` scrub. Same lifecycle as `widthByColumn`/`searchByColumn` (view-state only, NOT persisted, NOT exported).
- `lib/store/use-deck-store.ts`: `getVisibleColumnIds` takes an optional `colorFilter` arg and applies it AFTER tab filtering, BEFORE pinned-first partition — composes cleanly with existing filters. Both sides go through `normalizeColumnColor` so case folding can't cause a miss.
- `components/deck/deck-board.tsx`: new filter pill row above the grid — one chip per used color (dot + count) + "All" outlined pill, brand-ring on the active chip, hidden when fewer than 2 distinct colors are in use. `flex-wrap` so it wraps on small screens. A `useEffect` auto-clears the filter when the active color is no longer present in any column. Zero-match placeholder with a "Clear filter" affordance instead of an empty grid.
- `components/deck/deck-view.tsx`: deck-header "Refresh all" button now reads `activeColorFilter[deckId]` and passes it to `getVisibleColumnIds`, so a color-filtered refresh-all only refreshes the visible columns (otherwise filtered-out columns would receive a pending refresh signal they'd never drain, pinning the spinner on forever — same rationale as the tab filter).

## Design constraints honored
- No DB migration, no server action change, no export schema bump (`DECK_EXPORT_VERSION` untouched) — purely view-state.
- Filter is per-deck (sticky during a session across deck switches), not per-tab.
- Pinned columns are NOT exempt from the color filter — pinning is routing (always visible across tabs), color is labeling. An orange-tagged pin survives a "show orange" filter; a blue-tagged pin does not.
- Pill row hidden when `usedColors.length < 2`.

## Test plan
- [ ] Deck with 1 color → filter bar hidden
- [ ] Deck with ≥2 colors → filter bar visible, default "All" active
- [ ] Click a color chip → only matching columns visible, brand-ring on active chip
- [ ] Click "All" → all columns visible again
- [ ] Change the active-filter color on every column → filter auto-clears (no stuck state)
- [ ] Per-deck independent: switching decks preserves each deck's filter state for the session
- [ ] Delete a filtered deck → no orphan entry left in `activeColorFilter`
- [ ] Deck-header "Refresh all" with an active filter → only filtered columns refresh

Could NOT run Next 16 build/typecheck (offline sandbox — same constraint as PRs #49-#68). Verified by reading; ready for CI typecheck on merge.

*Built autonomously by Aeon — from repo-actions-2026-06-10.md idea #5.*
