### PR TITLE
fix(pypi): annotate top-30d map return so the null-filter narrows

### DIFF
--- a/lib/integrations/pypi.ts
+++ b/lib/integrations/pypi.ts
@@ -284,7 +284,7 @@ async function fetchTopMode(
     : new Date().toISOString();
 
   const items: FeedItem<PypiMeta>[] = slice
-    .map((r, idx) => {
+    .map((r, idx): FeedItem<PypiMeta> | null => {
       const name = r.project?.trim();
       if (!name) return null;
       return {
@@ -297,7 +297,7 @@ async function fetchTopMode(
           monthlyDownloads: Math.max(0, r.download_count ?? 0),
           weeklyDownloads: downloads[idx] ?? 0,
         },
-      } satisfies FeedItem<PypiMeta>;
+      };
     })
     .filter((x): x is FeedItem<PypiMeta> => x !== null);
 


### PR DESCRIPTION
## Problem

`lib/integrations/pypi.ts` fails `tsc` (and therefore `next build`, which type-checks) with two cascading errors in the top-30d feed:

- **TS2677** at the `.filter((x): x is FeedItem<PypiMeta> => x !== null)` predicate
- **TS2322** at the `const items: FeedItem<PypiMeta>[] = …` assignment

`FeedItem.url` is optional (`url?: string`), but the feed built each item from an inline object literal closed with `satisfies FeedItem<PypiMeta>`. `satisfies` *preserves* the literal's narrow inferred type (`url: string`, required), which is structurally narrower than `FeedItem<PypiMeta>` — so the `x is FeedItem<PypiMeta>` predicate isn't assignable to the element type, and the null-filter stops narrowing.

This was pre-existing on `main` (untouched by the recent deck PRs); it just isn't caught because the repo has no typecheck/lint CI.

## Fix

Annotate the `.map()` callback's return type as `FeedItem<PypiMeta> | null` — exactly how the sibling `rssItemToFeedItem`/huggingface/bluesky maps already type theirs — and drop the now-redundant `satisfies`. Two-line change.

## Verification

- `npx tsc --noEmit` → exit 0 (full project, previously failed only here)
- `npx eslint lib/integrations/pypi.ts` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)