### PR TITLE
fix: move non-action exports out of "use server" actions.ts so the app builds

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -20,6 +20,15 @@ import {
   WEBHOOK_URL_MAX,
   type WebhookMatch,
 } from "@/lib/columns/webhook";
+// Plain constants + sync validators shared with the client store. They live
+// outside this "use server" file because a "use server" module may only export
+// async functions — see `lib/deck-rules.ts` for the why.
+import {
+  DECK_EXPORT_VERSION,
+  TAB_GROUP_MAX,
+  isAllowedRefreshInterval,
+  normalizeColumnColor,
+} from "@/lib/deck-rules";
 
 export interface Snapshot {
   decks: Record<string, Deck>;
@@ -250,23 +259,6 @@ export async function updateColumnWebhookUrl(
 }
 
 /**
- * Whitelist of refresh-interval cadences (seconds). Anything outside this set
- * is rejected server-side and persisted as NULL (manual-only). Keeping the
- * allowlist short prevents the UI from being used to schedule pathological
- * sub-minute polling that would hammer upstream rate limits.
- */
-export const REFRESH_INTERVAL_OPTIONS = [60, 300, 900, 3600] as const;
-export type RefreshIntervalSeconds = (typeof REFRESH_INTERVAL_OPTIONS)[number];
-
-const REFRESH_INTERVAL_SET = new Set<number>(REFRESH_INTERVAL_OPTIONS);
-
-export function isAllowedRefreshInterval(
-  value: unknown,
-): value is RefreshIntervalSeconds {
-  return typeof value === "number" && REFRESH_INTERVAL_SET.has(value);
-}
-
-/**
  * Persist a column's auto-refresh cadence. Pass `null` to clear (manual-only).
  * Non-allowlisted values are coerced to `null` server-side — never trust the
  * client to enforce the cadence floor.
@@ -308,14 +300,6 @@ export async function updateColumnFilters(
 }
 
 /**
- * Hard cap on a tab-group label. Generous enough for a Title-Case section name
- * but tight enough to keep the tab bar readable and bound storage. Anything
- * longer is truncated server-side rather than rejected — the UI never silently
- * drops a paste.
- */
-export const TAB_GROUP_MAX = 50;
-
-/**
  * Persist a column's tab-group label. Pass an empty string to clear (no group).
  * Whitespace is collapsed to a single space and trimmed so "AI", " AI ", and
  * "AI  " all bucket to the same tab — operators don't have to think about
@@ -347,30 +331,6 @@ export async function updateColumnPinned(
     .update(columns)
     .set({ pinned })
     .where(eq(columns.id, id));
-}
-
-/**
- * Hex-color regex applied to every persisted column color. 6-hex form only
- * (`#rrggbb`); the 3-hex shorthand and named CSS colors are deliberately
- * rejected so the stored representation is canonical — round-tripping a
- * color through export → import → DB always gives the same string back.
- */
-export const COLOR_HEX_RE = /^#[0-9a-fA-F]{6}$/;
-
-/**
- * Normalize an operator-entered color string. Returns the canonical
- * lowercased `#rrggbb` form when valid; `null` when empty after trim or
- * when the input doesn't match the hex pattern. The same normalizer is
- * applied by `updateColumnColor`, `duplicateColumn`, and `importDeck` so a
- * tampered or hand-edited payload can never smuggle anything but a pure
- * 6-hex string into the DB.
- */
-export function normalizeColumnColor(raw: string | null | undefined): string | null {
-  if (raw === null || raw === undefined) return null;
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) return null;
-  if (!COLOR_HEX_RE.test(trimmed)) return null;
-  return trimmed.toLowerCase();
 }
 
 /**
@@ -516,8 +476,6 @@ export async function reorderColumnsInDeck(
     WHERE columns.id = v.id
   `);
 }
-
-export const DECK_EXPORT_VERSION = 1;
 
 const importedColumnSchema = z.object({
   typeId: z.string().min(1).max(128),

--- a/lib/deck-rules.ts
+++ b/lib/deck-rules.ts
@@ -1,0 +1,62 @@
+// Deck/column validation rules shared by the server actions (`app/actions.ts`)
+// and the client store (`lib/store/use-deck-store.ts`).
+//
+// These are plain constants and synchronous helpers — NOT server actions. They
+// used to live in `app/actions.ts`, but that file carries `"use server"`, and
+// a "use server" module may only export async functions. Exporting a const or
+// a sync function from it makes Turbopack reject the whole module ("only async
+// functions are allowed to be exported in a 'use server' file"), which cascades
+// into every importer failing to resolve any export. Hoisting them here keeps
+// `app/actions.ts` exporting nothing but Server Actions, and lets the client
+// import the real values directly instead of through an RPC boundary.
+
+/**
+ * Whitelisted auto-refresh cadences in seconds. Validated server-side so the
+ * client can't schedule pathological sub-minute polling that would hammer
+ * upstream rate limits. Keeping the allowlist short bounds the blast radius.
+ */
+export const REFRESH_INTERVAL_OPTIONS = [60, 300, 900, 3600] as const;
+export type RefreshIntervalSeconds = (typeof REFRESH_INTERVAL_OPTIONS)[number];
+
+const REFRESH_INTERVAL_SET = new Set<number>(REFRESH_INTERVAL_OPTIONS);
+
+export function isAllowedRefreshInterval(
+  value: unknown,
+): value is RefreshIntervalSeconds {
+  return typeof value === "number" && REFRESH_INTERVAL_SET.has(value);
+}
+
+/**
+ * Hard cap on a tab-group label. Generous enough for a Title-Case section name
+ * but tight enough to keep the tab bar readable and bound storage. Anything
+ * longer is truncated server-side rather than rejected — the UI never silently
+ * drops a paste.
+ */
+export const TAB_GROUP_MAX = 50;
+
+/**
+ * Hex-color regex applied to every persisted column/deck color. 6-hex form only
+ * (`#rrggbb`); the 3-hex shorthand and named CSS colors are deliberately
+ * rejected so the stored representation is canonical — round-tripping a
+ * color through export → import → DB always gives the same string back.
+ */
+export const COLOR_HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Normalize an operator-entered color string. Returns the canonical
+ * lowercased `#rrggbb` form when valid; `null` when empty after trim or
+ * when the input doesn't match the hex pattern. The same normalizer is
+ * applied by `updateColumnColor`, `duplicateColumn`, and `importDeck` so a
+ * tampered or hand-edited payload can never smuggle anything but a pure
+ * 6-hex string into the DB.
+ */
+export function normalizeColumnColor(raw: string | null | undefined): string | null {
+  if (raw === null || raw === undefined) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (!COLOR_HEX_RE.test(trimmed)) return null;
+  return trimmed.toLowerCase();
+}
+
+/** Schema version stamped into every exported deck payload. */
+export const DECK_EXPORT_VERSION = 1;

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -29,15 +29,17 @@ import {
   updateColumnTabGroup as serverUpdateTabGroup,
   updateColumnPinned as serverUpdatePinned,
   updateColumnColor as serverUpdateColor,
-  normalizeColumnColor,
   loadDeckSnapshots as serverLoadDeckSnapshots,
   restoreDeckSnapshot as serverRestoreDeckSnapshot,
-  isAllowedRefreshInterval,
-  TAB_GROUP_MAX,
   type DeckSnapshotMeta,
   type ImportedDeckResult,
   type Snapshot,
 } from "@/app/actions";
