### PR TITLE
feat: add Dexscreener DEX-pair column

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm + PyPI + crates.io packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions / Discussions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, CoinGecko crypto trending + prices, DeFiLlama TVL leaderboard, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm + PyPI + crates.io packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions / Discussions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, CoinGecko crypto trending + prices, DeFiLlama TVL leaderboard, Dexscreener DEX pair search + watchlist, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 47 column types out of the box — social feeds, news, GitHub (including CI runs and Discussions), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, CoinGecko prices, DeFiLlama TVL, Chinese hot boards.
+- 48 column types out of the box — social feeds, news, GitHub (including CI runs and Discussions), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, CoinGecko prices, DeFiLlama TVL, Dexscreener DEX pairs, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - Shape the signal per column — highlight items with alert keywords, or filter the feed to "show only" / "hide" by keyword so a firehose column shows just what matters.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
@@ -42,7 +42,7 @@ git clone https://github.com/aaronjmars/minitor.git && cd minitor
 
 The launcher checks Node, picks the right package manager (npm / pnpm / yarn / bun based on lockfile), installs deps, copies `.env.example` → `.env.local` if missing, runs DB migrations against PGlite, and starts the dev server at `http://localhost:3000`. Re-running it just starts the server.
 
-For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, Product Hunt, npm, PyPI, crates.io, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket, CoinGecko, DeFiLlama) work out of the box with no keys.
+For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https://console.x.ai/)** into `XAI_API_KEY` in `.env.local`. Keyless columns (Reddit, HN, Lobsters, Stack Overflow, DEV.to, Product Hunt, npm, PyPI, crates.io, Hugging Face, arXiv, Bluesky, Mastodon, RSS, Google News, Bing, GitHub, China Hot, YouTube channel/playlist, app reviews, wallet transactions, Polymarket, CoinGecko, DeFiLlama, Dexscreener) work out of the box with no keys.
 
 **Other launcher subcommands:**
 
@@ -65,7 +65,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 | **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |
 | **Mention monitors** (2) | `facebook`, `instagram` |
-| **Apps & on-chain** (6) | `apple-reviews`, `play-reviews`, `wallet-tx`, `polymarket`, `coingecko`, `defillama` |
+| **Apps & on-chain** (7) | `apple-reviews`, `play-reviews`, `wallet-tx`, `polymarket`, `coingecko`, `defillama`, `dexscreener` |
 | **China hot boards** (6) | `weibo-hot`, `zhihu-hot`, `douyin-hot`, `bilibili-hot`, `toutiao`, `baidu-hot` |
 
 Full plugin manifest: [`lib/columns/plugins/manifest.ts`](lib/columns/plugins/manifest.ts). Add a new source by copying [`lib/columns/plugins/_template/`](lib/columns/plugins/_template/) — see [`lib/columns/README.md`](lib/columns/README.md) for the full contract.

--- a/lib/columns/plugins/dexscreener/client.tsx
+++ b/lib/columns/plugins/dexscreener/client.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { ArrowDownRight, ArrowUpRight, CandlestickChart } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { formatCompactCount } from "@/lib/utils";
+import { meta, type DexscreenerConfig, type DexscreenerMeta } from "./plugin";
+
+const ACCENT = "#a45cff";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<DexscreenerConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label>Mode</Label>
+        <Select
+          value={value.mode}
+          onValueChange={(v) =>
+            onChange({ ...value, mode: v as DexscreenerConfig["mode"] })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="search">Search — symbol, name, or address</SelectItem>
+            <SelectItem value="watchlist">Watchlist — contract addresses</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          <strong>Search</strong> queries every chain at once and shows the most
+          active matching pairs. <strong>Watchlist</strong> tracks specific token
+          contracts and lists every pair they trade in.
+        </p>
+      </div>
+      {value.mode === "search" ? (
+        <div className="grid gap-1.5">
+          <Label htmlFor="dex-query">Query</Label>
+          <Input
+            id="dex-query"
+            placeholder="AEON, wif, 0xbf8e…"
+            value={value.query}
+            onChange={(e) => onChange({ ...value, query: e.target.value })}
+          />
+          <p className="text-xs text-muted-foreground">
+            A ticker (<code>AEON</code>), a token name, or a contract address.
+            Pairs are ranked by 24h volume.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-1.5">
+          <Label htmlFor="dex-watchlist">Contract addresses</Label>
+          <Input
+            id="dex-watchlist"
+            placeholder="0xbf8e…, 0x4200…"
+            value={value.watchlist}
+            onChange={(e) => onChange({ ...value, watchlist: e.target.value })}
+          />
+          <p className="text-xs text-muted-foreground">
+            Comma-, semicolon-, or space-separated token contract addresses (up
+            to 30). Every pair across every chain those tokens trade in is shown.
+          </p>
+        </div>
+      )}
+      <p className="text-xs text-muted-foreground">
+        Keyless — no API key required.
+      </p>
+    </div>
+  );
+}
+
+function formatPriceUsd(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "$0";
+  if (n >= 1000) return `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+  if (n >= 1) return `$${n.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
+  if (n >= 0.01) return `$${n.toFixed(4)}`;
+  // Sub-cent meme-coin prices need more significant figures — drop trailing
+  // zeros so $0.0000234 doesn't render as $0.00002340.
+  return `$${n.toPrecision(3).replace(/0+$/, "").replace(/\.$/, "")}`;
+}
+
+function ItemRenderer({ item }: ItemRendererProps<DexscreenerMeta>) {
+  const m = item.meta;
+  const pair = item.content;
+  const priceUsd = m?.priceUsd ?? 0;
+  const pct = m?.priceChange24h ?? 0;
+  const volume = m?.volume24hUsd ?? 0;
+  const liquidity = m?.liquidityUsd ?? 0;
+  const chainId = m?.chainId ?? "";
+  const dexId = m?.dexId ?? "";
+  const baseName = m?.baseName;
+  const imageUrl = m?.imageUrl;
+  const txns = m?.txns24h;
+  const up = pct >= 0;
+
+  return (
+    <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(164, 92, 255, 0.18)" }}
+        >
+          <span
+            className="grid size-3.5 place-items-center rounded-[3px] text-white"
+            style={{ backgroundColor: ACCENT }}
+          >
+            <CandlestickChart className="size-2.5" strokeWidth={3} />
+          </span>
+          Dexscreener
+        </span>
+        {chainId && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="capitalize text-muted-foreground/90">{chainId}</span>
+          </>
+        )}
+        {dexId && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="capitalize text-muted-foreground/90">{dexId}</span>
+          </>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-1 flex items-center gap-2"
+      >
+        {imageUrl && (
+          <>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={imageUrl}
+              alt={m?.baseSymbol ?? pair}
+              width={20}
+              height={20}
+              className="size-5 rounded-full ring-1 ring-border/60"
+              loading="lazy"
+            />
+          </>
+        )}
+        <h3
+          className="font-mono text-[14px] leading-[1.25] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand)]"
+          style={{ letterSpacing: "-0.005em" }}
+        >
+          {pair}
+        </h3>
+        {baseName && (
+          <span className="truncate text-[11px] text-muted-foreground">
+            {baseName}
+          </span>
+        )}
+      </a>
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11.5px] text-muted-foreground">
+        <span className="tabular-nums text-foreground/90">
+          {formatPriceUsd(priceUsd)}
+        </span>
+        <span
+          className="inline-flex items-center gap-0.5 tabular-nums"
+          style={{ color: up ? "#10b981" : "#ef4444" }}
+        >
+          {up ? (
+            <ArrowUpRight className="size-3" />
+          ) : (
+            <ArrowDownRight className="size-3" />
+          )}
+          {pct.toFixed(2)}%
+        </span>
+        {liquidity > 0 && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span>
+              Liq{" "}
+              <span className="tabular-nums">${formatCompactCount(liquidity)}</span>
+            </span>
+          </>
+        )}
+        {volume > 0 && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span>
+              Vol{" "}
+              <span className="tabular-nums">${formatCompactCount(volume)}</span>
+            </span>
+          </>
+        )}
+        {txns && txns.buys + txns.sells > 0 && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums">
+              <span style={{ color: "#10b981" }}>{formatCompactCount(txns.buys)}</span>
+              <span className="text-muted-foreground/50">/</span>
+              <span style={{ color: "#ef4444" }}>{formatCompactCount(txns.sells)}</span>
+            </span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const column = defineColumnUI<DexscreenerConfig, DexscreenerMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/dexscreener/plugin.ts
+++ b/lib/columns/plugins/dexscreener/plugin.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { CandlestickChart } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  mode: z.enum(["search", "watchlist"]).default("search"),
+  query: z.string().default(""),
+  watchlist: z.string().default(""),
+});
+
+export type DexscreenerConfig = z.infer<typeof schema>;
+
+export interface DexscreenerMeta {
+  chainId: string;
+  dexId: string;
+  baseSymbol: string;
+  quoteSymbol: string;
+  baseName?: string;
+  imageUrl?: string;
+  priceUsd: number;
+  priceChange24h: number;
+  volume24hUsd: number;
+  liquidityUsd: number;
+  fdvUsd?: number;
+  marketCapUsd?: number;
+  txns24h?: { buys: number; sells: number };
+}
+
+const MODE_LABELS: Record<DexscreenerConfig["mode"], string> = {
+  search: "Search",
+  watchlist: "Watchlist",
+};
+
+export const meta: PluginMeta<DexscreenerConfig, DexscreenerMeta> = {
+  id: "dexscreener",
+  label: "Dexscreener",
+  description:
+    "Live DEX pair feed from Dexscreener — search any token by symbol, name, or contract address across every chain, or watch a list of contract addresses. Each row shows price, 24h change, volume, liquidity, and buy/sell flow. Keyless.",
+  icon: CandlestickChart,
+  // Dexscreener brand violet — distinct from the existing on-chain cluster,
+  // which is otherwise all blues + one green: wallet-tx #627eea (Ethereum),
+  // polymarket #2D9CDB (electric blue), defillama #445ed0 (purple-blue),
+  // coingecko #8DC647 (green). A brighter violet sits clearly apart from the
+  // blue trio while staying in the crypto colour family.
+  accent: "#a45cff",
+  category: "blockchain",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    if (c.mode === "watchlist") {
+      const first = c.watchlist
+        .split(/[\s,;]+/)
+        .map((s) => s.trim())
+        .find(Boolean);
+      return first
+        ? `Dexscreener · ${first.slice(0, 10)}…`
+        : "Dexscreener · Watchlist";
+    }
+    const q = c.query.trim();
+    return q ? `Dexscreener · ${q}` : `Dexscreener · ${MODE_LABELS[c.mode]}`;
+  },
+  capabilities: {
+    paginated: true,
+    requiresEnv: [],
+    rateLimitHint: "Keyless. Dexscreener's public API allows ~300 calls/min.",
+  },
+};