+import {
+  isAllowedRefreshInterval,
+  normalizeColumnColor,
+  TAB_GROUP_MAX,
+} from "@/lib/deck-rules";
 
 // Sentinel for the implicit "All" tab — used when a deck has tab groups
 // configured but the operator wants to see every column at once. Exported so


### PR DESCRIPTION
## What

`main` does not build. `next build` fails with 62 errors, all cascading from a single root cause in `app/actions.ts`.

That file carries the `"use server"` directive, and Next/Turbopack permits a `"use server"` module to export **only async functions**. But it also exported six plain values:

- `REFRESH_INTERVAL_OPTIONS` (const)
- `isAllowedRefreshInterval` (sync function)
- `TAB_GROUP_MAX` (const)
- `COLOR_HEX_RE` (const)
- `normalizeColumnColor` (sync function)
- `DECK_EXPORT_VERSION` (const)

Turbopack rejects these with *"Only async functions are allowed to be exported in a 'use server' file"*, which makes the entire module fail to load — so every importer then errors with *"The module has no exports at all"*, taking down the whole app build.

```
./app/actions.ts:316:1
Only async functions are allowed to be exported in a "use server" file.
> 316 | export const TAB_GROUP_MAX = 50;
...
Error: Turbopack build failed with 62 errors
```

`tsc` doesn't enforce the `"use server"` export rule — only `next build` does — which is how this slipped onto a green-looking `main`.

## Why

A dead production build blocks every contributor and any deploy. This is the highest-priority thing to unblock on the repo right now.

## Changes

- **`lib/deck-rules.ts`** (new): a plain (non-`"use server"`) module holding the shared deck/column validation rules — `REFRESH_INTERVAL_OPTIONS` + `RefreshIntervalSeconds`, `isAllowedRefreshInterval`, `TAB_GROUP_MAX`, `COLOR_HEX_RE`, `normalizeColumnColor`, `DECK_EXPORT_VERSION`. Code and doc-comments moved verbatim — no behavior change.
- **`app/actions.ts`**: removed those declarations; imports them back from `lib/deck-rules` for internal use. The file now exports only Server Actions (plus type-only exports, which `"use server"` permits).
- **`lib/store/use-deck-store.ts`**: the client store now imports `isAllowedRefreshInterval` / `normalizeColumnColor` / `TAB_GROUP_MAX` from `lib/deck-rules` instead of through the `"use server"` boundary — it gets the real synchronous values, which is what it was always calling them as.

The existing local copies of these constants in `configure-column-dialog.tsx` / `deck-color-dialog.tsx` are left untouched to keep the diff focused on the build fix.

## Verification

- `next build` — ✅ compiles + generates all 7 routes
- `tsc --noEmit` — ✅ clean
- `eslint` — ✅ clean

---
*Built autonomously by Aeon*