--- a/lib/columns/plugins/dexscreener/server.ts
+++ b/lib/columns/plugins/dexscreener/server.ts
@@ -1,0 +1,29 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchDexscreenerItems } from "@/lib/integrations/dexscreener";
+import { sliceForPage } from "@/lib/columns/paginate";
+import { meta, type DexscreenerConfig, type DexscreenerMeta } from "./plugin";
+
+// Dexscreener's search/tokens endpoints return a full list in one shot (no
+// native cursor), so we fetch once and hand out pages via the shared
+// slice-paginator — same approach as the other list-style crypto columns.
+const fetch: ServerFetcher<DexscreenerConfig, DexscreenerMeta> = async (
+  config,
+  cursor,
+) => {
+  const items = await fetchDexscreenerItems(
+    config.mode,
+    config.query,
+    config.watchlist,
+  );
+  return sliceForPage(items, cursor);
+};
+
+export const server = defineColumnServer<DexscreenerConfig, DexscreenerMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -51,6 +51,7 @@ import { meta as producthunt } from "./producthunt/plugin";
 import { meta as coingecko } from "./coingecko/plugin";
 import { meta as githubDiscussions } from "./github-discussions/plugin";
 import { meta as defillama } from "./defillama/plugin";
+import { meta as dexscreener } from "./dexscreener/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -100,6 +101,7 @@ export const PLUGIN_METAS = [
   coingecko,
   githubDiscussions,
   defillama,
+  dexscreener,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -59,6 +59,7 @@ import { column as producthunt } from "@/lib/columns/plugins/producthunt/client"
 import { column as coingecko } from "@/lib/columns/plugins/coingecko/client";
 import { column as githubDiscussions } from "@/lib/columns/plugins/github-discussions/client";
 import { column as defillama } from "@/lib/columns/plugins/defillama/client";
+import { column as dexscreener } from "@/lib/columns/plugins/dexscreener/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -111,6 +112,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   coingecko,
   "github-discussions": githubDiscussions,
   defillama,
+  dexscreener,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -55,6 +55,7 @@ import { server as producthunt } from "@/lib/columns/plugins/producthunt/server"
 import { server as coingecko } from "@/lib/columns/plugins/coingecko/server";
 import { server as githubDiscussions } from "@/lib/columns/plugins/github-discussions/server";
 import { server as defillama } from "@/lib/columns/plugins/defillama/server";
+import { server as dexscreener } from "@/lib/columns/plugins/dexscreener/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -104,6 +105,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   coingecko,
   "github-discussions": githubDiscussions,
   defillama,
+  dexscreener,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/deck-templates.ts
+++ b/lib/deck-templates.ts
@@ -149,7 +149,7 @@ const baseEcosystem: DeckTemplate = {
   name: "Base Ecosystem",
   tagline: "Aeon repos + AEON price + DeFiLlama + X",
   description:
-    "Tracks the Aeon project + the Base on-chain stack. Two GitHub-stars columns for aeon and aeon-agent, a CoinGecko watchlist with $AEON, the DeFiLlama protocol leaderboard, and the X feed for @aeonframework.",
+    "Tracks the Aeon project + the Base on-chain stack. Two GitHub-stars columns for aeon and aeon-agent, a CoinGecko watchlist with $AEON, a Dexscreener feed of every $AEON pair, the DeFiLlama protocol leaderboard, and the X feed for @aeonframework.",
   accent: "#445ed0",
   iconName: "Layers",
   payload: {
@@ -170,6 +170,14 @@ const baseEcosystem: DeckTemplate = {
         typeId: "coingecko",
         title: "CoinGecko · Watchlist",
         config: { mode: "watchlist", watchlist: "aeon" },
+      },
+      {
+        typeId: "dexscreener",
+        title: "Dexscreener · $AEON",
+        config: {
+          mode: "watchlist",
+          watchlist: "0xbf8e8f0e8866a7052f948c16508644347c57aba3",
+        },
       },
       {
         typeId: "defillama",

--- a/lib/integrations/dexscreener.ts
+++ b/lib/integrations/dexscreener.ts
@@ -1,0 +1,186 @@
+import type { FeedItem } from "@/lib/columns/types";
+
+// Dexscreener public API — keyless for the two endpoints this column uses.
+// Dexscreener indexes DEX trading pairs across every major chain (Ethereum,
+// Base, Solana, BSC, …) and is the de-facto screen for spotting on-chain
+// price action the moment a pair starts moving — which is exactly the kind of
+// live signal a monitor column is for.
+//
+// Endpoints used (both documented at https://docs.dexscreener.com):
+//   - GET /latest/dex/search?q=<query>
+//       Free-text search across pairs by token symbol, name, or address.
+//       Returns `{ pairs: Pair[] }`. We sort the result by 24h volume so the
+//       most active pair for a query surfaces first.
+//   - GET /latest/dex/tokens/<addr1>,<addr2>,…
+//       Every indexed pair for the given token contract addresses (up to 30
+//       per call). Same `{ pairs: Pair[] }` shape — this powers watchlist mode.
+//
+// Both endpoints are advertised at 300 requests/min, keyless. Prices arrive as
+// strings (`priceUsd: "0.0000234"`); `num()` coerces them defensively.
+
+const BASE = "https://api.dexscreener.com/latest/dex";
+
+// Dexscreener caps the tokens endpoint at 30 comma-separated addresses.
+const MAX_WATCHLIST = 30;
+// A generous single-fetch batch the server then slice-paginates. Search can
+// return hundreds of pairs for a popular symbol; cap so a column stays sane.
+const MAX_ITEMS = 60;
+
+export type DexscreenerMode = "search" | "watchlist";
+
+export interface DexscreenerMeta {
+  chainId: string;
+  dexId: string;
+  baseSymbol: string;
+  quoteSymbol: string;
+  baseName?: string;
+  imageUrl?: string;
+  priceUsd: number;
+  priceChange24h: number;
+  volume24hUsd: number;
+  liquidityUsd: number;
+  fdvUsd?: number;
+  marketCapUsd?: number;
+  txns24h?: { buys: number; sells: number };
+}
+
+interface DexPair {
+  chainId?: string;
+  dexId?: string;
+  url?: string;
+  pairAddress?: string;
+  baseToken?: { address?: string; name?: string; symbol?: string };
+  quoteToken?: { address?: string; name?: string; symbol?: string };
+  priceUsd?: string | number;
+  txns?: { h24?: { buys?: number; sells?: number } };
+  priceChange?: { h24?: number };
+  volume?: { h24?: number };
+  liquidity?: { usd?: number };
+  fdv?: number;
+  marketCap?: number;
+  pairCreatedAt?: number;
+  info?: { imageUrl?: string };
+}
+
+interface PairsResponse {
+  pairs?: DexPair[] | null;
+}
+
+function num(v: unknown, fallback = 0): number {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") {
+    // priceUsd / priceChange can arrive as plain numeric strings. Strip any
+    // stray formatting before Number() so a "$0.0023" never collapses to 0.
+    const cleaned = v.replace(/[^0-9.\-eE]/g, "");
+    const n = Number(cleaned);
+    if (Number.isFinite(n)) return n;
+  }
+  return fallback;
+}
+
+function mapPair(p: DexPair): FeedItem<DexscreenerMeta> | null {
+  const chainId = p.chainId?.trim();
+  const pairAddress = p.pairAddress?.trim();
+  const baseSymbol = (p.baseToken?.symbol ?? "").toUpperCase();
+  const quoteSymbol = (p.quoteToken?.symbol ?? "").toUpperCase();
+  // A pair with no chain/address or no symbols is unrenderable and unlinkable.
+  if (!chainId || !pairAddress || !baseSymbol || !quoteSymbol) return null;
+  const priceUsd = num(p.priceUsd);
+  if (priceUsd <= 0) return null;
+
+  // pairCreatedAt is the pair's age, the most informative timestamp here — a
+  // brand-new pair surfacing in a search is itself a signal. Fall back to "now"
+  // when upstream omits it so the relative-time pill stays sensible.
+  const createdMs =
+    typeof p.pairCreatedAt === "number" && p.pairCreatedAt > 0
+      ? p.pairCreatedAt
+      : Date.now();
+
+  const buys = p.txns?.h24?.buys;
+  const sells = p.txns?.h24?.sells;
+
+  return {
+    id: `dexscreener:${chainId}:${pairAddress}`,
+    author: { name: `${baseSymbol}/${quoteSymbol}`, handle: baseSymbol },
+    content: `${baseSymbol}/${quoteSymbol}`,
+    url:
+      p.url ||
+      `https://dexscreener.com/${encodeURIComponent(chainId)}/${encodeURIComponent(pairAddress)}`,
+    createdAt: new Date(createdMs).toISOString(),
+    meta: {
+      chainId,
+      dexId: (p.dexId ?? "").trim(),
+      baseSymbol,
+      quoteSymbol,
+      baseName: p.baseToken?.name?.trim() || undefined,
+      imageUrl: p.info?.imageUrl || undefined,
+      priceUsd,
+      priceChange24h: num(p.priceChange?.h24),
+      volume24hUsd: num(p.volume?.h24),
+      liquidityUsd: num(p.liquidity?.usd),
+      fdvUsd: typeof p.fdv === "number" ? p.fdv : undefined,
+      marketCapUsd: typeof p.marketCap === "number" ? p.marketCap : undefined,
+      txns24h:
+        typeof buys === "number" || typeof sells === "number"
+          ? { buys: num(buys), sells: num(sells) }
+          : undefined,
+    },
+  };
+}
+
+async function fetchPairs(url: string): Promise<DexPair[]> {
+  const res = await fetch(url, {
+    headers: {
+      accept: "application/json",
+      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(
+      `dexscreener ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const json = (await res.json()) as PairsResponse;
+  return Array.isArray(json.pairs) ? json.pairs : [];
+}
+
+function mapAndSort(pairs: DexPair[]): FeedItem<DexscreenerMeta>[] {
+  return pairs
+    .map(mapPair)
+    .filter((a): a is FeedItem<DexscreenerMeta> => a !== null)
+    // Highest 24h volume first — the most active pair for a token is the one
+    // worth watching, and it dedupes the noise of dead micro-pools.
+    .sort((a, b) => (b.meta?.volume24hUsd ?? 0) - (a.meta?.volume24hUsd ?? 0))
+    .slice(0, MAX_ITEMS);
+}
+
+function parseAddresses(raw: string): string[] {
+  return Array.from(
+    new Set(
+      raw
+        .split(/[\s,;]+/)
+        .map((s) => s.trim())
+        .filter(Boolean),
+    ),
+  ).slice(0, MAX_WATCHLIST);
+}
+
+export async function fetchDexscreenerItems(
+  mode: DexscreenerMode,
+  query: string,
+  watchlist: string,
+): Promise<FeedItem<DexscreenerMeta>[]> {
+  if (mode === "watchlist") {
+    const addresses = parseAddresses(watchlist);
+    if (addresses.length === 0) return [];
+    const url = `${BASE}/tokens/${addresses.map(encodeURIComponent).join(",")}`;
+    return mapAndSort(await fetchPairs(url));
+  }
+
+  // mode === "search"
+  const q = query.trim();
+  if (!q) return [];
+  const url = `${BASE}/search?q=${encodeURIComponent(q)}`;
+  return mapAndSort(await fetchPairs(url));
+}


### PR DESCRIPTION
## What
Adds a **Dexscreener** column type — the 48th source. It feeds live DEX trading-pair data into a deck two ways:

- **Search** — free-text query by token symbol, name, or contract address across every chain; results ranked by 24h volume so the most active pair surfaces first.
- **Watchlist** — a list of token contract addresses (up to 30); shows every pair those tokens trade in.

Each row renders the pair (`AEON/WETH`), chain + DEX, price, 24h % change, liquidity, 24h volume, and the buy/sell transaction split — the at-a-glance read you'd otherwise open dexscreener.com for.

## Why
minitor already has the price + narrative layer (CoinGecko, DeFiLlama, on-chain wallet activity) but no DEX-level pair view — the screen people actually watch when a token starts moving on-chain. Dexscreener is the de-facto tool for that, and its API is keyless, so it slots in with zero new secrets. This was the queued fast-follow to the build fix in #71, now that `main` compiles again.

## Changes
- `lib/integrations/dexscreener.ts` (new): keyless client for Dexscreener's `/latest/dex/search` and `/latest/dex/tokens/{addrs}` endpoints. Maps the pair payload to `FeedItem`s, coerces string prices defensively, sorts by 24h volume, and caps the batch. Field mapping verified against a live API response.
- `lib/columns/plugins/dexscreener/{plugin,server,client}.tsx` (new): the standard 3-file plugin trio. `server.ts` uses the shared `sliceForPage` helper (Dexscreener returns a full list, no native cursor), matching the other list-style crypto columns.
- `lib/columns/plugins/manifest.ts`, `registry.ts`, `server-registry.ts`: registered the plugin in all three aggregators (the server-registry parity check enforces this at module init).
- `lib/deck-templates.ts`: added a `Dexscreener · $AEON` watchlist column to the **Base Ecosystem** starter deck, alongside its existing CoinGecko/$AEON column.
- `README.md`: bumped the column count 47 → 48 and added Dexscreener to the catalog table, the keyless-sources list, and the feature blurb.

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint` on all changed files — clean
- `npm run build` (`next build`, Turbopack) — compiled, TypeScript passed, all 7 routes generated. (Per the #71 lesson, a real build is the only check that catches the `"use server"`/registry-parity class of errors.)
- Live API call against the $AEON contract confirms the exact field shapes the integration reads (`priceUsd` as string, `txns.h24.{buys,sells}`, `volume.h24`, `liquidity.usd`, `pairCreatedAt`, `info.imageUrl`).

## New column accent
`#a45cff` (violet) — picked to sit clearly apart from the existing on-chain cluster (wallet-tx `#627eea`, polymarket `#2D9CDB`, defillama `#445ed0`, coingecko `#8DC647`).

---
*Built autonomously by Aeon*
