### PR TITLE
refactor: codebase cleanup — consolidate types, dedupe, prune dead code

### DIFF
--- a/CIRCULAR_DEPS_ASSESSMENT.md
+++ b/CIRCULAR_DEPS_ASSESSMENT.md
@@ -1,0 +1,123 @@
+# Circular Dependencies Assessment (Dimension #4)
+
+**Phase:** Assessment (read-only). No source files were modified.
+**Date:** 2026-06-14
+**Verdict:** **No circular dependencies exist in the codebase.** Three independent
+methods agree on zero cycles. There is no work to do here, and — importantly —
+no false cycle to "fix". This document records the evidence so a later phase does
+not waste effort re-deriving it, and flags the one structural invariant worth
+protecting.
+
+---
+
+## 1. Method (and why the result is trustworthy)
+
+The task warns that the `@/*` alias must resolve or cycles routed through aliased
+imports stay invisible. I verified resolution works and cross-checked with a
+second resolver and a hand-rolled SCC pass.
+
+### 1a. madge via tsconfig alias (`@/* -> ./*`)
+```
+npx --yes madge@latest --circular --extensions ts,tsx --ts-config tsconfig.json --warning .
+→ Processed 243 files (4 warnings)
+→ ✔ No circular dependency found!
+→ Skipped 4 files: server-only, tailwindcss, tw-animate-css, shadcn/tailwind.css
+```
+The 4 skipped files are **external packages / CSS**, not aliased internal modules.
+Alias resolution provably works: dumping the JSON graph shows
+`lib/columns/registry.ts` (which imports only `@/lib/...` paths) correctly
+resolves to `lib/columns/plugins/manifest.ts` and `lib/columns/types.ts`, and
+**no graph key starts with `@`** (i.e. every alias was rewritten to a real path).
+The original "4 unresolved-import warnings" from a naive run are these same
+external packages — they were never aliased imports and cannot hide an internal
+cycle.
+
+### 1b. madge via webpack alias resolver (independent cross-check)
+A `webpackConfig` with `alias: { '@': <repo root> }` produced the same result:
+```
+→ ✔ No circular dependency found!
+→ Skipped 11 files: zod, server-only, @neondatabase/serverless,
+  @electric-sql/pglite, date-fns, tailwindcss, tw-animate-css,
+  shadcn/tailwind.css, next-themes, class-variance-authority, cmdk
+```
+All 11 skips are `node_modules` packages — external, cannot form an internal cycle.
+
+### 1c. Independent Tarjan SCC pass on the full alias-resolved graph
+Exported the complete graph (`madge --json`, 243 nodes / 925 edges, all `@/`
+aliases resolved) and ran Tarjan's strongly-connected-components algorithm:
+```
+SCCs with >1 node (true cycles): 0
+Self-loops (file importing itself): 0
+```
+
+### Coverage notes
+- **Type-only imports are included.** madge's detective captured `import type`
+  edges (verified: `registry.ts -> types.ts` is a type-only import and appears in
+  the graph). So even type-level cycles — the kind `isolatedModules` /
+  `verbatimModuleSyntax` care about — would have surfaced. None exist.
+- **No barrel files.** There are zero `index.ts` / `index.tsx` re-export barrels
+  under `lib/`, `app/`, `components/`, `hooks/`, so there is no barrel
+  mis-resolution that could mask a cycle.
+- **No dynamic imports.** `grep` for `import(` across the source tree returns
+  nothing — every internal edge is a static `import`, the easiest case to analyze
+  exhaustively.
+
+---
+
+## 2. Why the predicted hotspots are clean (with refs)
+
+The task anticipated two classic cycle shapes. Both are structurally impossible
+as the code stands:
+
+### `types <-> registry` — does not exist
+- `lib/columns/types.ts` imports **zero internal modules**. Its only imports are
+  external type packages (`lib/columns/types.ts:1-3`: `react`, `lucide-react`,
+  `zod`). It is a pure leaf/sink, imported by **192 files** and importing none.
+  This is exactly the discipline that kills the types↔registry cycle.
+- The plugin layering is strictly one-directional:
+  `plugin.ts` (pure meta) → `lib/columns/plugins/manifest.ts` →
+  `lib/columns/registry.ts` (`registry.ts:13`) and
+  `lib/columns/server-registry.ts` (`server-registry.ts:9`). No plugin file
+  imports a registry; the registries import the manifest, the manifest imports
+  the plugin metas. No back-edges.
+
+### `store <-> components` — does not exist
+- `lib/store/use-deck-store.ts` imports 6 modules
+  (`app/actions.ts`, `lib/columns/api-client.ts`, `lib/columns/constants.ts`,
+  `lib/columns/registry.ts`, `lib/columns/types.ts`, `lib/deck-rules.ts`) and
+  **imports zero `components/` files**, while being imported by 14 components.
+  Strictly one-directional (data flows up, never back down into the store).
+- The adjacent `store -> actions -> store` risk is also clear:
+  `app/actions.ts` imports only `lib/columns/{constants,keyword-match,types,webhook}`,
+  `lib/db/{client,schema}`, `lib/deck-rules.ts`, `lib/env-keys.ts` — **it does not
+  import the store**.
+- `lib/deck-rules.ts` and `lib/columns/api-client.ts` are leaves
+  (`api-client.ts` imports only the `types.ts` leaf), so neither can close a loop.
+
+### Parity-check architecture is intact (and is not a cycle)
+The three-file parity system (`manifest.ts` ⟶ `registry.ts:119-123`,
+`server-registry.ts:115-128`) is a fan-in, not a cycle: both registries depend on
+the manifest, the manifest depends on plugin metas, and nothing depends back on
+the registries except leaf consumers (UI components, the API route). Do not
+mistake the static-key registration for a dependency loop.
+
+---
+
+## 3. Concrete problems found
+
+**None.** There are no circular dependencies, no self-loops, no type-only cycles,
+and no near-cycles (no module pair that is one edge away from forming a loop in
+the hotspots examined). The dependency graph is a clean DAG.
+
+---
+
+## 4. Prioritized recommendations
+
+| # | Recommendation | Confidence |
+|---|----------------|-----------|
+| 1 | **Take no action.** No cycle exists; there is nothing to untangle. Any "fix" here would be a no-op at best or a behavior-changing edit at worst. | **High** |
+| 2 | **Preserve the `types.ts`-is-a-leaf invariant.** The absence of the types↔registry cycle rests entirely on `lib/columns/types.ts` importing zero internal modules. A future change that makes `types.ts` import a runtime/registry module would likely introduce the first cycle. Worth a one-line comment or a lint guard, but this is optional hardening, not a defect. | **Medium** |
+| 3 | **(Optional) Add a CI cycle guard.** A `madge --circular --ts-config tsconfig.json .` (or `dpdm`) check in CI would lock in the current clean state cheaply. Not required to fix anything today. | **Low** |
+
+No `high`-confidence *change* is recommended because the only verified-safe
+conclusion is that no change is needed.

--- a/DEDUPE_ASSESSMENT.md
+++ b/DEDUPE_ASSESSMENT.md
@@ -1,186 +1,88 @@
-# Dedupe Assessment
+# DEDUPE_ASSESSMENT — Dimension #1: Deduplicate & consolidate (DRY where it reduces complexity)
 
-## HIGH confidence (implemented)
+Phase: ASSESSMENT (read-only). No source files were modified. `npx tsc --noEmit` was confirmed green before and is untouched.
 
-### 1. `compact()` number-formatter duplicated 10x
-Identical (or nearly identical) `compact(n: number)` body in:
-- `lib/columns/plugins/hacker-news/client.tsx:21-26`
-- `lib/columns/plugins/youtube/client.tsx:21-28` (adds a B branch)
-- `lib/columns/plugins/farcaster/client.tsx:15-20`
-- `lib/columns/plugins/github-trending/client.tsx:21-26`
-- `lib/columns/plugins/reddit/client.tsx:21-26`
-- `lib/columns/plugins/github-issues/client.tsx:19-24`
-- `lib/columns/plugins/github-prs/client.tsx:27-32`
-- `lib/columns/plugins/github-search/client.tsx:30-35`
-- `lib/columns/shared/tweet-renderer.tsx:19-25` (uses `K` upper-case)
-- `components/sidebar-01/nav-stats.tsx:6-10` (drops `Math.abs`)
+## Already done (verified, do NOT re-recommend)
+A prior dedup pass already landed and was re-verified during this assessment:
+- `formatCompactCount` lives in `lib/utils.ts:8` and is used ~78×; **zero** local `compact()` remain in plugins/shared/sidebar.
+- `identiconUrl` is in `lib/utils.ts:17`; **zero** inline `api.dicebear.com/9.x/identicon` URLs remain outside it.
+- `truncateText` is in `lib/utils.ts:21` (5 import sites).
+This assessment covers the **next layer** the prior pass did not touch.
 
-Eight of the ten are byte-for-byte identical. The other two (YouTube B-branch,
-sidebar `Math.abs`) are tiny supersets of the same idea — engagement counts are
-non-negative anyway. Promoting one canonical `formatCompactCount` to
-`lib/utils.ts` removes ~70 lines and makes future tweaks (locale-aware
-formatting, threshold) one-touch.
+## Current state — what's already DRY (sets the bar)
+- **Date formatting is fully centralized** via `components/relative-time.tsx`: 32 client.tsx use `RelativeTime`; **zero** local date formatters.
+- **`lib/columns/plugins/_newsnow/renderer.tsx`** is the model abstraction: `makeNewsNowItemRenderer({icon,accent,badgeLabel})` + `NewsNowConfigHint`, consumed by 6 hot-board plugins whose client.tsx are ~30 trivial lines each. **This is the template for the fixes below.**
+- **`lib/columns/shared/`** has `LinkItem` (7 plugins) and `TweetItem` (2 plugins).
+- **`lib/columns/paginate.ts`** (`pageFromCursor`/`sliceForPage`) is shared by 24 server fetchers.
+- **`lib/deck-rules.ts`** already exports the canonical refresh/tab-group/color constants; `app/actions.ts` + `use-deck-store.ts` import them correctly.
+- The api route (`app/api/columns/[type]/route.ts`) is the single config-validation chokepoint — no dup there.
 
-Decision: extract `formatCompactCount` to `lib/utils.ts` and update all call
-sites. Keep YouTube's B-branch in the canonical impl (covers the worst case
-without regressing the others).
+The remaining duplication clusters in: **plugin client.tsx renderers**, **plugin server.ts fetchers**, **integration HTML/number helpers**, and a small **color/tab-group constant re-declaration in two dialogs** despite a canonical source already existing.
 
-### 2. `dicebear identicon` avatar URL duplicated 19x
-The exact pattern
-`` `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(x)}` ``
-appears in:
-- `lib/integrations/github.ts` (10 occurrences)
-- `lib/integrations/{newsnow,reddit,blockscout,xai,substack,youtube,telegram,hackernews,rss}.ts`
+---
 
-Decision: extract `identiconUrl(seed: string)` to `lib/utils.ts`. The avataaars
-variants (3 occurrences in `xai`, `farcaster`, `mock/generators`) and the
-keyword-icons variant (1 occurrence in xai for Grok summaries) stay inline —
-they use a different style and are one-of-a-kind, not duplication.
+## Concrete problems (with file:line references)
 
-### 3. `truncateWithEllipsis` body trimming repeated 8x
-The pattern `body.length > N ? \`${body.slice(0, N).trimEnd()}…\` : body`
-appears in:
-- `lib/integrations/github.ts:178, 226, 295, 450, 512, 561`
-- `lib/integrations/youtube.ts:132-135`
-- `lib/integrations/newsnow.ts:81-84`
-- `lib/integrations/rss.ts:52` (already abstracted into `clean()` locally)
+### A. Color + tab-group constants re-declared in two dialogs (canonical source already exists)
+`lib/deck-rules.ts` exports `COLOR_HEX_RE` (:43), `normalizeColumnColor` (:53 — trim → empty→null → regex→null → lowercase), `TAB_GROUP_MAX` (:35). Yet two dialogs re-declare byte-equivalent copies instead of importing:
+- `components/column/configure-column-dialog.tsx:40` `COLOR_HEX_RE`, `:46` `normalizeHexColor` (identical body to `normalizeColumnColor`), `:39` `TAB_GROUP_MAX`, `:42` `normalizeTabGroup` (= `.replace(/\s+/g," ").trim().slice(0,TAB_GROUP_MAX)`, the exact logic at `app/actions.ts:312` and `use-deck-store.ts:800`).
+- `components/dialogs/deck-color-dialog.tsx:21` `COLOR_HEX_RE`, `:23` `normalizeHexColor`.
+- The 8-entry `COLOR_SWATCHES` palette is duplicated verbatim: `configure-column-dialog.tsx:58` and `deck-color-dialog.tsx:33` (a comment at deck-color-dialog.tsx:30 literally says "Same eight presets as the column-color picker" — a manual keep-in-sync note = drift risk).
 
-Decision: extract `truncateText(s, max)` to `lib/utils.ts` and replace direct
-use sites in github/youtube/newsnow. Keep `rss.ts`'s local `clean()` — it
-combines truncation with HTML stripping; the truncation step now calls the
-shared helper. Saves ~16 lines, behavior preserved.
+### B. `formatPriceUsd` — byte-identical across two plugins
+`lib/columns/plugins/coingecko/client.tsx:76` and `lib/columns/plugins/dexscreener/client.tsx:85` are identical (verified by diff ignoring comments): same 5-branch `$0 / >=1000 / >=1 / >=0.01 / sub-cent toPrecision(3)` body.
 
-## MEDIUM confidence (NOT implemented; would need broader changes)
+### C. Percent-change "pill" JSX — identical across three crypto plugins
+`<span … style={{color: up ? "#10b981" : "#ef4444"}}>{up ? <ArrowUpRight/> : <ArrowDownRight/>}{pct.toFixed(2)}%</span>` is byte-identical in:
+- `coingecko/client.tsx:204-214`, `dexscreener/client.tsx:176-186`, `defillama/client.tsx:170-181`.
+- (`wallet-tx` imports `ArrowUpRight` too but uses it as a tx-direction icon at line 108 — NOT this pill; do not lump it in.)
 
-### 4. NewsNow plugin server boilerplate is mostly identical
-Six servers (`weibo-hot`, `zhihu-hot`, `douyin-hot`, `bilibili-hot`, `toutiao`,
-`baidu-hot`) differ only in the platform string passed to `fetchNewsNow` and
-the `Config`/`Meta` type names. ~25 lines × 6 = 150 lines that could collapse
-to ~20 lines via a `defineNewsNowServer(platformKey)` factory.
+### D. "Source badge" JSX block — same shape in 13 plugins
+`<span className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 …"><span className="grid size-3.5 place-items-center rounded-[3px] …">{icon|char}</span>{label}</span>`, parameterized only by background-color, inner icon/char, and label. 13 client.tsx: coingecko, dexscreener, devto, crates, defillama, hacker-news, lobsters, huggingface, npm, polymarket, producthunt, pypi, stack-overflow. The inner-square className is identical across npm:105 / crates:88 / pypi:89. `_newsnow` already proves the factory for exactly this.
 
-Why NOT implementing: each plugin currently lives as a self-contained tuple of
-`plugin.ts + client.tsx + server.ts`, mirrored in `manifest.ts`,
-`registry.ts`, `server-registry.ts`. Touching the server-only file pattern
-would either (a) require a different factory shape that breaks the established
-plugin contract, or (b) introduce flag-based generic helpers that complicate
-the contract for a one-time cleanup. The repetition is mechanical and matches
-the pattern set in `_template/server.ts`. The README at `lib/columns/README.md`
-likely treats this as the canonical shape; collapsing it adds indirection
-without removing code from the hottest path.
+### E. Server-fetcher pagination boilerplate — two near-identical idioms, ~17 sites
+1. **0-based page + `{items,hasMore}` wrap** (12 sites): coingecko, crates, devto, npm, pypi, huggingface, arxiv, hacker-news, lobsters, stack-overflow, polymarket, defillama. All do:
+   `const page = cursor ? Number(cursor) || 0 : 0; const r = await fetchXPage(…, PAGE_SIZE, page); return { items: r.items, nextCursor: r.hasMore ? String(page+1) : undefined };`
+   (e.g. `coingecko/server.ts:11-24`, `crates/server.ts:11-18`, `npm/server.ts:11-18`.)
+2. **1-based page + `items.length === PAGE_SIZE`** (5 sites): `github-issues/server.ts:16-26`, `github-prs/server.ts:11-23`, `github-search/server.ts:14-24`, `github-trending/server.ts:14-25`, `github-releases/server.ts:30-38` (variant: uses `all.length` after a prerelease filter). `cursor ? Number(cursor) || 1 : 1` + `items.length === PAGE_SIZE ? String(page+1) : undefined` is copy-pasted.
+   Note: `pageFromCursor` (`paginate.ts:13`) already encapsulates idiom-1's cursor parse but none of these 17 fetchers use it.
 
-Recommendation: leave for a future refactor that addresses the registry
-boilerplate at the same time (manifest + registry + server-registry could be
-generated from a single per-plugin descriptor).
+### F. github-stars / github-forks server.ts — essentially identical
+`github-stars/server.ts` and `github-forks/server.ts` differ only by the imported fetcher (`fetchStargazers` vs `fetchForks`) and type names; both trim repo, throw `"Repository is required (owner/repo)."`, call `fetchX(repo, PAGE_SIZE, cursor)`. That same guard string recurs in `github-releases/server.ts:18` and `github-actions/server.ts:18`.
 
-### 5. github-stars + github-forks renderers ~95% identical
-`lib/columns/plugins/github-stars/client.tsx` and
-`lib/columns/plugins/github-forks/client.tsx` differ in: icon, badge color/label,
-verb ("starred"/"forked"), and an extra forkUrl link block (forks only).
-Server.ts files differ only in which fetcher is called.
+### G. NewsNow server.ts — 6 near-identical fetchers
+weibo/zhihu/douyin/bilibili/toutiao/baidu `server.ts` differ only by the platform string (`"weibo"`, `"zhihu"`, …) and type names; all call `fetchNewsNow(platform, 50)` then `sliceForPage(items, cursor)`. (The client side is already factored via `_newsnow`; the server side is not.)
 
-Why NOT implementing: the `forkUrl` extension makes a unified renderer either
-parameterized (icon, color, verb, optionalSecondaryLink — three flag-style
-parameters) or a thin wrapper that passes a render-prop. Both options are uglier
-than the current near-duplication. The two plugins are likely to evolve
-independently (e.g. forks get `forkCount`, stars get `starredFromOrg`). DRY
-here would be a premature abstraction.
+### H. HTML-entity decode / strip-HTML helpers in integrations
+- `decodeEntities` defined in 4 files; **byte-identical** in `rss.ts` and `arxiv.ts` (same `NAMED_ENTITIES` map + same 3-`replace` body). `stackoverflow.ts:68` and `pypi.ts:63` are variants with overlapping-but-narrower entity lists.
+- `stripHtml`/`stripTags` defined in 5 files; `lobsters.ts:63` and `polymarket.ts:126` are **byte-identical** (polymarket's comment says "strip it the same way Lobsters does"). `mastodon.ts:76` is a richer `<a>`/`<p>`-aware variant.
+- `NAMED_ENTITIES` const duplicated in `rss.ts` + `arxiv.ts`.
 
-### 6. `instagram/linkedin/facebook/google-news/bing` plugins all delegate to `LinkItem`
-Already deduplicated via the `LinkItem` shared renderer. The remaining
-per-plugin client.tsx files are mostly distinct ConfigForms — those have to
-stay distinct because each platform's input semantics differ. No further
-abstraction available.
+### I. Integration fetch + `!res.ok` throw boilerplate — ~30 sites
+`const res = await fetch(url, {…}); if (!res.ok) throw new Error(\`X ${res.status}: …slice(0,200)\`); return await res.json()` recurs ~30× across integrations — **5× inside `github.ts` alone**, where a `ghFetch<T>` helper already exists at `github.ts:97` but `searchCode`:481, stargazers:653/725, `fetchWorkflowRuns`:972 bypass it with inline re-implementations. Each external call site varies in headers/error-prefix/slice length, so cross-file consolidation is coupling-prone.
 
-### 7. Toast format `count > 0 ? \`${count} new item${count === 1 ? "" : "s"}\` : "No new items"`
-Duplicated in `lib/store/use-deck-store.ts:210` and
-`components/column/column-card.tsx:98`. Would save ~2 lines via a tiny helper.
+### J. ConfigForm "Mode <Select> + conditional <Input> + helper <p>" scaffold
+22 client.tsx import the shadcn `Select` cluster and build the same Label/Select shape; 16 use the `mode: v as XConfig["mode"]` cast; helper-text `<p className="text-xs text-muted-foreground">` appears 63×. Structure is similar but option lists + help copy are all distinct — **weakest** candidate.
 
-Why NOT implementing: it's a UX string; abstracting it would require a helper
-that returns toast args (description differs by call site). The savings (2
-lines) don't justify a new helper; if the message ever needs i18n, the call
-sites are easy to grep.
+---
 
-### 8. `paginate.ts` already exists; unused page-cursor pattern in github-* servers
-`github-search`, `github-issues`, `github-trending`, `github-prs` all
-re-implement page-cursor with the same body:
+## Prioritized recommendations
 
-```ts
-const page = cursor ? Number(cursor) || 1 : 1;
-const items = await fetcher(...args, PAGE_SIZE, page);
-return { items, nextCursor: items.length === PAGE_SIZE ? String(page + 1) : undefined };
-```
+1. **[HIGH]** Import `COLOR_HEX_RE` / `normalizeColumnColor` / `TAB_GROUP_MAX` (and the tab-group normalizer) from `@/lib/deck-rules` in both color dialogs; hoist the 8-entry `COLOR_SWATCHES` palette into one shared const. Bodies verified equivalent; canonical source already imported elsewhere. Removes a hand-maintained "keep in sync" comment. (§A)
+2. **[HIGH]** Extract `formatPriceUsd` (byte-identical) to a shared module; import in coingecko + dexscreener. Do NOT fold in polymarket/wallet-tx `formatUsd` — different rounding (Rec 8). (§B)
+3. **[HIGH]** Extract a `<PctChangePill value={pct} />` shared component for the identical pill in coingecko/dexscreener/defillama; wallet-tx excluded. (§C)
+4. **[HIGH]** Extract `decodeEntities` + `NAMED_ENTITIES` to a shared text-util; migrate rss + arxiv (exact). stackoverflow/pypi optional (their entity lists are subsets — verify each). (§H)
+5. **[HIGH]** Share the byte-identical `stripHtml` between lobsters + polymarket; leave mastodon's richer variant alone. (§H)
+6. **[MEDIUM]** A `pageWrap`-style helper for the 12 "0-based page + {items,hasMore}" fetchers, plus a sibling for the 5 GitHub `items.length === PAGE_SIZE` fetchers. MEDIUM: per-source 0/1-based offset differs, and lobsters/polymarket/defillama do pre-call massaging that must stay in the closure. (§E)
+7. **[MEDIUM]** A `makeSourceBadge({bg,accent,icon|char,label})` factory mirroring `makeNewsNowItemRenderer` for the 13-plugin badge. MEDIUM: some use a Lucide icon, some a literal char, and npm/crates/pypi share a `text-[9px] font-bold` inner-square variant — the factory must take both shapes. (§D)
+8. **[MEDIUM]** Optionally consolidate compact-USD `formatUsd` (polymarket vs wallet-tx) behind a parameterized helper — but the precision rules are deliberately different, so only if the options stay readable; otherwise leave (premature-abstraction risk). (§ formatUsd variants)
+9. **[MEDIUM]** Tiny factories: `makeRepoWatcherServer(fetcher,label)` for github-stars/forks (+ reuse the repo guard) and `makeNewsNowServer(platform)` for the 6 hot-board servers (mirror the already-factored client side). Small LOC, high structural-clarity payoff, zero behavior change. (§F, §G)
+10. **[LOW]** First make `github.ts`'s `searchCode`/stargazers/`fetchWorkflowRuns` use the existing in-file `ghFetch<T>` (safe internal win). A cross-integration `fetchJson` helper is LOW/likely-premature given per-API header/error variance. (§I)
+11. **[LOW] Do NOT** consolidate `plugin.ts` meta or the 22 ConfigForm Select scaffolds — declarative metadata and per-plugin-unique option/help copy; a generic abstraction would need so much config it wouldn't reduce complexity, and would obscure the parity-checked registry (Safety Rule #1). Listed to prevent over-abstraction. (§J)
 
-Why NOT implementing: this is technically "page-from-1" cursor, while
-`paginate.ts:pageFromCursor` defaults to 1 too. Could collapse via a helper
-`fetchPaged(fetchFn, cursor)`, but the four call sites pass different argument
-shapes (varargs into the per-source fetcher). A typed helper would either need
-generics + tuple-spread or a closure-based fetcher signature. The line savings
-are ~3 lines × 4 = 12 lines for ~10 lines of helper code + extra imports —
-net wash that costs readability.
+---
 
-### 9. `normalizeGitHubRepo` (lib/integrations/github.ts) vs `normalizeRepo` (lib/integrations/github-backlinks.ts)
-Both validate `owner/repo` and accept full GitHub URLs. They differ in:
-- Return type: string vs `{ ownerRepo, canonicalUrl }`
-- Error message text
-- `github-backlinks` strips `.git` suffix; the other doesn't
-
-Why NOT implementing: the two are already in different integration files with
-clear ownership. Unifying would require either picking one signature
-(breaking the other's call sites) or layering, neither of which is obviously
-better. Keep separate.
-
-## LOW confidence (deliberately left alone)
-
-### 10. Repeated badge class string
-`"inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"`
-appears 21 times across plugin clients.
-
-Why NOT extracting: this is Tailwind composition. shadcn convention is
-co-located classes, and extracting to a `<Badge>` component would add 1 layer
-of indirection per render. The string is grep-able and the inline style is
-the way the rest of the codebase reads. Plus each badge has a different
-`backgroundColor` style — they're not really "the same" badge.
-
-### 11. Repeated `font-serif text-[16px]...fontFeatureSettings` h3 style
-~16 occurrences of essentially the same headline style.
-
-Why NOT extracting: same reasoning as #10. Tailwind classes are fine to
-repeat; a Headline component would force prop-drilling for color overrides,
-hover variants, etc. Each plugin tweaks the hover color differently.
-
-### 12. Plugin file structure (`plugin.ts`/`client.tsx`/`server.ts`) is repeated 30 times
-Each plugin has the same file layout and similar imports.
-
-Why NOT touching: this is the documented plugin contract (see
-`lib/columns/README.md`). The "repetition" is the contract itself. Collapsing
-it would require a different DSL/generator for plugins.
-
-### 13. `[title, ...rest] = item.content.split("\n\n"); rest.join("\n\n").trim()` repeats ~10x in renderers
-Splits the content blob into title/snippet.
-
-Why NOT extracting to a util: it's a 2-line idiom, and several renderers do
-slight variations (e.g. bing inlines it, others use `description` rather than
-`snippet`). Extracting would be marginal at best, and it's already a stable
-shape. If someone wanted to change the content encoding (`\n\n` → something
-else) they'd grep and replace 10 spots; that's tractable.
-
-### 14. `reorderColumnsInDeck` and `reorderDecks` share an UPDATE...FROM VALUES SQL pattern
-Both use the same trick to bulk-update positions.
-
-Why NOT extracting: they update different tables and `reorderColumnsInDeck`
-also writes `deck_id`. A generic helper would need to take a table identifier
-and column list as parameters, which is uglier than the current 7-line
-duplication. SQL helpers that take dynamic identifiers are also more
-error-prone (escaping, drizzle quirks). Leave alone.
-
-### 15. `RelativeTime` usage with `addSuffix`/`compact`
-~40 call sites pass either `addSuffix` or `compact` props. Already a shared
-component — no further dedupe needed.
-
-### 16. `ConfigForm` Input + Label pattern in plugin clients
-~30 occurrences of `<div className="grid gap-1.5"><Label>X</Label><Input ...></div>`.
-
-Why NOT extracting: each Input has different placeholder, helper text, and
-sometimes adjacent Selects. A shared FormField component would either add
-prop-drilling (helper text, error state, regex) or end up looking exactly like
-shadcn's. The current shape is the shadcn-recommended composition.
+## Safety notes
+- All recs preserve user-facing behavior (Rule #5) and touch no manifest/registry/server-registry keys or the parity check (Rule #1).
+- `_template/` and `_newsnow/` untouched as sources (Rule #2); `_newsnow` cited only as the pattern to imitate.
+- Recs 1–5 are exact-equivalence moves (HIGH, grepped repo-wide). Recs 6–9 are uniform-shape factories with minor per-site variance (MEDIUM). Recs 10–11 are coupling-prone / premature (LOW / don't-do).

--- a/LEGACY_ASSESSMENT.md
+++ b/LEGACY_ASSESSMENT.md
@@ -1,0 +1,142 @@
+# LEGACY_ASSESSMENT.md — Dimension #7: Deprecated / legacy / fallback code; make paths singular
+
+Phase: ASSESSMENT (read-only). No source files were modified.
+
+## Executive summary
+
+This codebase is **remarkably clean** on the legacy/deprecated axis. The
+investigation found:
+
+- **0** `TODO` / `FIXME` / `XXX` / `HACK` / `WIP` markers anywhere in `.ts`/`.tsx`.
+- **0** feature flags, **0** env-var gating (`*_FLAG`, `*_ENABLE`, `*_V2`,
+  `*_LEGACY`, `*_BETA`, `*_EXPERIMENT` all return nothing).
+- **0** `as any`, `@ts-ignore`, or `@ts-expect-error` escape hatches (the only
+  eslint-disables are intentional `no-img-element` / `exhaustive-deps`).
+- **0** commented-out code blocks (every `//` hit is prose).
+- **0** `.bak` / `.old` / `.orig` / orphan files; working tree is clean.
+- **0** version-gated branches. The deck export format is a single clean
+  `version: 1` (`lib/deck-rules.ts:62`) consumed by a single
+  `z.literal(DECK_EXPORT_VERSION)` (`app/actions.ts:517`). New fields are
+  **additive optionals** (e.g. `deckColor`, `app/actions.ts:519-524`) — there is
+  no migration code, no multi-version coercion, no v0→v1 upgrade path.
+
+Almost every string matching `legacy` / `fallback` / `old` / `compat` is
+**intentional graceful degradation that is real product behavior**, not
+removable dead code. The codebase explicitly documents a "keyless dashboards are
+a first-class use case" product decision (`lib/integrations/github-discussions.ts:13`),
+which is why so many fetchers have a public-key/demo-key fallback.
+
+There is essentially **one** genuinely removable legacy artifact (an unused
+re-export alias) plus a handful of *defensive* dual-shape reads against external
+APIs that should be **left alone** (cannot be verified safe without the live API
+contract).
+
+## Concrete findings
+
+### F1 — Unused legacy type re-export `GHPRItemMeta` (REMOVABLE)
+`lib/integrations/github.ts:5-9`
+
+```ts
+// Re-exported under the legacy `GHPRItemMeta`
+// name in case external callers grew an import on it.
+export type { GHPRMeta as GHPRItemMeta };
+```
+
+The comment itself states it exists speculatively "in case external callers grew
+an import on it." A whole-repo grep for `GHPRItemMeta` returns **only** these two
+lines (the comment and the export). There is no internal importer, no barrel
+re-export, no dynamic/string reference. The real type `GHPRMeta` is owned by and
+imported directly from `lib/columns/plugins/github-prs/plugin.ts`. This is a
+zero-consumer back-compat alias for hypothetical external callers that do not
+exist in this repo — the textbook "just in case" leftover. **Safe to delete the
+comment + the `export type` line.**
+
+> Contrast: `GHWatcherItemMeta` (`github.ts:593`) reads similarly but is the
+> ACTUAL source type for `github-stars` / `github-forks` plugins
+> (`plugins/github-stars/plugin.ts:4,12`, `.../server.ts:9,12`, and the forks
+> equivalents). It is NOT legacy — do not touch it. Same for the `GHStarsMeta` /
+> `GHForksMeta` aliases, which are the plugins' public meta contracts.
+
+### F2 — Documentation comments that say "legacy" but gate nothing (NO-OP / cosmetic)
+- `lib/integrations/github-discussions.ts:8` — "so its API surface (legacy
+  callers) stays stable." Pure prose explaining why discussions live in a
+  separate file from `github.ts`. No code branch. Could be reworded but there is
+  nothing to remove.
+- `lib/integrations/huggingface.ts:68,91` — handles HF "legacy single-segment
+  ids" (old community models whose id is just `name` with no `owner/`). This is
+  **live external-data handling**, not internal legacy. HF still serves such ids.
+  Keep.
+- `lib/integrations/polymarket.ts:40` — reads `volume24hr` with a `typeof` guard
+  because the live Gamma API returns a *number* despite older schema docs typing
+  it as a string. Defensive parse of an external feed. Keep.
+
+### F3 — External-API dual-shape reads (DEFENSIVE — keep unless API verified)
+`lib/integrations/farcaster.ts:170,188,208,227,244`
+
+```ts
+const casts = json.casts ?? json.result?.casts ?? [];
+const fid   = json.user?.fid ?? json.result?.user?.fid;
+```
+
+These read both the Neynar v2 top-level envelope (`json.casts` / `json.user`) and
+the older `json.result.*` envelope. The response interfaces
+(`NeynarCastsResponse`, `NeynarUserLookupResponse`, `farcaster.ts:58-67`) declare
+`result?` as optional precisely to support both. *In principle* this is a
+candidate to collapse to the single current v2 shape — but it cannot be verified
+safe from inside the repo, because the source of truth is Neynar's live response
+and the column is used both with a user key and the rate-limited demo key (which
+historically returned different envelopes). **Low confidence; recommend leaving
+as-is** unless someone confirms the live contract.
+
+### F4 — Graceful-degradation fallbacks that ARE product behavior (KEEP — do NOT remove)
+These all surfaced in the marker grep but are intentional, user-facing behavior:
+- `components/sidebar-01/nav-header.tsx:30-55` — `copyToClipboard` uses
+  `navigator.clipboard` then falls back to the `document.execCommand("copy")`
+  textarea trick on insecure-context / older browsers. Real degradation path.
+- `lib/integrations/farcaster.ts:79-114` — `NEYNAR_API_KEY || DEMO_KEY` and
+  `fallbackToDemoOn402`. Documented keyless-first product decision.
+- `lib/integrations/github.ts` (~30 call sites) & `github-discussions.ts:11-14`
+  — optional `GITHUB_TOKEN`; degrades to unauthenticated 60 req/hr. Product
+  decision.
+- `lib/integrations/xai.ts:50-51` — avatar URL fallback chain (unavatar →
+  dicebear). Real avatar-resolution behavior.
+- `lib/integrations/{coingecko,defillama,dexscreener}.ts` `num(v, fallback=0)` —
+  numeric coercion helpers for untyped external JSON. Defensive parsing.
+- `lib/integrations/arxiv.ts:123-149` — id/URL extraction fallbacks for varied
+  Atom feed shapes. Defensive parsing.
+- `components/deck/deck-board.tsx:127` — "tab-disappear fallback" that clears a
+  stale color filter when its columns vanish. View-state correctness, not legacy.
+- `lib/db/client.ts` — three-driver resolution (pglite/neon/postgres). This is a
+  capability matrix, not legacy. The `catch {}` at `resolveDatabaseConfig`'s URL
+  parse "falls through to postgres branch" intentionally.
+
+### F5 — Import-time input coercion (NOT legacy — current-path sanitization)
+`app/actions.ts:680-741` — `importDeck` coerces `pinned`, `tabGroup`, `color`,
+`refreshIntervalSeconds`, keyword fields from hand-editable JSON. This defends
+the *current* import path against tampered payloads; it is not back-compat for an
+older format. Keep.
+
+## Prioritized recommendations
+
+| # | Recommendation | Confidence | Why |
+|---|----------------|-----------|-----|
+| L1 | Delete the unused `GHPRItemMeta` legacy re-export alias (comment + `export type { GHPRMeta as GHPRItemMeta }`) in `lib/integrations/github.ts:5-9`. Verified zero consumers repo-wide (only self-references). | **High** | True "just in case" leftover with no internal/dynamic/barrel reference; `GHPRMeta` is imported directly everywhere it's needed. tsc-safe (removing an unused type export changes no value semantics). |
+| L2 | (Optional, cosmetic) Reword the "(legacy callers)" prose in `github-discussions.ts:8` since no legacy caller branch actually exists. | Low | Pure comment; no behavior. Skip unless doing a docs pass. |
+| L3 | Consider collapsing the Neynar `json.result?.*` dual-shape reads in `farcaster.ts` to the single v2 envelope IF the live API contract is confirmed v2-only. | Low | Cannot verify safe from inside the repo; risks breaking the demo-key path. Do not do blind. |
+
+## What NOT to do (guardrails honored)
+- Do **not** remove `GHWatcherItemMeta` / `GHStarsMeta` / `GHForksMeta` — actively
+  used plugin contracts (F1 note).
+- Do **not** remove any `*_API_KEY || DEMO_KEY` / optional-`GITHUB_TOKEN` /
+  `copyToClipboard` execCommand / `num(v, fallback)` paths — they are real
+  graceful degradation (F4).
+- `plugins/_template/` and `plugins/_newsnow/renderer.tsx` confirmed: `_template`
+  is intentionally NOT in `manifest.ts`; `_newsnow/renderer` is imported by 6 hot
+  plugins (toutiao, zhihu-hot, bilibili-hot, douyin-hot, weibo-hot, baidu-hot).
+  Both KEEP.
+
+## Net assessment
+The "make paths singular" mandate finds almost nothing to do here: paths are
+already singular. The single actionable, high-confidence removal is L1 (the dead
+`GHPRItemMeta` alias). Everything else flagged by legacy/fallback markers is
+deliberate product behavior or external-API defensiveness that must be preserved.

--- a/SLOP_ASSESSMENT.md
+++ b/SLOP_ASSESSMENT.md
@@ -1,72 +1,155 @@
-# Comment & stub assessment
+# SLOP_ASSESSMENT.md — Dimension #8: AI slop, stubs, larp, unhelpful comments
 
-## Overall
+Phase: ASSESSMENT (read-only). No source files were modified in this pass.
 
-This codebase is unusually clean for an LLM-touched repo. The vast majority of comments either capture genuine "why" context (upstream API quirks, rate-limit trivia, race conditions, reasoning behind a workaround) or live in the `_template/` plugin scaffold where narrative is explicitly the point.
+> Note: this file previously held a PR-#21-era cleanup log whose line references
+> have since rotted (the banner boxes in `github.ts`, the `// ignore` narration,
+> the `types.ts` "Backwards-compat aliases" block, and the `relative-time.tsx:65`
+> narration it listed no longer exist — already removed). This is a fresh
+> assessment of the **current** tree.
 
-What I found:
-- ~340 comments across 65 non-`components/ui` files. Roughly 90% are kept as-is.
-- A small set of banner / section-divider comments worth removing.
-- A few "narration of obvious code" comments to remove.
-- One in-motion-change comment ("Backwards-compat aliases") to remove.
-- One LARP-flavored block: `lib/integrations/farcaster.ts` keeps three unused paid-tier helpers + a multi-mode dispatcher behind `void fetchFarcaster`. The header comment honestly documents this. Conservative call: keep them — re-enable path is real (the Neynar paid tier exists), comments are accurate, removing forces a future re-implementer to redo upstream-discovery work. Flag, don't delete.
+## Executive summary
 
-## Top offenders (action taken in this pass)
+For the slop dimension this codebase is in excellent shape. A full sweep of all
+242 `.ts`/`.tsx` files found:
 
-| # | Location | Current | Action | Why |
-|---|---|---|---|---|
-| 1 | `lib/integrations/github.ts:606-608` | `// ===========...\n// Stargazers + forks (used by the github-watchers plugin)\n// ===========...` | REMOVE banner box, keep one-line section header | Banner ASCII art adds nothing; one-liner is enough |
-| 2 | `lib/integrations/farcaster.ts:201-204` | `// -----------...\n// PAID-TIER HELPERS — kept intentionally for re-enable.\n// All three return 402 PaymentRequired on Neynar's free tier.\n// -----------...` | REMOVE banner rules, keep prose | Banners are visual noise |
-| 3 | `lib/integrations/farcaster.ts:3-23` | 21-line ASCII-banner header with "FARCASTER VIA NEYNAR" + box-drawn rules | REWRITE: drop banner rules + the "to re-enable" 4-step recipe, keep the actual factual info | The banner rules + step-by-step "restore the multi-mode dispatch" runbook is in-motion / scratchpad-flavored. Underlying tier-limit info is real and worth keeping. |
-| 4 | `lib/integrations/app-reviews.ts:24` | `// ---- App Store (iTunes RSS, keyless) -----...` | KEEP (informative one-liner) | Has real info, just one line, not a banner box |
-| 5 | `lib/integrations/app-reviews.ts:105-110` | `// ---- Google Play (batchexecute scrape, keyless) ---...\n// Google Play has no public reviews API...` | KEEP | The text below is genuinely non-obvious upstream info |
-| 6 | `lib/integrations/app-reviews.ts:230` | `// ---- Public entry point ------------...` | REMOVE | Pure section divider, no info |
-| 7 | `lib/integrations/hackernews.ts:133` | `// ---- Mentions search ----------...` | REMOVE | Pure section divider |
-| 8 | `lib/integrations/xai.ts:163` | `// ---------- Public fetchers ----------` | REMOVE | Pure section divider |
-| 9 | `lib/integrations/github.ts:347` | `// ---- Free-form search across scopes (used by github-search plugin) ---` | KEEP (one-liner with real info) | Not a banner box; informative |
-| 10 | `app/actions.ts:248` | `// ---- env key management (Settings dialog) -----...` | REMOVE rule, keep label | One line is enough |
-| 11 | `lib/columns/types.ts:139-141` | `// ---- Backwards-compat aliases (existing call sites) ---\n// Old code imported... New code should prefer the new names.` | REWRITE | In-motion; "old code / new code" is rotted. Aliases are still used in 3 files; just say so plainly. |
-| 12 | `lib/integrations/github.ts:650` | `// ignore` | REMOVE | Narrates that an empty catch ignores |
-| 13 | `app/actions.ts:193` | `// Gather existing ids to count "new" arrivals` | KEEP | Borderline; explains intent of the lookup which isn't obvious |
-| 14 | `app/actions.ts:233` | `// Cap history per column` | KEEP | Borderline; explains intent of the SQL DELETE |
-| 15 | `components/relative-time.tsx:65` | `// Subscribe so we re-render once per second.` | REMOVE | Narrates `useSyncExternalStore(subscribe, ...)` — obvious |
-| 16 | `lib/integrations/substack.ts:43` | `// Full URL or bare host: extract the subdomain before .substack.com.` | KEEP | Useful — describes branch intent |
-| 17 | `lib/integrations/substack.ts:48` | `// Plain handle. Allow alphanumerics and hyphens; reject anything else.` | KEEP | Same |
-| 18 | `lib/integrations/substack.ts:178` | `// Prefix with publication to avoid id collisions across feeds.` | KEEP | Genuine why |
-| 19 | `lib/integrations/github-backlinks.ts:93/100/107/123` | One-line per-source labels | KEEP | Each is a useful breadcrumb in a fan-out function |
-| 20 | `next.config.ts:4-5` | "PGlite ships a WASM binary..." | KEEP | Genuine reason for `serverExternalPackages` entries |
-| 21 | `drizzle.config.ts:5-7` | "drizzle-kit's `generate` doesn't need credentials..." | KEEP | Genuine why |
-| 22 | `lib/db/client.ts:11-19` | Multi-line driver-selection table | KEEP | Top-of-file map is valuable; non-obvious behavior |
-| 23 | `lib/db/client.ts:51` | `// fall through to postgres branch — let the driver surface a real error` | KEEP | Genuine why |
-| 24 | `lib/db/client.ts:61-62` | "We declare `db` as the NodePg shape because..." | KEEP | Genuine why; explains a deliberate type choice |
-| 25 | `lib/columns/server-registry.ts:75-77` | "Parity check..." | KEEP, but slightly redundant with file header | Mildly chatty but not slop |
-| 26 | `lib/columns/server-registry.ts:95-96` | "Verify each registered server's id matches its key (catches typos like `redit` → reddit)..." | KEEP | Genuine why with concrete example |
-| 27 | `lib/columns/registry.ts:46-48` | "Keyed by id rather than positional — 'use client' boundary..." | KEEP | Genuine why |
-| 28 | `lib/columns/registry.ts:82` | `// Pre-built ordered list, indexed by manifest order. Built once at module init.` | KEEP | Useful one-liner |
-| 29 | `components/column/column-card.tsx:50-52` | `// undefined = unknown ... // string = ready ... // null = exhausted` | KEEP | Genuine state-encoding key |
-| 30 | `components/column/column-card.tsx:96` | `// Reset pagination cursor on a fresh refresh.` | KEEP | Borderline but explains intent of the next line |
-| 31 | `components/column/column-card.tsx:114-117` | "First load after a cold open..." | KEEP | Genuine why for the two-stage logic |
-| 32 | `components/column/column-card.tsx:156` | `// consumed by the beam-frame CSS` | KEEP | Useful — CSS custom property usage isn't obvious |
-| 33 | `components/sidebar-01/nav-stats.tsx:12-13` | "Re-render every minute so 'Updated' stays fresh — useSyncExternalStore keeps `Date.now()` out of render bodies (React's purity rule)." | KEEP | Genuine why w/ reference to React rule |
-| 34 | `hooks/use-min-duration.ts:12-14` | "React's blessed pattern for deriving state from props..." | KEEP | Genuine why |
-| 35 | `lib/integrations/farcaster.ts:294` | `// Suppress "declared but never read" — these are intentionally kept for re-enable.\nvoid fetchFarcaster;` | KEEP | The comment IS the warning that makes the larp explicit. Removing the comment without removing the larp would be worse. |
-| 36 | `lib/integrations/farcaster.ts:263` | `// Multi-mode dispatcher — wire this back up in route.ts when the plan is upgraded.` | KEEP | Same — pin the dead code with explicit context |
-| 37 | All `_template/*` narrative comments | Long pedagogy comments in plugin scaffold | KEEP | Template is documentation by design |
+- **Zero** `TODO`/`FIXME`/`XXX`/`HACK` comments.
+- **Zero** "not implemented" / "coming soon" throws.
+- **Zero** mock/fake/dummy/sample-data identifiers in product code.
+- **Zero** narration-of-in-motion-work comments ("now we…", "changed to…",
+  "this replaces…", "old code / new code"). The `instead of` / `rather than`
+  phrasing that appears throughout documents deliberate design choices (the
+  *why*) — keep-quality comments, not narration.
+- **Zero** ceremonial banner boxes / empty section dividers (the prior cleanup
+  removed them; the only dashed separators left, in `lib/deck-templates.ts`,
+  head substantive per-template explanations, not empty `// --- Imports ---`).
+- **Zero** redundant JSDoc: no `@param`/`@returns` ceremony anywhere; the
+  `/** */` blocks (e.g. `lib/columns/types.ts`) document real invariants.
+- **Zero** copy-paste comment slop across the ~70 plugin files — every comment
+  line is unique (verified via `uniq -c`; all counts = 1).
+- High comment density (`use-deck-store.ts` 231 comment lines, `actions.ts` 228)
+  is *substantive*: wire-format contracts, drop-not-fail posture, server/client
+  validation parity, the registry parity-check invariant. Assets, not slop.
 
-## Stubs / LARP / overengineered
+There is essentially **one** real slop finding: a self-contained dead-code
+island in `lib/integrations/farcaster.ts` kept alive only by a `void`-discard to
+silence the linter. Everything else is Low / micro-nit.
 
-- `lib/integrations/farcaster.ts`: `fetchTrending`, `fetchChannel`, `fetchSearch`, `fetchFarcaster` — three of these are unused; `fetchFarcaster` is suppressed via `void`. They are real, working calls into the Neynar paid tier. Keeping per author intent (commented as such).
-- `defineColumnUI` / `defineColumnServer`: looked like potential larp ("factory pattern producing one type") but used at 126 call sites and provides a non-trivial typing seam (`as unknown as AnyColumnUI`). Real abstraction.
-- The `_template` plugin folder is scaffolding-by-design, not larp — it's intentionally not registered, makes adding a plugin fast.
-- No empty stub functions, no "TODO: implement" placeholders, no abandoned interfaces with single implementations that aren't actually used, no over-abstracted factory patterns.
+The other top-level `*_ASSESSMENT.md` artifacts were not touched.
 
-## Summary of changes applied
+---
 
-- 4 banner-box comments removed (`farcaster.ts`, `github.ts`, multi-rule dividers).
-- 1 `// ignore` deletion.
-- 1 obvious-narration comment removal (`relative-time.tsx:65`).
-- 1 in-motion comment rewritten (`types.ts` "Backwards-compat aliases").
-- 4 single-line section dividers without info content removed (`hackernews.ts`, `xai.ts`, `app-reviews.ts:230`, `actions.ts:248`).
-- The `farcaster.ts` 21-line header trimmed: kept the factual upstream context (free vs paid tiers, demo-key trick, hub-fallback ruling), dropped the in-motion runbook ("To re-enable: 1. ... 2. ... 3. ...") and the ASCII rules.
+## Findings (with file:line references)
 
-Net result: ~25 lines of comment removed, no behavior changes, build still green.
+### F1 — Dead "kept for re-enable" code island in farcaster.ts  (the one real finding)
+
+`lib/integrations/farcaster.ts` carries a cohesive cluster never reached by any
+execution path, kept purely "for re-enable":
+
+- `fetchTrending` — `farcaster.ts:195`
+- `fetchChannel` — `farcaster.ts:212`
+- `fetchSearch` — `farcaster.ts:248` (a one-line re-export of `fetchFarcasterSearch`)
+- `fetchFarcaster` dispatcher — `farcaster.ts:253`
+- exported types used ONLY by the above: `FCMode` (`farcaster.ts:18`),
+  `FCWindow` (`farcaster.ts:19`)
+- the linter-suppression statement `void fetchFarcaster;` — `farcaster.ts:284`
+- four framing comments — `farcaster.ts:5`, `:192-193`, `:252`, `:283`
+
+Verification performed:
+- The farcaster plugin fetcher (`lib/columns/plugins/farcaster/server.ts`)
+  imports ONLY `fetchFarcasterUser` and `fetchFarcasterSearch`.
+- Repo-wide grep: nothing outside `farcaster.ts` references
+  `fetchTrending` / `fetchChannel` / `fetchSearch` / `fetchFarcaster` /
+  `FCMode` / `FCWindow`. (The names `fetchTrending`/`fetchChannel` also exist as
+  unrelated module-private functions in `github.ts`, `youtube.ts`,
+  `coingecko.ts`.)
+- The "wire this back up in route.ts" comment (`:252`) is stale: there are zero
+  farcaster references in `app/api/columns/[type]/route.ts`.
+- `void fetchFarcaster;` (`:284`) is the tell-tale larp artifact — a no-op whose
+  only job is to stop the unused-symbol lint from firing on dead code.
+
+This is the textbook "stub kept around, suppressed with a void-discard" pattern,
+and the dominant slop in the repo (~95 lines incl. comments).
+
+Why NOT rated High for removal: intent is documented and defensible (a one-line
+path back when the Neynar plan is upgraded). Removal is technically safe — tsc
+stays green, the eslint count cannot rise, and there is **no** plugin-registry /
+parity-check impact (this is an integration module, not a registered plugin) —
+but deleting deliberately-parked product capability is an owner judgment call,
+not a pure-mechanical cleanup. Hence Medium.
+
+If the owner wants to keep the capability parked, the slop can still be cut by
+removing just the `void fetchFarcaster;` suppressor (`:284`) + its comment
+(`:283`); the cleanest honest outcome, though, is full removal (recover from git
+history when actually re-enabling).
+
+### F2 — `void mode;` unused-parameter suppression in producthunt.ts
+
+`lib/integrations/producthunt.ts:152` — `fetchProductHuntPage(mode, …)` never
+uses `mode` and discards it with `void mode;`. The comment (`:148-151`) explains
+it is kept "as a type so future PH endpoints can plug in". Mild slop (unused
+param + forward-looking placeholder), but `mode` is part of the public signature
+callers pass, so it is NOT removable without touching the caller and the plugin
+config shape, and the why is honestly documented. Low — a safe micro-change
+would rename `_mode` to drop the `void`; near-zero value.
+
+### F3 — Historical PR-number references inside comments
+
+`lib/columns/types.ts:229` ("…column color labels, PR #61"),
+`lib/store/use-deck-store.ts:677` ("PR #59's 'DnD across pin/unpin no-op' rule"),
+`app/actions.ts:156` ("…from PR #61"), `app/actions.ts:369` ("…rule from PR #59").
+Each anchors a real invariant to a PR for provenance. Mildly historical, but the
+invariant text beside each is the load-bearing content and must be kept. Low —
+at most drop the bare "PR #NN" tokens; not worth a dedicated change.
+
+### F4 — `lib/deck-rules.ts:5` "used to live in app/actions.ts" framing
+
+`lib/deck-rules.ts:1-11` correctly documents the real Next.js constraint that a
+`"use server"` module may only export async functions (a genuine, non-obvious
+gotcha that MUST be kept). The single phrase "They used to live in
+`app/actions.ts`" (`:5`) is light historical narration but the natural way to
+explain why the module exists. Low — optional reword to lead with the
+constraint; not a priority.
+
+---
+
+## Things that look like slop but are NOT — KEEP (don't let another pass cut these)
+
+- `console.log(json)` / `console.log(url)` — `components/sidebar-01/nav-header.tsx:85,110`.
+  Intentional user-facing fallback: the paired toast literally tells the user to
+  "paste the JSON manually from the console" when clipboard is blocked.
+- `console.log("[minitor] webhook delivered …")` — `lib/columns/webhook.ts:150`.
+  Operational delivery logging, prefixed and paired with `console.error` failure
+  branches.
+- `eslint-disable-next-line @next/next/no-img-element` across plugin clients
+  (dexscreener/github-forks/youtube/coingecko/github-stars/github-prs/defillama)
+  and `react-hooks/exhaustive-deps` at `components/column/column-card.tsx:191` —
+  legitimate targeted suppressions.
+- `eslint-disable-next-line @typescript-eslint/no-unused-vars` at
+  `lib/columns/types.ts:67` — the `TMeta` phantom type param is structurally
+  required.
+- `void save()` / `void autoFetchColumn(...)` / `void onRefreshRef.current(...)`
+  in components — idiomatic fire-and-forget promise discards.
+- `_template/` (scaffolding, intentionally unreferenced) and
+  `_newsnow/renderer.tsx` (shared renderer) — the numbered "1./2./3." comments
+  in `_template/*` are the point of a template. KEEP per project safety rules.
+- The dashed separators + per-template paragraphs in `lib/deck-templates.ts` —
+  substantive, not ceremonial.
+- The dense "why" comments in `use-deck-store.ts`, `actions.ts`, `types.ts`,
+  every integration's drop-not-fail / wire-format notes, and the registry
+  parity-check rationale — KEEP / sharpen, never strip.
+
+---
+
+## Prioritized recommendations
+
+| # | Recommendation | Confidence |
+|---|----------------|------------|
+| R1 | Remove the dead farcaster re-enable island (`fetchTrending`, `fetchChannel`, `fetchSearch`, `fetchFarcaster`, `FCMode`, `FCWindow`, the `void fetchFarcaster;` suppressor, and the four re-enable comments) from `lib/integrations/farcaster.ts` — OR, if the owner wants the capability parked, at minimum drop the `void`-discard slop. Verified-unreferenced and parity-check-safe; Medium (not High) only because deleting documented intentional re-enable code is an owner judgment call. | Medium |
+| R2 | (Optional, micro) Rename `mode` → `_mode` and drop `void mode;` at `lib/integrations/producthunt.ts:152`. | Low |
+| R3 | (Optional, micro) Trim bare "PR #NN" provenance tokens in `types.ts:229`, `use-deck-store.ts:677`, `actions.ts:156`, `actions.ts:369` while keeping every invariant sentence. | Low |
+| R4 | (Optional, micro) Reword the "used to live in app/actions.ts" framing in `lib/deck-rules.ts:5`, keeping the gotcha. | Low |
+
+No High-confidence slop deletions exist: the codebase has no clear-cut,
+risk-free slop to remove. R1 is the only material item and carries an
+intent/judgment caveat that keeps it at Medium.

--- a/TRYCATCH_ASSESSMENT.md
+++ b/TRYCATCH_ASSESSMENT.md
@@ -1,123 +1,232 @@
-# try/catch + defensive programming assessment
+# TRY/CATCH & DEFENSIVE-FALLBACK ASSESSMENT (Dimension #6)
 
-Audit of every `try { ... } catch` block in the project (TS/TSX, excluding `components/ui/*`).
+Scope: every `try {}/catch`, `.catch()`, and `Promise.allSettled` rejection branch
+in `/Users/aaron/Downloads/opti/minitor` (excluding `node_modules`, `.next`).
+Read-only assessment — no source changed. `tsc` and eslint baselines untouched.
 
-Verdict legend: KEEP (legitimate trust boundary with meaningful handling) · IMPROVE (boundary, but handling is hiding) · REMOVE (wraps internal code, hides bugs).
+> Supersedes the earlier 17-block pass: that pass covered only `try/catch` blocks
+> and missed the `.catch()` promise-rejection sites, the bare `catch {}`, the
+> `Promise.allSettled` partial-failure branches, and the silent-continue patterns.
 
----
+## Method
 
-## Server actions / DB / file IO
+Counted 40 try-blocks / 60 `catch` tokens. Read all 35 source files that contain
+`catch` or `.catch(`. Classified each catch body as **JUSTIFIED** (genuine
+external/unsanitized input or expected failure AND does something meaningful) or
+**UNJUSTIFIED** (swallows, logs-and-continues hiding failure, returns a silent
+default that masks a bug, wraps code that cannot meaningfully throw, or rethrows
+unchanged). Verdicts quote the catch body.
 
-### `app/actions.ts:293` — read `.env.local`
-- Boundary: **file IO** (`readFile` may ENOENT).
-- Handling: silently fall through to `raw = ""`, then write the file fresh.
-- Verdict: **KEEP** (HIGH confidence). The empty-file fallback is the documented intent — file may not exist on first run. This is a clearly motivated default, not error hiding.
+## Headline finding
 
----
+This codebase's exception handling is, overall, **deliberate and well-justified.**
+The overwhelming majority of catches sit at true I/O boundaries (network fetch,
+`JSON.parse` of external bodies/cursors, `new URL()` of user/feed input,
+DB/server-action calls, the Zod boundary) and do something meaningful — build a
+typed error and rethrow, surface a `toast`, return a documented drop-not-fail
+fallback, or feed a fire-and-forget path explicitly contracted to never break its
+trigger. There is no broad swallow-everything anti-pattern.
 
-## API routes
+The few real problems are narrow:
 
-### `app/api/columns/[type]/route.ts:45` — plugin fetcher invocation
-- Boundary: **third-party network** (Grok, GitHub, Reddit, etc. via `entry.fetch`).
-- Handling: returns 502 with the original message; client toast surfaces it.
-- Verdict: **KEEP** (HIGH). This is the canonical "translate thrown SDK/network error into HTTP error" pattern. `console.error` is supplementary log, not the only handling.
+1. One **empty-brace** catch with no comment (`github.ts:632`).
+2. A cluster of **silent `console.warn`/swallow-and-continue** sites that are
+   *correct by product design* but worth confirming are intended, not accidental.
+3. A latent **body-already-consumed** fallback in one error path (`huggingface.ts`).
 
----
-
-## DB driver bootstrap
-
-### `lib/db/client.ts:48` — URL parse for routing driver choice
-- Boundary: **URL parse** of user-supplied `DATABASE_URL`.
-- Handling: leave `host` empty so we fall through to the `postgres` branch and let the driver surface the real error.
-- Verdict: **KEEP** (HIGH). Documented and intentional — bad URLs surface from the driver itself, which gives a richer error than the parse failure would.
-
----
-
-## Client mutations / Zustand
-
-### `lib/store/use-deck-store.ts:202` — `autoFetchColumn` network call
-- Boundary: **fetch + DB persist** via `callColumnApi` and `applyFetchedItems`.
-- Handling: surfaces failure via `toast.error` with the message.
-- Verdict: **KEEP** (HIGH).
-
-### `components/column/column-card.tsx:90` — manual refresh
-- Same shape as above — fetch, toast on failure.
-- Verdict: **KEEP** (HIGH).
-
-### `components/column/column-card.tsx:113` — load-more pagination
-- Same shape — fetch, toast on failure.
-- Verdict: **KEEP** (HIGH).
-
-### `components/settings/settings-dialog.tsx:77` — `setEnvKeys`
-- Boundary: server-action call (writes `.env.local`).
-- Handling: `toast.error` with message, leaves dialog open.
-- Verdict: **KEEP** (HIGH).
+Nothing here is a "delete the try/catch" slam-dunk that changes behavior. The
+highest-value, zero-risk change is making the one empty catch self-documenting.
 
 ---
 
-## Integrations (URL parse / RSS parse / cursor decode)
+## A. JUSTIFIED catches (the dominant pattern — leave these)
 
-### `lib/integrations/github-backlinks.ts:58` — canonicalize external URLs
-- Boundary: **URL parse** on third-party URLs from HN/Reddit/Google News.
-- Handling: return original string unchanged.
-- Verdict: **KEEP** (HIGH). Some feed URLs are malformed; keeping the raw string for dedup is the right call.
+Grouped so the report is auditable without re-quoting all 50+.
 
-### `lib/integrations/rss.ts:144` — parse feed URL up front
-- Boundary: URL parse on user-supplied feed URL — but the catch *re-throws* a clearer error.
-- Verdict: **KEEP** (HIGH). Replaces the opaque `Invalid URL` from `URL` constructor with an actionable message. This is improvement, not hiding.
+### A1. `res.text().catch(() => "")` inside an error-construction path
+Body: `const body = await res.text().catch(() => "");` then `throw new Error(...body.slice(0,200))`.
+The fetch already failed (`!res.ok`); reading the error body can itself fail; the
+fallback is `""` and the real error still propagates. Meaningful + external.
+Sites: `github.ts:100,490,663,735,974`; `blockscout.ts:225`; `farcaster.ts:101,110`;
+`mastodon.ts:67`; `github-discussions.ts:152`; `xai.ts:100`; `youtube.ts:98`.
 
-### `lib/integrations/rss.ts:157` — `unwrapGoogleRedirect`
-- Boundary: URL parse on item links from feeds.
-- Handling: pass through original URL.
-- Verdict: **KEEP** (HIGH). External feed URL may be malformed.
+### A2. `req.json().catch(...)` / `res.json().catch(...)` on external bodies
+- `app/api/columns/[type]/route.ts:20` — `await req.json().catch(() => ({}))`; the
+  request body is unsanitized and may be empty/non-JSON; the empty object flows
+  through Zod (`safeParse`) → typed 400. Correct boundary.
+- `lib/columns/api-client.ts:17` — `await res.json().catch(() => ({ error: ... }))`
+  on the error branch, then throws the message. Justified.
 
-### `lib/integrations/substack.ts:120` — `isSubstackUrl`
-- Boundary: URL parse on item URLs returned by Grok web_search.
-- Handling: return `false`.
-- Verdict: **KEEP** (HIGH). Predicate has to handle malformed URLs.
+### A3. `JSON.parse` of genuinely external / opaque-cursor data → documented fallback
+- `app/actions.ts:629-633` importDeck — `JSON.parse` of user-pasted text →
+  `throw new Error("Not valid JSON")`. Textbook user-input boundary.
+- `app/actions.ts:817-822` loadDeckSnapshots — parse a stored payload to count
+  columns; on failure leave count 0. Stored data could be corrupt; non-fatal.
+- `blockscout.ts:133-144` decodeCursor; `wallet-tx/server.ts:25-38` decode — base64url
+  cursor came from the client; parse failure → safe default cursor. Correct.
+- `polymarket.ts:65-71` parseJsonArray — Gamma sends `outcomes` as a JSON-encoded
+  string; parse failure → `[]`. External, documented.
+- `xai.ts:61-77` extractJsonArray — parses an LLM's free-text output and throws a
+  descriptive error if it isn't a JSON array. Genuine external boundary.
 
-### `lib/integrations/substack.ts:130` — `publicationFromUrl`
-- Same shape — return `null` on bad URL.
-- Verdict: **KEEP** (HIGH).
+### A4. `new URL(...)` of user / feed / item input → fallback
+`db/client.ts:48-52` (DB host parse, falls through to pg driver, commented),
+`webhook.ts:92-95` (SSRF validator returns a typed reason), `rss.ts:158-160`
+(invalid feed URL → thrown user error), `rss.ts:146-150` unwrapGoogleRedirect,
+`github-backlinks.ts:60-72` canonicalize, `producthunt.ts:59-69` slugFromUrl,
+`linkedin.ts:13-17` / `substack.ts:145-163` host checks, `rss/plugin.ts:28-34`
+defaultTitle, `github-backlinks/client.tsx:79-85` hostName. All parse untrusted
+strings → sensible default or typed error. Justified.
 
-### `lib/integrations/blockscout.ts:139` — `decodeCursor`
-- Boundary: **JSON.parse** on a base64-encoded cursor that arrived from the wire.
-- Handling: return `undefined` (caller treats as "start from beginning").
-- Verdict: **KEEP** (HIGH). Tampered/garbled cursors should not crash; resetting pagination is the documented behavior.
+### A5. Server-action / fetch wrappers in UI that surface a user-facing message
+`use-deck-store.ts:938-941` autoFetchColumn (`toast.error("Fetch failed")`),
+`column-card.tsx:273-276` onRefresh, `column-card.tsx:335-338` onLoadMore,
+`import-deck-dialog.tsx:46-51`, `templates-dialog.tsx:52-57`,
+`version-history-dialog.tsx:63-68`, `settings-dialog.tsx:81-86`,
+`welcome.tsx:141-147`, `nav-header.tsx:87-90,112-115`, `deck-view.tsx:66-70` /
+`deck-view.tsx:112-116` (`.catch` on loadSnapshot / shared-deck import). Each
+catches a real async failure and turns it into a toast / error state. Justified.
 
-### `lib/integrations/linkedin.ts:12` — `isLinkedinUrl`
-- URL-parse predicate on Grok results.
-- Verdict: **KEEP** (HIGH).
+### A6. Bounded fire-and-forget contracted to never throw
+`webhook.ts:158-163` sendColumnWebhook (logs failure, returns void by design — a
+webhook send must not fail a fetch persist; documented). `use-deck-store.ts:357-361`
+fireAndLog (logs the optimistic server-action error; UI already moved on
+optimistically — intentional + documented).
 
-### `lib/integrations/github.ts:645` — parse `Link:` rel="last"
-- Boundary: URL parse on a header value GitHub provided. Used for pagination hint only.
-- Handling: ignore — falls through to `undefined` lastPage.
-- Verdict: **KEEP** (HIGH). Pagination is best-effort; the alternative is crashing the request.
+### A7. Empty / swallowing catch WITH a clear product rationale + comment
+- `app/actions.ts:792-794` captureDeckSnapshot — `catch {}` + comment "Snapshotting
+  must never break the triggering mutation." Best-effort version history. Justified.
+- `app/actions.ts:1009-1013` setEnvKeys — `catch {}` reading `.env.local` + comment
+  "File may not exist yet — start from empty." Expected ENOENT. Justified.
 
-### `lib/columns/plugins/github-backlinks/client.tsx:80` — host extraction for display
-- Boundary: URL parse on item URL for rendering host badge.
-- Handling: empty string → host badge hidden.
-- Verdict: **KEEP** (HIGH). Renderer-side defense against malformed external URLs.
+### A8. Browser-API catches with a documented boolean/null contract
+`nav-header.tsx:30-55` copyToClipboard (two catches; clipboard APIs throw on
+permission / insecure-context; returns `boolean` the caller branches on).
+`deck-share.ts:55-68` decodeDeckShareHash (`catch → return null`; untrusted share
+fragment; documented "Never throws"). Justified.
 
-### `lib/columns/plugins/rss/plugin.ts:28` — `defaultTitle`
-- Boundary: URL parse on user-supplied feed URL to derive the column title.
-- Handling: fall back to "RSS".
-- Verdict: **KEEP** (HIGH). User can paste anything into the URL field; this is the title generator running before validation.
-
-### `lib/columns/plugins/wallet-tx/server.ts:27` — wallet cursor decode
-- Boundary: JSON.parse on base64 cursor.
-- Handling: reset to `{ off: 0 }`.
-- Verdict: **KEEP** (HIGH). Same as Blockscout cursor.
+### A9. `version-history-dialog.tsx:43-45` — `.catch(() => setSnapshots([]))`
+Loads snapshot list; on failure shows an empty list + a `finally` that clears
+loading. Non-critical read; degraded UI is acceptable. Justified (minor: no error
+toast, but the empty-state copy covers it).
 
 ---
 
-## Summary
+## B. PROBLEM catches (ranked)
 
-- **17 try/catch blocks total.**
-- **17 KEEP** — every block sits at a real trust boundary (URL parse, JSON.parse, file IO, third-party network) with appropriate handling: either a clearly motivated fallback (URL parse → ignore item / return original / empty host badge), a re-thrown clearer error, or surfacing through toast / HTTP status to the user.
-- **0 IMPROVE.**
-- **0 REMOVE.**
+### B1 — Empty-brace catch with NO comment  ·  `lib/integrations/github.ts:632`
+```js
+    if (m) {
+      try {
+        const u = new URL(m[1]);
+        const p = u.searchParams.get("page");
+        if (p) return Number(p);
+      } catch {}
+    }
+```
+The only truly bare `catch {}` in the repo. Functionally **fine** — `m[1]` is a URL
+pulled from GitHub's `Link` header via regex; a malformed match should be ignored
+and pagination falls through to `return undefined`. But unlike captureDeckSnapshot /
+setEnvKeys (both carry a one-line "why"), this one is silent — exactly the shape a
+reviewer flags as a swallowed error. **Verdict: behaviorally JUSTIFIED,
+stylistically UNJUSTIFIED.** Fix = a one-line comment, not a structural change.
+Adding the comment is purely additive (zero behavior change): **High** confidence.
+Removing/altering the `try` is NOT recommended — `new URL` genuinely can throw.
 
-No changes implemented. The codebase already follows the philosophy: try/catch only at boundaries, no internal-code-wrapping cruft, no `catch { return null }` patterns hiding bugs in code the developer controls.
+### B2 — Silent `console.warn`-and-continue on auto-refresh  ·  `column-card.tsx:235-244`
+```js
+      } catch (err) {
+        // Silent on auto-refresh so a flaky upstream doesn't spam toasts; the
+        // operator already has the manual refresh button to surface errors.
+        console.warn(`[minitor] auto-refresh failed for column ${column.id}`, err);
+      }
+```
+*Logs-and-continues*, hiding the failure from the UI — normally the UNJUSTIFIED
+shape. Here it is a **defensible, commented product decision** (a 5-min interval
+poll on a flaky feed must not stack error toasts) and it still logs. **Verdict:
+JUSTIFIED, but the single most "smell-shaped" site that is actually intentional.**
+Recommendation: keep as-is. Confidence: **High (keep)**.
 
-Defensive `?.` / `??` patterns were spot-checked (267 occurrences) but a full audit was out of scope for this pass. None of the spot-checked sites looked load-bearing-defensive in the way try/catch does — most are legitimate "value may genuinely be undefined" use, e.g. optional FeedItem fields.
+### B3 — Download-count enrichment swallows to 0  ·  `npm.ts:173-178`, `pypi.ts:130-133`
+```js
+  } catch {
+    // Network / parse failures degrade silently to 0 — the row still renders ...
+    return 0;
+  }
+```
+Per-row enrichment wrapped so one failed sub-request doesn't drop the package.
+Swallows the error (no log), but the fallback `0` is a **documented, user-meaningful**
+degraded value and the "never drop a row for a missing badge" contract is explicit.
+**Verdict: JUSTIFIED.** Sole critique: zero logging makes a *systemic* downloads-API
+outage invisible server-side. A `console.debug` would help observability (additive
+log only). Confidence it's worth adding: **Medium**; impact: **Low**.
+
+### B4 — `res.text()` fallback after a failed `res.json()` on the same Response  ·  `huggingface.ts:176-182`
+```js
+    let detail = "";
+    try {
+      const err = (await res.json()) as HFErrorResponse;
+      detail = err.error ?? "";
+    } catch {
+      detail = (await res.text()).slice(0, 200);
+    }
+    throw new Error(`Hugging Face ${res.status}: ${detail}`);
+```
+On `!res.ok`, try JSON error shape, else fall back to raw text. The inner
+`await res.text()` is itself unguarded, and the body stream was already consumed by
+the failed `res.json()` attempt — so this `.text()` can throw and escape the
+intended error path. **Verdict: mostly JUSTIFIED (boundary + meaningful), but the
+text() fallback is a latent bug.** Worst case is a less-informative error that
+bubbles to route.ts's 502 handler — not a crash. Confidence it's real: **Medium**;
+impact: **Low**.
+
+### B5 — `Promise.allSettled` partial-failure branches
+- `github-backlinks.ts:136-151`: collects rejected reasons, **throws only if ALL
+  sources failed** (`if (all.length === 0 && errors.length > 0) throw`). The correct
+  partial-failure pattern. **Verdict: JUSTIFIED.**
+- `substack.ts:119-129`: keeps fulfilled feeds, drops rejected ones **silently**;
+  an all-feeds-failed case returns `[]`, indistinguishable from "no posts," masking
+  a total outage. **Verdict: borderline UNJUSTIFIED (UX gap).** Behavior-changing to
+  fix, so out of scope for a pure cleanup. Confidence it's a real (minor) gap:
+  **Medium**.
+
+### B6 — Redundant-but-harmless `JSON.parse` after in-process `JSON.stringify`
+`app/actions.ts:774-794` captureDeckSnapshot: `const json = await exportDeck();
+const parsed = JSON.parse(json)`. `json` was produced by exportDeck's own
+`JSON.stringify` microseconds earlier in the same process, so the parse can't
+realistically fail for malformed-JSON reasons — but the surrounding `catch {}`
+exists for the DB transaction, not the parse. Not a bug; just noting the parse is
+belt-and-braces. **Verdict: JUSTIFIED (catch is for the DB call).**
+
+---
+
+## C. What NOT to do (safety notes for the implementation phase)
+
+- Do **not** delete any `res.text().catch(() => "")` — the body read genuinely can
+  fail and the error still rethrows; removing it converts a clean upstream-error
+  message into an unhandled rejection.
+- Do **not** "simplify" the `JSON.parse` in captureDeckSnapshot / the cursor
+  decoders — they sit at real boundaries (stored data, client cursors).
+- Do **not** convert the silent auto-refresh / downloads-to-0 catches into toasts
+  or thrown errors — that reverses a deliberate, commented product decision and
+  changes user-facing behavior (Safety Rule #5).
+- Do **not** touch `captureDeckSnapshot` / `setEnvKeys` `catch {}` — both are
+  commented best-effort paths.
+
+---
+
+## D. Prioritized recommendations
+
+| # | Change | File:line | Confidence |
+|---|--------|-----------|------------|
+| 1 | Add a one-line comment to the bare `catch {}` so it matches the repo's commented-catch convention (no behavior change). | `lib/integrations/github.ts:632` | **High** |
+| 2 | Confirm (don't change) the silent auto-refresh continue is intended; most smell-shaped JUSTIFIED site. | `components/column/column-card.tsx:235` | **High (keep)** |
+| 3 | Optionally add a `console.debug` to the downloads-enrichment swallows for outage observability (additive log only). | `lib/integrations/npm.ts:173`, `lib/integrations/pypi.ts:130` | **Medium** |
+| 4 | Latent: `res.text()` fallback after a failed `res.json()` on the same Response can throw (body consumed); only degrades the error message. | `lib/integrations/huggingface.ts:176-182` | **Medium** |
+| 5 | UX gap: substack `allSettled` returns `[]` on total feed failure, indistinguishable from "no posts." Behavior-changing — out of scope for pure cleanup. | `lib/integrations/substack.ts:119-129` | **Low** |
+
+### Net
+There is **no unjustified try/catch that can be safely removed** to improve the
+code without altering behavior. The single concrete, zero-risk improvement is #1
+(annotate the one bare `catch {}`). Everything else is either already correct or a
+behavior-changing product/UX call that this cleanup dimension should not make.

--- a/TYPES_ASSESSMENT.md
+++ b/TYPES_ASSESSMENT.md
@@ -1,111 +1,254 @@
-# Types assessment
+# TYPES_ASSESSMENT — Dimension #2: Consolidate shared type definitions
 
-Survey of every `type`/`interface` declaration outside `node_modules`,
-`.next`, and `components/ui/*` (shadcn). Roughly 60 plugins/integration files
-plus ~10 component files contain declarations.
+Phase: ASSESSMENT (read-only). No source files were modified. `npx tsc --noEmit`
+verified green (0 errors) at assessment time.
 
-## Existing organization (mostly already good)
+> NOTE: A prior version of this file recommended consolidating `WalletTxMeta`,
+> `BacklinkSource`/`BacklinksConfig`, `SubstackMeta`, and `GHPRMeta`. Those have
+> ALREADY been done in the current tree (the integrations now import + re-export
+> these from the plugin — see `blockscout.ts:2`, `github-backlinks.ts:2`,
+> `substack.ts` re-export, `github.ts:2`). This assessment covers what is
+> STILL duplicated.
 
-- **`lib/columns/types.ts`** — canonical home for the column-plugin contract:
-  `FeedItem`, `FeedAuthor`, `PageResult`, `ColumnUI`, `ColumnServer`,
-  `PluginMeta`, `Column`, `Deck`, `defineColumnUI`/`defineColumnServer`, etc.
-  Imported by every plugin and the store. This is the right shape.
-- **Plugin folders** (`lib/columns/plugins/<id>/plugin.ts`) own the
-  per-plugin `XxxConfig` (`z.infer<typeof schema>`) and `XxxMeta` shape and are
-  the canonical source for both client & server. This is also correct — meta
-  shapes are tightly coupled to the renderer + fetcher, not to the underlying
-  HTTP integration's internal types.
-- **`lib/columns/shared/tweet-renderer.tsx`** — `TweetMeta` is shared across
-  the X plugins (re-exported from each plugin); good.
-- **`lib/integrations/app-reviews.ts`** — `AppReviewMeta` is the canonical
-  "review" meta and is correctly imported as `AppReviewMeta` by both the
-  apple-reviews and play-reviews plugins (no duplication).
-- **`lib/integrations/github.ts`** — `GHWatcherItemMeta` is correctly imported
-  by both github-stars and github-forks plugins (no duplication).
-- **`components/sidebar-01/types.ts`** — local sidebar types
-  (`NavItem`, `User`, `FavoriteItem`, `TeamItem`, `TopicItem`, `SidebarData`).
-  Used only inside `components/sidebar-01/`. Should stay local.
-- **`app/actions.ts`** exports `Snapshot` and `EnvKeyStatus`; both are
-  consumed via `import type` from the same module — this is fine (server
-  actions module is the canonical owner).
-- **`lib/db/client.ts`** exports `DatabaseKind` and `DatabaseConfig`; only
-  used inside the same module — fine.
-- **`lib/env-keys.ts`** exports `EnvKeySpec`; only consumed by `app/actions.ts`
-  via `ENV_KEYS` — fine.
-- **Drizzle inferred types** — none are currently re-exported, but no consumer
-  imports them either. `loadSnapshot` reads via raw SQL and constructs
-  `Snapshot` directly. Not an issue today; only worth re-deriving if a future
-  consumer needs `typeof columns.$inferSelect`.
+## Current state
 
-The existing organization is solid — there is no `lib/types/` directory, and
-there shouldn't be one: domain types already live with the abstraction that
-owns them (columns contract in `lib/columns/types.ts`, plugin metas with the
-plugin, sidebar widgets with the sidebar). Component prop types are
-appropriately local.
+The codebase has a clean, intentional type hub at `lib/columns/types.ts` (the
+plugin/column contracts: `FeedItem`, `PageResult`, `PluginMeta`, `ColumnUI`,
+`ServerFetcher`, `Column`, `Deck`, etc.) and an established, correct
+consolidation *pattern* for per-plugin renderer metadata:
 
-## Real duplications (HIGH confidence)
+> The plugin's `plugin.ts` OWNS its `XxxMeta` renderer contract; the matching
+> `lib/integrations/*.ts` fetcher *imports* that type and re-exports it.
 
-Three integration files declare types that are **byte-for-byte duplicates** of
-the canonical types in their corresponding plugin folder. The plugin owns the
-authoritative shape (it's `z.infer<typeof schema>` for configs, and the meta
-is what the renderer + server actually consume). The integration version is a
-hand-written copy that drifts silently.
+Already following this correctly:
+- `lib/integrations/github.ts:2` imports `GHPRMeta` from the github-prs plugin,
+  re-exports as `GHPRItemMeta`.
+- `lib/integrations/blockscout.ts:2` imports + re-exports `WalletTxMeta`.
+- `lib/integrations/substack.ts` re-exports `SubstackMeta`;
+  `lib/integrations/github-backlinks.ts:2` re-exports `BacklinkSource`.
+- Alias pattern (one def, aliased on reuse): `apple-reviews/plugin.ts:13` &
+  `play-reviews/plugin.ts:13` alias `AppReviewMeta`; `github-stars/plugin.ts:12`
+  & `github-forks/plugin.ts:12` alias `GHWatcherItemMeta`.
 
-| # | Type | Duplicate locations | Canonical home (recommend) |
-|---|------|---------------------|----------------------------|
-| 1 | `WalletTxMeta` | `lib/integrations/blockscout.ts:53` (with `[key:string]:unknown` index sig) **and** `lib/columns/plugins/wallet-tx/plugin.ts:24` | Plugin (`wallet-tx/plugin.ts`). Integration should `import type { WalletTxMeta }` from the plugin. |
-| 2 | `BacklinkSource` + `BacklinksConfig` | `lib/integrations/github-backlinks.ts:7,14` **and** `lib/columns/plugins/github-backlinks/plugin.ts:10,12` | Plugin. Integration should import from the plugin. |
-| 3 | `SubstackMeta` | `lib/integrations/substack.ts:16` **and** `lib/columns/plugins/substack/plugin.ts:12` | Plugin. Integration should import from the plugin. |
-| 4 | `GHPRItemMeta` (integration) ↔ `GHPRMeta` (plugin) | `lib/integrations/github.ts:250` **and** `lib/columns/plugins/github-prs/plugin.ts:16` | Same shape, different name. Plugin's `GHPRMeta` is the consumed name (used in client.tsx `ItemRendererProps<GHPRMeta>`). Integration should import `GHPRMeta` from the plugin and drop its own. |
+The problem: **most other plugins do NOT follow this pattern** — they define an
+`XxxMeta` interface that is a second, independent copy of the `XxxMeta` in their
+integration file. The copies are never cross-imported, so they can silently
+drift. There is also a cluster of near-identical "column-without-items" /
+"deck-export-payload" shapes across `app/actions.ts`, `use-deck-store.ts`, and
+`lib/deck-templates.ts`, plus a hand-written DB row type that restates the
+Drizzle schema. No file uses `InferSelectModel`/`$inferSelect` anywhere
+(verified by whole-repo grep).
 
-For all four, the plugin file is server-safe (it imports nothing client-only —
-just zod + a lucide icon ref), so an integration importing from it stays inside
-the server bundle.
+---
 
-Note: an integration → plugin import is the inverse of the typical plugin →
-integration import path used elsewhere. That's fine because the meta type is a
-shared *contract* between fetcher (integration) and renderer (plugin), not a
-fetcher implementation detail. We could equally move the meta to a third file,
-but the plugin file is already the source of truth that every consumer reads.
+## Concrete problems
 
-## Borderline / coincidentally similar — DO NOT consolidate
+### P1 — 13 duplicated `*Meta` renderer-contract interfaces (integration ⇄ plugin)
 
-- `HNMeta` (plugin) vs `HNSearchHitMeta` (integration) — *different* shapes
-  (the search variant has `kind`, `storyTitle`, `commentsUrl`); they evolve
-  independently.
-- `FCMeta` (plugin) vs `NeynarCast` (integration) — totally different; one is
-  domain, other is API DTO.
-- The various `Xxx*Response` / DTO interfaces inside integrations
-  (`AlgoliaResponse`, `WeiboSearchResponse`, `GHRepo`, `GHIssue`,
-  `NeynarCastsResponse`, `BSResponse`, etc.) are private to a single
-  integration file. Keep local.
-- `Chain` (blockscout) and the wallet-tx plugin's `z.enum([...chains])` — the
-  list of chain ids is duplicated as a const tuple and a zod enum, but
-  consolidating would require deriving the zod enum from `SUPPORTED_CHAINS`
-  with `z.enum(SUPPORTED_CHAINS as unknown as readonly [string, ...string[]])`
-  — adds friction without reuse benefit. Leave alone.
+Each pair defines the SAME interface twice. Field structure is identical
+(verified by diffing each interface body with comments/blank-lines stripped).
+They are never cross-imported, so an edit to one side is a silent type-safety
+gap until the other is hand-updated.
 
-## Component prop types — keep local
+| Type | Integration def | Plugin def |
+|------|-----------------|------------|
+| `PypiMeta` | `lib/integrations/pypi.ts:40` | `lib/columns/plugins/pypi/plugin.ts:12` |
+| `CoingeckoMeta` | `lib/integrations/coingecko.ts:32` | `lib/columns/plugins/coingecko/plugin.ts:12` |
+| `CratesMeta` | `lib/integrations/crates.ts:31` | `lib/columns/plugins/crates/plugin.ts:14` |
+| `DefillamaMeta` | `lib/integrations/defillama.ts:28` | `lib/columns/plugins/defillama/plugin.ts:18` |
+| `DevtoMeta` | `lib/integrations/devto.ts:60` | `lib/columns/plugins/devto/plugin.ts:12` |
+| `DexscreenerMeta` | `lib/integrations/dexscreener.ts:31` | `lib/columns/plugins/dexscreener/plugin.ts:13` |
+| `LobstersMeta` | `lib/integrations/lobsters.ts:116` | `lib/columns/plugins/lobsters/plugin.ts:12` |
+| `NpmMeta` | `lib/integrations/npm.ts:24` | `lib/columns/plugins/npm/plugin.ts:14` |
+| `PolymarketMeta` | `lib/integrations/polymarket.ts:53` | `lib/columns/plugins/polymarket/plugin.ts:12` |
+| `ProductHuntMeta` | `lib/integrations/producthunt.ts:20` | `lib/columns/plugins/producthunt/plugin.ts:12` |
+| `StackOverflowMeta` | `lib/integrations/stackoverflow.ts:47` | `lib/columns/plugins/stack-overflow/plugin.ts:12` |
+| `ArxivMeta` | `lib/integrations/arxiv.ts:32` | `lib/columns/plugins/arxiv/plugin.ts:28` |
+| `HuggingfaceMeta` | `lib/integrations/huggingface.ts:19` | `lib/columns/plugins/huggingface/plugin.ts:13` |
 
-All `interface Props { ... }` blocks in
-`components/{column,deck,dialogs,sidebar-01,onboarding,settings}/*` and
-`components/relative-time.tsx` are component-local prop shapes that aren't
-reused anywhere else. Standard React practice. No action.
+(`HuggingfaceMeta`: the only field difference is `resource: HuggingfaceResource`
+in the integration vs `resource: HuggingfaceConfig["resource"]` in the plugin —
+both resolve to the identical `"models" | "datasets" | "spaces"` union.)
 
-## Plan
+Verified safe to consolidate:
+- None of the 13 integration files import from their plugin yet (no existing
+  cycle); none of the 13 `plugin.ts` files import from their integration (so the
+  `integration → plugin` direction creates no cycle — `plugin.ts` is pure meta).
+- The integration `*Meta` is referenced ONLY inside its own integration file
+  (`FeedItem<XxxMeta>` return types); the plugin `*Meta` ONLY by that plugin's
+  `server.ts`/`client.tsx`/`plugin.ts`. No external/hidden consumer (grepped the
+  whole repo for each of the 13).
+- Direction to use is the already-shipping one: integration imports the plugin's
+  `XxxMeta` and re-exports it — mirroring github-prs / wallet-tx / substack.
 
-Apply the four HIGH-confidence consolidations:
+### P2 — `GHActionRunMeta` vs `GHActionsMeta` duplication forces an unsafe cast
 
-1. Make `lib/integrations/blockscout.ts` re-export `WalletTxMeta` from
-   `lib/columns/plugins/wallet-tx/plugin.ts`.
-2. Make `lib/integrations/github-backlinks.ts` re-export `BacklinkSource` and
-   `BacklinksConfig` from `lib/columns/plugins/github-backlinks/plugin.ts`.
-3. Make `lib/integrations/substack.ts` re-export `SubstackMeta` from
-   `lib/columns/plugins/substack/plugin.ts`.
-4. Make `lib/integrations/github.ts` re-export `GHPRMeta` (renaming
-   `GHPRItemMeta` → `GHPRMeta`) from `lib/columns/plugins/github-prs/plugin.ts`.
+`lib/integrations/github.ts:891` (`GHActionRunMeta`) and
+`lib/columns/plugins/github-actions/plugin.ts:18` (`GHActionsMeta`) are
+structurally identical — the `status`/`conclusion` unions are the same members,
+named via `GHActionStatus`/`GHActionConclusion` in the integration vs inlined in
+the plugin. Because they are two types, `github-actions/server.ts:33` is forced
+to launder the fetcher output through `items as unknown as FeedItem<GHActionsMeta>[]`
+— an `as unknown as` double-cast whose own comment (`server.ts:26-31`) admits
+"we could re-export the integration type." Consolidation removes a genuine
+type-erasing cast, not just a redundant declaration — the single highest-value
+case. (Best to also align the inlined plugin unions to reuse the exported
+`GHActionStatus`/`GHActionConclusion`.)
 
-Each consolidation is a re-export so existing call sites that already
-`import { ... } from "@/lib/integrations/..."` keep working.
+### P3 — Column-row shape redefined ~5× (one app shape + literals)
 
-Verified after the fact with `npx tsc --noEmit` and `npm run lint`.
+The "a column's persisted fields, minus `items`" shape is written by hand in
+multiple places kept in lockstep manually:
+
+- `Column` — `lib/columns/types.ts:139` (canonical; adds `items` +
+  `lastFetchedAt`).
+- `ImportedDeckColumn` — `app/actions.ts:587` (`Column` minus
+  `items`/`lastFetchedAt`, plus `id`).
+- The inline literal in `importedDeckPatch` —
+  `lib/store/use-deck-store.ts:325-339` — builds the `Column` field set from an
+  `ImportedDeckColumn`, field-by-field.
+- The optimistic-insert literals in `addColumn`
+  (`use-deck-store.ts:610-613`) and `duplicateColumn`
+  (`use-deck-store.ts:662-685`) build the same shape by hand.
+
+A new persisted column field (history shows `tabGroup`, `pinned`, `color`, …)
+must be threaded through `Column`, `ImportedDeckColumn`, the Zod
+`importedColumnSchema` (`actions.ts:480`), the `importedDeckPatch` literal, AND
+the two optimistic-insert literals — 5+ edit sites for one field. Duplication of
+*structure*, not just a name.
+
+### P4 — Deck-export payload shape duplicated across export / template / Zod
+
+The DeckExport v1 payload is described three times:
+- `DeckExport = z.infer<typeof importedDeckSchema>` — `app/actions.ts:516-529`.
+- `DeckTemplateColumn` — `lib/deck-templates.ts:26-56` (= DeckExport's column
+  shape minus `notifyWebhookUrl`).
+- `DeckTemplatePayload` — `lib/deck-templates.ts:58-69` (= DeckExport minus
+  `exportedAt`).
+
+`deck-templates.ts`'s own header comment says templates "use the SAME schema as
+Export/Import/Share" — yet the type is re-declared rather than derived.
+
+### P5 — Hand-written DB row type duplicates the Drizzle schema
+
+`ItemRow` — `app/actions.ts:39-47` — hand-types the `feed_items` row returned by
+the raw `db.execute(sql\`…\`)` window query in `loadSnapshot`, restating columns
+already in `lib/db/schema.ts:61-79` (`feedItems`). Because it's a raw-SQL result
+(snake_case `column_id`, `created_at`) it can't be a clean `InferSelectModel`,
+but the `author`/`meta` jsonb field types could reference the schema-derived
+types instead of re-asserting them. This is the one place
+`InferSelectModel`/`$inferSelect` would replace a hand-written row type. Lower
+value than P1–P4 (single site, raw-SQL boundary).
+
+### P6 — Thin dialog `Props` overlap (do NOT merge)
+
+Seven+ dialog components each declare a local `interface Props` sharing
+`{ open: boolean; onOpenChange: (open: boolean) => void }`
+(`confirm-dialog.tsx:17`, `rename-dialog.tsx:16`, `deck-color-dialog.tsx:44`,
+`version-history-dialog.tsx:18`, `import-deck-dialog.tsx:18`,
+`configure-column-dialog.tsx:32`, `add-column-dialog.tsx:27`,
+`settings-dialog.tsx:24`). The rest of each `Props` is dialog-specific. This is
+coincidental overlap with a 2-field payload, not a shared concept — extracting a
+`DialogControlProps` base saves little and couples independent components.
+Documented so a later pass doesn't over-merge. Recommend NOT merging.
+
+---
+
+## Prioritized recommendations
+
+1. **[High] T1 — Consolidate the 13 duplicate `*Meta` interfaces (P1).** Per
+   pair, delete the integration-side copy, `import type { XxxMeta }` from the
+   plugin, and re-export it for the integration's own consumers — exactly the
+   github-prs / wallet-tx / substack pattern already in the tree. Pure
+   structural dedupe, zero behavior change, no cycle risk (verified). tsc stays
+   green (field-identical types).
+
+2. **[High] T2 — Unify `GHActionRunMeta` / `GHActionsMeta`, drop the unsafe cast
+   (P2).** Make `github-actions/plugin.ts` reuse the integration's
+   `GHActionRunMeta` (+ exported `GHActionStatus`/`GHActionConclusion`), then
+   replace `items as unknown as FeedItem<GHActionsMeta>[]`
+   (`github-actions/server.ts:33`) with a direct return. Removes a real
+   type-erasing double-cast — highest single-case payoff.
+
+3. **[Medium] T3 — Derive the import/optimistic column shapes from one source
+   (P3).** Define a single `PersistedColumnFields` (the `Column` fields minus
+   `items`/`lastFetchedAt`) in `lib/columns/types.ts` and express
+   `ImportedDeckColumn`, the `importedColumnSchema` inference target, and the
+   `importedDeckPatch`/`addColumn`/`duplicateColumn` literals in terms of it.
+   Medium — crosses the server-action ↔ store boundary; must preserve the
+   store's `undefined` vs the DB's `null` semantics exactly.
+
+4. **[Medium] T4 — Make templates derive from the DeckExport types (P4).**
+   Express `DeckTemplateColumn`/`DeckTemplatePayload` as `Omit` over the
+   `DeckExport` (`z.infer`) shape (template column = export column minus
+   `notifyWebhookUrl`; template payload = export minus `exportedAt`). Honors the
+   file's own "SAME schema as Export" claim. Medium — `DeckExport` lives in the
+   `"use server"` `actions.ts`; a `import type` of it is allowed (types aren't
+   runtime exports) but verify the client-side import boundary for templates.
+
+5. **[Low] T5 — Replace the hand-written `ItemRow` with schema-derived types
+   (P5).** Base the `author`/`meta`/column field types in `ItemRow`
+   (`app/actions.ts:39`) on `InferSelectModel<typeof feedItems>` /
+   `feedItems.$inferSelect`, keeping the snake_case raw-SQL field names. Low —
+   single site, raw-SQL boundary, modest payoff.
+
+6. **[Low / do-not-do] T6 — Dialog `Props` (P6).** Leave as-is; documented above
+   as coincidental overlap, not a shared concept. Listed only to prevent a later
+   over-merge.
+
+## Confidence notes
+- T1, T2 are High: I verified (whole-repo grep) no hidden consumers of the
+  integration-side duplicates, no import cycles, identical field structures, and
+  that the consolidation direction matches an already-shipping pattern in the
+  same repo. tsc is green now and the changes are assignment-compatible.
+- T3, T4 are Medium: the shapes are genuinely related but the edit crosses the
+  server-action / store / DB-`null` boundary where `undefined` ↔ `null`
+  semantics must be preserved exactly — more than a mechanical move.
+- T5 is Low (single raw-SQL site). T6 is explicitly "do not merge."
+
+---
+
+## IMPLEMENTATION (phase 2) — applied 2026-06-14
+
+All re-verified against the current tree before editing; `npx tsc --noEmit`
+ends at 0 errors and `npx next build` succeeds (registry/server-registry parity
+checks pass at module init). eslint unchanged at baseline (26 errors + 7 warns).
+
+- **T1 — DONE (all 13).** Each integration now `import type { XxxMeta }` from
+  its plugin and `export type { XxxMeta }` (mirroring the github-prs / wallet-tx
+  / substack pattern); the local interface was deleted. The richer field doc
+  comments that lived on the integration side (pypi, defillama, producthunt,
+  arxiv) were moved onto the plugin-owned interface so no documentation was lost.
+  huggingface: the plugin's `resource: HuggingfaceConfig["resource"]` is now the
+  single definition; `HuggingfaceResource` stays in the integration (still used
+  by 3 internal helpers).
+- **T2 — DONE.** `GHActionsMeta` (+ new named `GHActionStatus` /
+  `GHActionConclusion` field unions) is now owned by `github-actions/plugin.ts`;
+  `github.ts` imports + re-exports them and aliases `GHActionRunMeta =
+  GHActionsMeta`. The `items as unknown as FeedItem<GHActionsMeta>[]` double-cast
+  in `github-actions/server.ts` is removed — the fetcher output now flows through
+  directly (the unused `FeedItem` import was dropped too).
+- **T3 — PARTIALLY DONE (the safe parts).** `ImportedDeckColumn` is now
+  `Omit<Column, "items" | "lastFetchedAt">`; the `importedDeckPatch` literal in
+  the store collapsed to `{ ...c, items: [] }`. The `addColumn` literal
+  (`{ id, typeId, title, config, items: [] }`) was left as-is — it is the minimal
+  new-column shape, not duplicated structure. The `duplicateColumn` literal was
+  left as-is — it is intentional per-field selection with divergent semantics
+  (config shallow-copy, deliberate `pinned: undefined`, documented color
+  inheritance), NOT mechanical duplication. No `PersistedColumnFields` type was
+  introduced: the Zod `importedColumnSchema` is the runtime validator and must
+  stay hand-maintained (per-field bounds + comments); deriving it from a TS type
+  is impossible and the reverse (`z.infer`) is already how `DeckExport` is built.
+- **T4 — DONE.** `DeckTemplateColumn = Omit<DeckExport["columns"][number],
+  "notifyWebhookUrl">` and `DeckTemplatePayload = Omit<DeckExport, "exportedAt" |
+  "columns"> & { version; columns: DeckTemplateColumn[] }`, via a type-only
+  `import type { DeckExport } from "@/app/actions"` (proven-safe pattern —
+  version-history-dialog already type-imports from the "use server" actions
+  module; the build confirms the client bundle stays clean).
+- **T5 — SKIPPED (not a safe improvement).** Deriving `ItemRow.author` from
+  `feedItems.$inferSelect` would type it as `unknown` (the schema's `author`
+  jsonb has no `.$type<>()` annotation), which is WEAKER than the current
+  `FeedItem["author"]`. The existing hand-typing carries strictly more type
+  info than the schema would, so the "derive from schema" rec would regress
+  precision. Left as-is.
+- **T6 — NOT DONE (by design).** Dialog `Props` left untouched, as assessed.

--- a/TYPES_WEAK_ASSESSMENT.md
+++ b/TYPES_WEAK_ASSESSMENT.md
@@ -1,43 +1,175 @@
-# Weak Types Assessment
+# Dimension #5 — Weak Types (any / unknown / unsafe casts) — Assessment
 
-Searched 171 .ts/.tsx files (excluding node_modules, .next, components/ui).
+**Scope:** lib/, app/, components/, hooks/ (242 .ts/.tsx, strict mode ON).
+**Phase:** ASSESSMENT (read-only). No source changed.
+**Verified baseline:** `npx tsc --noEmit` → **0 errors** (green).
 
-## Summary
+> NOTE: a prior version of this file existed and is now **stale** — both of its two
+> "HIGH-confidence" fixes (`actions.ts` `as unknown as {rows}` cast, and the
+> `column-card.tsx` `--beam-radius as never` style keys) have **already been applied**
+> in the current source (`app/actions.ts:123` now reads `(itemResult.rows ?? []) as
+> ItemRow[]` directly; `column-card.tsx:347` already uses
+> `CSSProperties & Record<\`--${string}\`, string | number>`). This file replaces it
+> with the current, re-verified state.
 
-The codebase is in good shape type-wise. There are no `: any` annotations,
-no `Record<string, any>`, no `: Function`, no `: object`, no `@ts-ignore`,
-no `@ts-expect-error`, and no `eslint-disable @typescript-eslint/no-explicit-any`.
+## TL;DR
 
-Most `unknown` usage is legitimate (boundary input pre-validation, pagination
-cursor blobs, plugin config erasure). What remains:
+This codebase is **already in the top decile** on weak types. **Zero** `: any` annotations,
+**zero** `as any`, **zero** `@ts-ignore` / `@ts-expect-error` / `@ts-nocheck`. Re-verified the
+prompt baseline:
 
-| Location | Current | Recommended | Source | Confidence | Action |
-| --- | --- | --- | --- | --- | --- |
-| `app/actions.ts:88` | `(itemResult as unknown as { rows?: ItemRow[] }).rows ?? []` (with `Array.isArray` branch) | direct `itemResult.rows` access | All three drivers (`drizzle-orm/pglite`, `drizzle-orm/neon-http`, `drizzle-orm/node-postgres`) return `{ rows: T[] }` from `db.execute()`. Confirmed in node_modules: `pglite/session.d.ts` `Results<T>`, `node-postgres/session.d.ts` `QueryResult<T>`, `neon-http/session.d.ts` `NeonHttpQueryResult<T>` — all have `.rows`. The `Array.isArray` branch is dead code. | HIGH | FIX |
-| `components/column/column-card.tsx:157-158` | `["--beam-radius" as never]: "10px"` | Use `CSSProperties & Record<\`--${string}\`, string>` for the style object so CSS custom property keys are valid statically | TS lib `React.CSSProperties` doesn't include `--*` keys; canonical pattern is to widen the style type. | HIGH | FIX |
-| `lib/db/client.ts:69,73` | `drizzlePglite(client, { schema }) as unknown as Db` and same for `drizzleNeonHttp` | Keep as is | Drizzle's three driver types are *structurally* compatible at the call sites we use, but TS sees them as nominally distinct because of the HKT brand. Inventing a unifying type would require duplicating Drizzle's internals. The cast is documented in the comment immediately above. | LOW | KEEP (legitimate) |
-| `lib/columns/types.ts:129,136` | `return ui as unknown as AnyColumnUI` in `defineColumnUI`/`defineColumnServer` | Keep as is | `TConfig` is invariant in `ConfigForm: ComponentType<ConfigFormProps<TConfig>>` (because of `onChange: (next: TConfig) => void`). Erasing to `Record<string, unknown>` is the explicit design — the JSDoc spells it out. Trying to make this sound would require either GADTs (TS doesn't have them) or runtime tagging that adds no value. | LOW | KEEP (legitimate, documented) |
-| `components/column/{add-column,configure-column}-dialog.tsx` `as never` casts on `ConfigForm`/`defaultTitle` calls | `as never` to bypass invariance of `TConfig` | Keep as is | Same root cause as above — the registry erases `TConfig`. The dialogs reconstitute the typed form by feeding the erased config back. `as never` is the standard escape hatch when you've deliberately erased a type parameter. Replacing with `as Record<string, unknown>` doesn't compile (the parameter is `TConfig`, not the erased type). | LOW | KEEP (architectural) |
-| `lib/integrations/github.ts:44` `pull_request?: unknown` on `GHIssue` | Used only for `!!i.pull_request` boolean check | Keep as `unknown` | The shape is irrelevant — only existence matters. `unknown` is the strongest type that supports a boolean coercion. | LOW | KEEP (legitimate) |
-| `lib/integrations/blockscout.ts:64,107,131,141` `Record<string, unknown>` for cursor blobs | Cursor is an opaque base64 of unknown JSON shape | Keep | Blockscout's `next_page_params` is intentionally schemaless (the API treats it as opaque too). The decoder only stringifies values, never inspects fields. | LOW | KEEP (legitimate) |
-| `lib/integrations/telegram.ts:214`, `lib/integrations/blockscout.ts:64` `[key: string]: unknown` index signatures on `Meta` types | Allow extension fields | Keep | The `Meta` types are stored as JSONB in the DB. Permissive index signature is intentional for forward compatibility. | LOW | KEEP (legitimate) |
-| `lib/integrations/app-reviews.ts` (`parsePlayReview`, `safeArrayAt`, JSON.parse → `unknown[]`) | Multiple `unknown` casts when parsing Google Play's untyped batchexecute response | Keep | This is exactly the pattern `unknown` was designed for: hostile/undocumented JSON, narrow with `typeof` / `Array.isArray` checks before use. | LOW | KEEP (legitimate) |
-| `app/actions.ts:25,79,139,157` `Record<string, unknown>` for column `config`/`meta` | JSONB column, schema is per-plugin | Keep | The DB column is `jsonb` and the runtime schema lives in plugin Zod definitions. The server action is intentionally schema-agnostic — narrowing happens in the API route via `entry.meta.schema.safeParse(rawConfig)`. | LOW | KEEP (legitimate) |
-| `lib/store/use-deck-store.ts:43,45`, `components/onboarding/welcome.tsx:18`, `components/column/{add,configure}-column-dialog.tsx`, `lib/columns/api-client.ts:5` `Record<string, unknown>` for column `config` | Store/dialog/API-client parameters | Keep | Same reason as above — the store is plugin-agnostic. | LOW | KEEP (legitimate) |
-| `lib/integrations/xai.ts:75` `return parsed as GrokItem[]` after `JSON.parse` | LLM-generated JSON cast as `GrokItem[]` (which has all-optional fields) | Keep | `GrokItem` is fully optional; subsequent code defensively reads each field. Adding a Zod parse here for an LLM response would over-engineer "best-effort" parsing. | LOW | KEEP (legitimate) |
+- `: any` real type annotations — **0** (the 3 grep hits are the word "any" in prose comments:
+  `lib/integrations/mastodon.ts:13`, `lib/integrations/arxiv.ts:123`, `lib/columns/webhook.ts:58`).
+- `as any` — **0**.
+- `unknown` — **66 lines**, of which I judge **1 actionable** (T1); the rest are legitimate
+  boundary types.
+- `as unknown as` — **7 sites**, all documented and legitimate (registry erasure + DB driver
+  union).
+- `as never` — **5 sites**, all the documented config-erasure escape hatch (legitimate).
 
-## HIGH-confidence changes to implement
+The floor is so high that recommendations are small and mostly Medium/Low. There is exactly **one
+fully-safe, behavior-preserving High win** (T1: Drizzle `$type` on the `config` column). Do **not**
+"harden" the legitimate boundary `unknown`s — that is churn with real risk and no semantic gain.
 
-1. `app/actions.ts:86-88` — drop `Array.isArray` branch and `as unknown as` cast; access `.rows` directly.
-2. `components/column/column-card.tsx:154-159` — type the inline style as `CSSProperties & Record<\`--${string}\`, string>` (or use a named type) and drop the `as never` casts on the keys.
+---
 
-## What was NOT changed (and why, briefly)
+## LEGITIMATE — leave alone (so a later agent doesn't churn it)
 
-- All `Record<string, unknown>` configs/meta — the architecture is genuinely
-  type-erased at the registry boundary; per-plugin types live in Zod schemas.
-- All driver-cast `as unknown as Db` — different Drizzle driver brand types,
-  identical call surface; cast documented at the cast site.
-- All JSON-parse `unknown` paths — correct usage of `unknown` at trust
-  boundaries.
-- Catch blocks — `err` is implicit `unknown` in modern TS, narrowed via
-  `err instanceof Error` before use throughout.
+1. **Registry config-erasure casts** — `lib/columns/types.ts:129,136`
+   (`return ui as unknown as AnyColumnUI`). `TConfig` is invariant (it appears in
+   `onChange: (next: TConfig) => void`), so a typed `ColumnUI<C,M>` is not assignable to the erased
+   `ColumnUI<Record<string,unknown>, unknown>` without the cast. Documented at lines 120-124.
+   `AnyColumnUI` / `AnyColumnServer` (`types.ts:98,118`) widen `TMeta` to `unknown` on purpose. **Keep.**
+
+2. **DB driver-union casts** — `lib/db/client.ts:69,73`
+   (`drizzlePglite(...) as unknown as Db`, `drizzleNeonHttp(...) as unknown as Db`). Three concrete
+   Drizzle driver return types unified into one `Db` (node-pg shape) so call sites are
+   driver-agnostic. Documented at lines 61-62. The node-pg branch (line 77) needs no cast; the other
+   two do because the driver brand types are nominally distinct. **Keep.**
+
+3. **Config-erasure `as never` at the consumer** — `components/column/add-column-dialog.tsx:105,110,239,242`
+   and `components/column/configure-column-dialog.tsx:218`. `selectedType` is `AnyColumnUI` (config
+   erased), but `selectedType.ConfigForm` wants `ConfigFormProps<TConfig>` and
+   `selectedType.defaultTitle` wants `(config: TConfig)`. `TConfig` is unknowable at this erased call
+   site, so `as never` (assignable to any `TConfig`) is the canonical escape hatch. Replacing with
+   `as Record<string,unknown>` does **not** compile (the param is the invariant `TConfig`, not the
+   erased type). Same root cause as #1. **Keep.**
+
+4. **`(await res.json()) as <WireType>`** — 35 sites across `lib/integrations/*` (e.g.
+   `github.ts:977`, `reddit.ts:124`, `youtube.ts:101`, `stackoverflow.ts:175`). The "raw external JSON
+   asserted to its declared wire shape" pattern the prompt called out as legitimate. The wire
+   interfaces are hand-written and accurate. Converting all 35 to Zod would be a large,
+   behavior-changing effort (Zod would reject unexpected upstream payloads that currently flow
+   through). **Out of scope for this dimension; keep.**
+
+5. **`as FeedItem<XMeta>[]` structural-bridge casts** — 31 plugin `server.ts` files (e.g.
+   `hacker-news/server.ts:16`, `youtube/server.ts:24,33`, `bluesky/server.ts:24`), plus the two
+   `as unknown as` variants at `github-actions/server.ts:33` and `github-discussions/server.ts:33`. I
+   diffed the two GitHub pairs field-by-field: `GHActionRunMeta` (`github.ts:891`) vs `GHActionsMeta`
+   (`plugins/github-actions/plugin.ts:18`), and `GHDiscussionMeta` (`github-discussions.ts:20`) vs
+   `GHDiscussionsMeta` (`plugins/github-discussions/plugin.ts:24`) — **structurally identical** (the
+   integration uses named union aliases, the plugin inlines the same literals). These casts encode a
+   deliberate, documented **ownership split** (plugin owns the renderer contract, integration owns the
+   fetch shape). See T4 for the only micro-tidy here. **Keep the split.**
+
+6. **`v as XConfig["mode"]` Select casts** — 26 plugin `client.tsx` Select `onValueChange` handlers
+   (e.g. `hacker-news/client.tsx:30`). Standard shadcn/Radix idiom: `onValueChange` is typed
+   `(value: string) => void` upstream and the `<SelectItem value>` set constrains the runtime domain.
+   Removing requires a generic typed-Select wrapper (UI-infra, out of scope). **Keep.**
+
+7. **Validator / narrowing helpers over `unknown`** — `lib/deck-rules.ts:24` (`value: unknown`),
+   `num(v: unknown, …)` in `coingecko.ts:117` / `defillama.ts:76` / `dexscreener.ts:69`,
+   `lib/integrations/app-reviews.ts:124-201` (`safeArrayAt`, `parsePlayReview` hand-narrowing Google
+   Play's positional-array JSON). Exemplary: `unknown` in → narrow → typed out. **Keep.**
+
+8. **Zod / JSON-parse boundaries** — `app/actions.ts:483` (`config: z.record(z.string(),
+   z.unknown())`), `app/actions.ts:628` (`let parsed: unknown; parsed = JSON.parse(json)` then
+   `safeParse`), `blockscout.ts:135` (`JSON.parse(json) as Record<string, unknown>` for an opaque
+   cursor blob). Textbook. **Keep.**
+
+9. **`config: Record<string, unknown>` plugin-config bag** — pervasive (`lib/columns/types.ts`
+   multiple, `lib/store/use-deck-store.ts:280,283`, `lib/columns/api-client.ts:5`,
+   `app/actions.ts:192,212,591`, `lib/deck-templates.ts:29`, `components/onboarding/welcome.tsx:40`,
+   `components/column/{add-column,configure-column}-dialog.tsx`). Column config is genuinely
+   heterogeneous across ~40 plugins; each plugin's Zod `schema` is the source of truth and validates
+   at the server/API boundary. `Record<string,unknown>` is the correct erased type — strengthening it
+   would need a discriminated union over every plugin and break the open plugin system. **Keep.**
+
+10. **`github.ts:52` `pull_request?: unknown`** — GitHub's Issues API attaches `pull_request` only to
+    *flag* that an "issue" is actually a PR; the code tests presence only, never reads fields.
+    Presence-only `unknown` is exactly right. **Keep.**
+
+11. **Comment-only / string "unknown"** — `column-card.tsx:93`, `templates-dialog.tsx:152`, and the
+    literal `"unknown"` author fallbacks (`blockscout.ts:280`, `github.ts:543`, `reddit.ts:85`,
+    `mastodon.ts:107`, `huggingface.ts:93`). Not types. **Keep.**
+
+---
+
+## ACTIONABLE problems (file:line)
+
+### T1 — `jsonb("config")` infers as `unknown`, forcing `as Record<string,unknown>` casts — **HIGH**
+
+`lib/db/schema.ts:28` declares `config: jsonb("config").notNull().default({})` with **no
+`.$type<>()`**. Drizzle infers an un-annotated `jsonb` select type as `unknown`, so every read casts:
+
+- `app/actions.ts:105` — `config: (c.config as Record<string, unknown>) ?? {}`
+- `app/actions.ts:438` — `config: (src.config as Record<string, unknown>) ?? {}`
+- `app/actions.ts:572` — `config: (c.config as Record<string, unknown>) ?? {}`
+
+**Fix:** annotate once —
+`config: jsonb("config").$type<Record<string, unknown>>().notNull().default({})`. Verified `.$type<T>()`
+exists on Drizzle 0.45.2's column builder (`node_modules/drizzle-orm/column-builder.d.ts:172`,
+documented for `json('details').$type<UserDetails>()`). After this, `c.config` / `src.config` are
+`Record<string,unknown>` and the three casts become plain reads. Keep the `?? {}` (preserves exact
+behavior). Insert/update sites (`actions.ts:200-206` `.values({ config })`, `updateColumnConfig`
+`.set({ config })`) already pass `Record<string,unknown>`, which matches the new `$type`, so they
+type-check unchanged. `$type` is **compile-time only** → no runtime behavior change. Single cleanest
+fully-verified win.
+
+### T2 — `xai.ts:76` asserts element shape after only `Array.isArray` — **MEDIUM**
+
+`lib/integrations/xai.ts:76` — `return parsed as GrokItem[];`. `parsed` is `JSON.parse(slice)`,
+checked only with `Array.isArray` (line 73); the **elements** are never validated as `GrokItem`, yet
+downstream reads typed fields. This is the weakest cast in the repo, on the least-trustworthy
+boundary (Grok LLM output). **Why Medium, not High:** `GrokItem`'s fields are all-optional and
+downstream code reads them defensively, so adding a Zod array parse is *behavior-adjacent* — it would
+start dropping/rejecting malformed elements that currently pass through. That crosses the
+"preserve all behavior" line for an assessment-confidence call. Confirm downstream tolerance before
+promoting.
+
+### T3 — `producthunt.ts:89` `item.meta as FeedRowMeta | undefined` — **LOW**
+
+`lib/integrations/producthunt.ts:89` narrows the upstream RSS item's `meta` (typed `unknown` via
+`FeedItem<TMeta=unknown>`) to `FeedRowMeta` with no runtime check. Internal (same module owns the
+producer), so low risk. **Fix (Low):** thread the concrete meta generic through the RSS fetch so
+`item.meta` arrives typed, or accept a typed param. Marginal benefit.
+
+### T4 — Narrow the two `as unknown as FeedItem<…>` GitHub casts to single-step `as` — **LOW**
+
+`github-actions/server.ts:33` and `github-discussions/server.ts:33` use `as unknown as
+FeedItem<…>[]`, while the other 29 structurally-identical plugin bridges use single-step `as
+FeedItem<…>[]`. Since the meta shapes are structurally identical (verified in #5 above), the
+double-cast can be a single `as`. Pure consistency tidy, no correctness gain. **Low.**
+
+---
+
+## Prioritized recommendations
+
+| # | Title | Confidence | Files |
+|---|-------|-----------|-------|
+| T1 | `.$type<Record<string,unknown>>()` on `config` jsonb column; drop 3 `as Record<string,unknown>` casts | **High** | lib/db/schema.ts; app/actions.ts |
+| T2 | Validate Grok LLM output with Zod instead of `as GrokItem[]` | Medium | lib/integrations/xai.ts |
+| T3 | Thread typed meta through producthunt RSS fetch (drop `item.meta as FeedRowMeta`) | Low | lib/integrations/producthunt.ts |
+| T4 | Narrow the two `as unknown as FeedItem<…>` GitHub casts to single-step `as` | Low | lib/columns/plugins/github-actions/server.ts; lib/columns/plugins/github-discussions/server.ts |
+
+**Do NOT touch:** every item in the LEGITIMATE section — registry erasure casts (`types.ts`), DB
+driver casts (`client.ts`), config-erasure `as never` (dialogs), the `(await res.json()) as Wire`
+integration casts, the `Record<string,unknown>` config bag, the Select `v as Config["mode"]` casts,
+and the `unknown`-input validators. All correct; preserve exactly.
+
+## Net assessment
+
+Strict mode on, zero `any`, zero `ts-ignore`, `unknown` used as a real type (narrow-then-use) rather
+than a lazy `any`. The only fully-safe, behavior-preserving improvement is **T1** (one schema
+annotation removing three casts). Everything else is a deliberate documented design boundary or a
+behavior-adjacent validation change belonging to a different (validation/safety) dimension.

--- a/UNUSED_ASSESSMENT.md
+++ b/UNUSED_ASSESSMENT.md
@@ -1,117 +1,165 @@
-# Unused Code Assessment
+# UNUSED CODE ASSESSMENT (Dimension #3)
 
-This document captures the findings of `npx knip` and `npx ts-prune` runs, with manual verification of every candidate. HIGH confidence items are removed in this branch; MEDIUM/LOW are flagged here for separate review.
+Phase: ASSESSMENT (read-only). No source changed. Tooling: `npx --yes knip@latest`
+(config-free), cross-checked with repo-wide `grep` for every candidate including
+dynamic/string refs, re-exports, and the plugin registries.
 
-Tools used:
-- `npx knip@latest --no-config-hints`
-- `npx ts-prune`
-- Manual `rg` searches across `*.ts`, `*.tsx`, `*.css`, `*.json`, `*.mjs`, `*.md` for each candidate
+Baselines confirmed at assessment time: `npx tsc --noEmit` -> 0 errors;
+`npx eslint` -> 33 problems (26 errors, 7 warnings).
 
-Conventions: knip's flag is shown verbatim; my verification result and decision follow.
-
----
-
-## Unused files — REMOVED (HIGH confidence)
-
-| File | Type | knip | Verification | Confidence | Decision |
-|---|---|---|---|---|---|
-| `components/deck/deck-tabs.tsx` | React component (`DeckTabs`) | unused | `rg DeckTabs` finds zero importers | HIGH | REMOVE |
-| `components/sidebar-01/nav-main.tsx` | React component (`NavMain`) | unused | no importers | HIGH | REMOVE |
-| `components/sidebar-01/nav-collapsible.tsx` | React component (`NavCollapsible`) | unused | only references itself + `sidebar-01/types.ts` | HIGH | REMOVE |
-| `components/sidebar-01/types.ts` | type module (`SidebarData`, `User`, etc.) | unused | only imported by `nav-collapsible.tsx` (also being removed) | HIGH | REMOVE |
-| `components/ui/card.tsx` | shadcn primitive | unused | zero importers | HIGH | REMOVE |
-| `components/ui/scroll-area.tsx` | shadcn primitive | unused | zero importers | HIGH | REMOVE |
-| `lib/integrations/telegram.ts` | integration module | unused | zero importers | HIGH | REMOVE |
-| `lib/integrations/weibo.ts` | integration module | unused | zero importers (note: `weibo-hot` plugin uses `newsnow.ts`, not this file) | HIGH | REMOVE |
-| `lib/mock/generators.ts` | mock data utilities | unused | zero importers | HIGH | REMOVE |
-
-## Unused files — KEPT (MEDIUM confidence)
-
-| File | Type | knip | Verification | Confidence | Decision |
-|---|---|---|---|---|---|
-| `lib/columns/plugins/_template/{plugin.ts,client.tsx,server.ts}` | Plugin scaffolding | unused | `rg _template` shows it's referenced from `README.md` and `lib/columns/README.md` as the canonical "copy this to add a source" template; `_template` is intentionally not registered. | MEDIUM | KEEP — documented intentional scaffolding |
+> NOTE: the prior contents of this file were STALE — they described files that no
+> longer exist (`components/deck/deck-tabs.tsx`, `lib/integrations/telegram.ts`,
+> `@tabler/icons-react`, `AvatarGroup`, …) and even mis-stated that
+> `getChainInfo`/`explorerAddressUrl` were "used internally" (they are not).
+> This rewrite reflects the CURRENT tree.
 
 ---
 
-## Unused dependencies — REMOVED (HIGH confidence)
+## TL;DR — the headline
 
-| Package | knip | Verification | Confidence | Decision |
-|---|---|---|---|---|
-| `@tabler/icons-react` | unused | `rg tabler` finds only `package.json`/`package-lock.json` entries; zero imports | HIGH | REMOVE |
-| `border-beam` | unused | `rg border-beam` finds only CSS *comments* describing visual feel; no actual usage | HIGH | REMOVE |
+knip output, decoded against the actual tree:
 
-## Unused dependencies — KEPT (peer / runtime requirement)
+- **Unused files (3):** all under `lib/columns/plugins/_template/` — INTENTIONAL
+  scaffolding, KEEP (safety rule #2). Nothing else is an unused file.
+- **Unlisted dependencies (53):** every one is `server-only`, a package that ships
+  transitively with Next.js. FALSE POSITIVE — not in `package.json` on purpose,
+  nothing to remove.
+- **Unused exports (107) / unused exported types (18):** the overwhelming majority
+  are **not dead code**. They are values/types that ARE referenced inside their own
+  module; only the `export` keyword is redundant (knip can't see that they have no
+  *cross-file* importer). Removing the `export` is mechanical, low-value churn and
+  in two cases (`schema`, `"use server"`) is load-bearing convention. Only **3**
+  exports are genuinely dead (no caller anywhere, including their own file).
 
-| Package | knip | Reason kept |
-|---|---|---|
-| `react-dom` | "unused" | Required by Next.js at runtime; not directly imported but DOM rendering depends on it. Removing breaks build. |
-| `@types/react-dom` | "unused devDep" | Conventional companion to `@types/react` for the Next.js + React 19 type ecosystem; safer to keep. |
-| `dotenv-cli` | "unlisted binary `dotenv`" | Used as `dotenv` binary in `npm run db:studio` script. |
-
----
-
-## Unused exports — REMOVED (HIGH confidence: function/type entirely unreferenced)
-
-| Export | File | Verification | Decision |
-|---|---|---|---|
-| `grokXUser` | `lib/integrations/xai.ts` | Zero references anywhere | REMOVE function |
-| `grokXMentions` | `lib/integrations/xai.ts` | Zero references | REMOVE function |
-| `grokAsk` | `lib/integrations/xai.ts` | Zero references | REMOVE function |
-| `searchHackerNewsByUrlOrKeyword` | `lib/integrations/hackernews.ts` | Zero references | REMOVE function |
-| `fetchSubreddit` | `lib/integrations/reddit.ts` | Only `fetchSubredditPage` is used (by `plugins/reddit/server.ts`); `fetchSubreddit` is a deprecated wrapper with zero refs | REMOVE function |
-| `AvatarGroup` | `components/ui/avatar.tsx` | Zero external use; not used internally | REMOVE function + export |
-| `AvatarGroupCount` | `components/ui/avatar.tsx` | Zero external use; not used internally | REMOVE function + export |
-| `AvatarBadge` | `components/ui/avatar.tsx` | Zero external use; not used internally | REMOVE function + export |
-
-## Unused exports — KEPT (MEDIUM: used internally; only the `export` keyword is redundant)
-
-These functions/types are referenced inside their own modules (callers, type aliases, JSDoc-by-type-position). Dropping the `export` would be mechanical churn rather than removing code. Listed here for completeness.
-
-- `pageFromCursor` (`lib/columns/paginate.ts`) — used by `sliceForPage` in same file
-- `buttonVariants` (`components/ui/button.tsx`) — used by `Button` props internally
-- `LOCAL_PGLITE_DIR`, `resolveDatabaseConfig`, `DatabaseKind`, `DatabaseConfig` (`lib/db/client.ts`) — used internally
-- `SUPPORTED_CHAINS`, `Chain`, `WalletTxMeta`, `getChainInfo`, `explorerTxUrl`, `explorerAddressUrl`, `isValidEvmAddress`, `encodeCursor`, `decodeCursor` (`lib/integrations/blockscout.ts`) — used internally
-- `compact` (`lib/columns/shared/tweet-renderer.tsx`) — used internally
-- `normalizeRepo`, `BacklinkSource`, `BacklinksConfig`, `NormalizedRepo` (`lib/integrations/github-backlinks.ts`) — internal
-- `normalizeGitHubRepo`, `GHMode`, `GHSearchScope`, `GHPRItemMeta`, `GHWatcherItem`, `GHWatcherPage` (`lib/integrations/github.ts`) — internal
-- `HNMode`, `HNSearchScope`, `HNSearchSort`, `HNSearchHitMeta` (`lib/integrations/hackernews.ts`) — internal
-- `FCMode`, `FCWindow` (`lib/integrations/farcaster.ts`) — internal
-- `YTMode`, `YTOrder` (`lib/integrations/youtube.ts`) — internal
-- `SubstackMeta`, `ParsedHandle` (`lib/integrations/substack.ts`) — internal
-- `NewsNowPlatform`, `PLATFORM_LABELS` (`lib/integrations/newsnow.ts`) — internal
-- `AppReviewPlatform` (`lib/integrations/app-reviews.ts`) — internal
-- `GrokTool` (`lib/integrations/xai.ts`) — internal
-- `EnvKeySpec` (`lib/env-keys.ts`) — used by `ENV_KEYS` typing
-- `FeedAuthor`, `ColumnCategory`, `ColumnCapabilities`, `ColumnUI`, `ColumnServer` (`lib/columns/types.ts`) — these are the documented public typing surface for the plugin contract; `defineColumnUI`/`defineColumnServer` consume them. Removing exports would weaken the documented API.
-- `ColumnType<T>` (`lib/columns/types.ts`) — back-compat alias; types.ts comments say "old code imported `ColumnType`". Could be dropped if no consumers remain. Flagged but kept for now (low-risk to keep).
-- `NewsNowItemMeta` (`lib/columns/plugins/_newsnow/renderer.tsx`) — leave alone for plugin-shape consistency
-- `schema` exports across all 30+ plugins (`lib/columns/plugins/<id>/plugin.ts`) — consistent plugin pattern; the `meta.schema` field re-exposes them. Stylistic, leave alone.
-
-## Unused shadcn UI re-exports — KEPT (MEDIUM)
-
-These shadcn components export several named primitives (e.g. `Command`, `CommandShortcut`, many `Sidebar*`, several `Select*`, `Sheet*`, `Dialog*`, `DropdownMenu*`, `InputGroup*`) that are unused externally but are part of the shadcn primitive's standard surface. Several are also used *internally* by the same file (e.g. `useSidebar`, `DialogPortal`, `DialogOverlay`). Removing each one is mechanical churn that diverges from upstream shadcn templates and complicates future component additions. Recommend a separate cleanup pass if/when these primitives are confirmed not needed.
-
-Specifically:
-- `components/ui/avatar.tsx`: `AvatarGroup`, `AvatarGroupCount`, `AvatarBadge` — REMOVED (unused everywhere; not standard shadcn primitives that ship with it)
-- `components/ui/dialog.tsx`: `DialogOverlay`, `DialogPortal`, `DialogTrigger` — KEPT (DialogOverlay/Portal used internally; DialogTrigger commonly part of dialog DX surface)
-- `components/ui/dropdown-menu.tsx`: 9 unused subcomponents — KEPT (standard shadcn API)
-- `components/ui/sidebar.tsx`: 10 unused subcomponents incl. `useSidebar` (internally used) — KEPT
-- `components/ui/select.tsx`, `components/ui/sheet.tsx`, `components/ui/input-group.tsx`, `components/ui/command.tsx` — same, KEPT
+So the real, safe deletion surface here is small: **3 dead functions.** Everything
+else is either intentional, a false positive, or an `export`-keyword tidy that the
+project's conventions argue against.
 
 ---
 
-## Other knip findings — informational
+## HIGH confidence — genuinely dead, safe to delete
 
-- "Unlisted dependency `server-only`": this package ships with Next.js (not in package.json directly). Safe to ignore.
-- "Unlisted binaries `next`, `eslint`, `drizzle-kit`, `dotenv`, `postcss`": these come from devDependencies of installed packages or are dependencies-of-dependencies. Safe to ignore.
+Each verified with `grep -rn "<sym>"` across `*.ts/*.tsx/*.mjs/*.js/*.json/*.md`
+(excluding `node_modules`/`package-lock.json`): the ONLY hit is the declaration
+itself — zero callers, no re-export, no dynamic/string reference.
+
+| # | Symbol | Location | Notes |
+|---|--------|----------|-------|
+| U1 | `getTemplate(id)` | `lib/deck-templates.ts:296` | Consumers of `deck-templates` (`app/gallery/page.tsx`, `components/dialogs/templates-dialog.tsx`, `components/onboarding/welcome.tsx`) import `TEMPLATES` / `templateAsImportJson` / types — never `getTemplate`. No internal caller either. |
+| U2 | `getChainInfo(chain)` | `lib/integrations/blockscout.ts:49` | Wraps `CHAINS[chain]`. No caller anywhere. The only blockscout symbol the `wallet-tx` plugin imports is `fetchAddressTransactions` (`lib/columns/plugins/wallet-tx/server.ts:16`). Removing it leaves `CHAINS`/`ChainInfo` still live (read by `explorerTxUrl` L54, fetch L116, L216), so no orphan cascade. |
+| U3 | `explorerAddressUrl(chain, address)` | `lib/integrations/blockscout.ts:57` | Sibling of `explorerTxUrl` (which IS used at L256). The address variant has zero callers. Same no-orphan reasoning as U2. |
+
+These three are independent, self-contained removals. After deleting them, re-run
+`tsc --noEmit` (expect 0) and `eslint` (expect <= 33).
 
 ---
 
-## Verification commands run
+## MEDIUM confidence — `export`-keyword tidy only (code is LIVE, not dead)
 
-```
-npx knip@latest --no-config-hints
-npx ts-prune
-rg <symbol> -g '*.ts' -g '*.tsx'           # for each export candidate
-rg <symbol> -g '*.ts' -g '*.tsx' -g '*.md' # for files referenced from docs
-```
+knip lists these as "unused exports", but each is referenced **inside its own file**.
+The function/const/type is NOT dead — only the `export` is unnecessary because no
+other module imports it. Down-scoping to file-private is safe and would shrink the
+public surface, but it is pure churn with no behavior change and modest value. Do
+NOT "delete" these — at most drop the `export` keyword.
+
+Representative verified set (hit counts are intra-file references):
+
+- `pageFromCursor` `lib/columns/paginate.ts:13` — called by `sliceForPage` (L24) in same file. (Other plugins import `sliceForPage`, never `pageFromCursor`.)
+- `captureDeckSnapshot` `app/actions.ts:774` — called 5x within `actions.ts` (L195/396/457/467/745). **CAUTION:** this lives in a `"use server"` file, so each export is a server-action RPC endpoint. No client imports it, so down-scoping is *probably* safe, but it touches the server-action boundary (safety rule #5) — treat as MEDIUM, verify no client `import { captureDeckSnapshot }` before touching.
+- `WEBHOOK_TIMEOUT_MS` `lib/columns/webhook.ts:10` — used at L136.
+- `LOCAL_PGLITE_DIR` `lib/db/client.ts:21` — used at L44.
+- `resolveDatabaseConfig` `lib/db/client.ts:33` — used at L59.
+- `REFRESH_INTERVAL_OPTIONS` `lib/deck-rules.ts:18` — used at L19/L21.
+- `COLOR_HEX_RE` `lib/deck-rules.ts:43` — used at L57. (Two components define their OWN local `COLOR_HEX_RE` copies — a DEDUPE concern, not an UNUSED one.)
+- `MAX_SHARE_JSON_BYTES` `lib/deck-share.ts:17` — used at L37/L39.
+- `SUPPORTED_CHAINS` `lib/integrations/blockscout.ts:16` — feeds `Chain` type (L28).
+- `explorerTxUrl` — actually USED cross-nothing but used internally at L256; knip did NOT flag it, listed here only to contrast with U2/U3.
+- `isValidEvmAddress` (L107->L211), `encodeCursor` (L125->L275), `decodeCursor` (L131->L217) `lib/integrations/blockscout.ts` — all used internally.
+- `parseCategoryFilter` `lib/integrations/defillama.ts:172` — used L193.
+- `normalizeRepo` `lib/integrations/github-backlinks.ts:27` — used L90.
+- `parseRepo` `lib/integrations/github-discussions.ts:82` — used L135.
+- `DiscussionsDisabledError` `lib/integrations/github-discussions.ts:112` — thrown L162/L173.
+- `normalizeGitHubRepo` `lib/integrations/github.ts:608` — used L808/L832/L964.
+- `PLATFORM_LABELS` `lib/integrations/newsnow.ts:16` — used L73.
+- `parseTopicFilter` `lib/integrations/producthunt.ts:111` — used L159.
+
+Unused exported TYPES, same story — each is referenced within its own file (so the
+type is live; only the `export` is redundant):
+
+- `DeckExport` `app/actions.ts:529` — used L564/L777/L818 (and conceptually the
+  whole share/template/snapshot subsystem). LIVE.
+- `FeedAuthor` `lib/columns/types.ts:5` (L13), `ColumnCategory` (L35->L75),
+  `ColumnCapabilities` (L48->L81) — part of the documented plugin contract surface
+  in `types.ts`; used internally and intended as public API. KEEP exports.
+- `DatabaseKind` `lib/db/client.ts:23` (L26), `DatabaseConfig` (L25->L35).
+- `DeckTemplateColumn` `lib/deck-templates.ts:26` (L68), `DeckTemplatePayload` (L58->L85).
+- `FCMode` (L18->L254), `FCWindow` (L19->L196/L277) `lib/integrations/farcaster.ts`.
+- `NormalizedRepo` `lib/integrations/github-backlinks.ts:22` (L27).
+- `GHWatcherItem` `lib/integrations/github.ts:601` (L604/L647/L686/L763/L842),
+  `GHActionStatus` (L872->L898/L921), `GHActionConclusion` (L880->L900/L922).
+- `GrokTool` `lib/integrations/xai.ts:32` (L38).
+- `ColumnWidth` `lib/store/use-deck-store.ts:125` (L166/L227).
+
+Two of the "unused type" reports are RE-EXPORT aliases that ARE consumed cross-file —
+knip false positives, KEEP as-is:
+
+- `BacklinkSource` `lib/integrations/github-backlinks.ts:14` is `export type { BacklinkSource }`
+  re-exporting the plugin's renderer contract; `github-backlinks/client.tsx` imports
+  and uses it (L14/L18/L26/L73/L75). LIVE across files.
+- `GHPRItemMeta` `lib/integrations/github.ts:9` is a legacy alias re-export
+  (`export type { GHPRMeta as GHPRItemMeta }`); kept for back-compat naming per its
+  own comment. Low risk; KEEP unless a deliberate API-rename pass owns it.
+
+---
+
+## LOW confidence / DO NOT TOUCH (false positives & intentional)
+
+- **`schema` export in all ~48 `plugins/<id>/plugin.ts`** (knip lists each, e.g.
+  `reddit/plugin.ts:5`, `arxiv/plugin.ts:20`, …). Each `schema` is consumed in the
+  SAME file by `meta.schema` and `defaultConfig: schema.parse({})`, and the
+  `*Config` type via `z.infer<typeof schema>`. It is the deliberate single-source-of-
+  truth plugin pattern (see `types.ts:76`). No external `import { schema }` exists
+  (grep: zero). This is convention, not dead code — KEEP every one.
+- **`lib/columns/plugins/_template/{plugin.ts,client.tsx,server.ts}`** — knip's only
+  "unused files". Intentional scaffolding, unregistered on purpose (safety rule #2).
+  KEEP.
+- **`lib/columns/plugins/_newsnow/renderer.tsx`** — NOT flagged by knip; it is imported
+  by 6 Chinese "hot" plugin clients (baidu/bilibili/douyin/toutiao/weibo/zhihu). LIVE.
+  Mentioned only to confirm rule #2 holds.
+- **`server-only` (53 "unlisted dependency" rows)** — transitive Next.js package, not a
+  direct dependency by design. FALSE POSITIVE. Adding it to `package.json` would be
+  the only "fix" and is unnecessary; certainly nothing to delete.
+- **All shadcn `components/ui/*` re-exports** knip lists (`Command`, `CommandShortcut`,
+  `DialogPortal`, `DialogOverlay`, `DialogTrigger`, 9x `DropdownMenu*`, 10x `Sidebar*`
+  incl. `useSidebar`, several `Select*`/`Sheet*`/`InputGroup*`, `buttonVariants`) —
+  these are upstream shadcn primitive surfaces. Several are used internally
+  (`useSidebar`, `DialogOverlay`/`DialogPortal`, `buttonVariants`). Removing them
+  diverges from the generated shadcn templates and breaks future `shadcn add`
+  re-generation diffs. Recommend NOT pruning as part of an "unused code" pass; if a
+  team wants a leaner UI kit that is a separate, deliberate decision. LOW/KEEP.
+- **`scripts/db-migrate.mjs`**, Next entrypoints (`page.tsx`, `route.ts`, `layout.tsx`,
+  `generateMetadata`, icons) — not flagged; confirmed not dead.
+
+---
+
+## Prioritized recommendation list
+
+1. **[HIGH] Delete `getTemplate`** — `lib/deck-templates.ts:296`. Zero references.
+2. **[HIGH] Delete `getChainInfo`** — `lib/integrations/blockscout.ts:49`. Zero
+   references; `CHAINS`/`ChainInfo` stay live via other helpers.
+3. **[HIGH] Delete `explorerAddressUrl`** — `lib/integrations/blockscout.ts:57`. Zero
+   references; sibling `explorerTxUrl` stays.
+4. **[MEDIUM] Optional `export`-keyword down-scoping** of the intra-file-only exports
+   listed in the MEDIUM section (e.g. `pageFromCursor`, `WEBHOOK_TIMEOUT_MS`,
+   `LOCAL_PGLITE_DIR`, `resolveDatabaseConfig`, `parseCategoryFilter`, `normalizeRepo`,
+   `parseRepo`, `normalizeGitHubRepo`, `parseTopicFilter`, `PLATFORM_LABELS`,
+   `MAX_SHARE_JSON_BYTES`, `REFRESH_INTERVAL_OPTIONS`, and the matching types). Pure
+   surface-shrink, no behavior change. Skip `schema`, the plugin-contract types in
+   `types.ts`, and the `"use server"` action `captureDeckSnapshot` unless that is the
+   explicit goal.
+5. **[LOW] Leave** `_template`, `_newsnow`, all plugin `schema` exports, shadcn
+   re-exports, the `BacklinkSource`/`GHPRItemMeta` re-export aliases, and the
+   `server-only` "unlisted dependency" rows — false positives or intentional.
+
+After steps 1-3: re-run `npx tsc --noEmit` (expect 0) and `npx eslint`
+(expect <= 33). The three removals are independent and touch only their own files.

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -102,7 +102,7 @@ export async function loadSnapshot(): Promise<Snapshot> {
       id: c.id,
       typeId: c.typeId,
       title: c.title,
-      config: (c.config as Record<string, unknown>) ?? {},
+      config: c.config ?? {},
       alertKeywords: c.alertKeywords ?? undefined,
       notifyWebhookUrl: c.notifyWebhookUrl ?? undefined,
       refreshIntervalSeconds: c.refreshIntervalSeconds ?? undefined,
@@ -435,7 +435,7 @@ export async function duplicateColumn(
     id: newId,
     typeId: src.typeId,
     title,
-    config: (src.config as Record<string, unknown>) ?? {},
+    config: src.config ?? {},
     alertKeywords: src.alertKeywords ?? undefined,
     notifyWebhookUrl: src.notifyWebhookUrl ?? undefined,
     refreshIntervalSeconds: src.refreshIntervalSeconds ?? undefined,
@@ -569,7 +569,7 @@ export async function exportDeck(deckId: string): Promise<string> {
     columns: cols.map((c) => ({
       typeId: c.typeId,
       title: c.title,
-      config: (c.config as Record<string, unknown>) ?? {},
+      config: c.config ?? {},
       ...(c.alertKeywords ? { alertKeywords: c.alertKeywords } : {}),
       ...(isAllowedRefreshInterval(c.refreshIntervalSeconds)
         ? { refreshIntervalSeconds: c.refreshIntervalSeconds }
@@ -584,20 +584,12 @@ export async function exportDeck(deckId: string): Promise<string> {
   return JSON.stringify(payload, null, 2);
 }
 
-export interface ImportedDeckColumn {
-  id: string;
-  typeId: string;
-  title: string;
-  config: Record<string, unknown>;
-  alertKeywords?: string;
-  notifyWebhookUrl?: string;
-  refreshIntervalSeconds?: number;
-  filterKeywords?: string;
-  excludeKeywords?: string;
-  tabGroup?: string;
-  pinned?: boolean;
-  color?: string;
-}
+// A persisted column as returned from an import/restore: every field a `Column`
+// carries except the runtime-only `items` (fetched fresh on first view) and
+// `lastFetchedAt` (set on first fetch). Derived from `Column` so a new persisted
+// column field is threaded through automatically rather than hand-maintained
+// here in lockstep.
+export type ImportedDeckColumn = Omit<Column, "items" | "lastFetchedAt">;
 
 export interface ImportedDeckResult {
   deckId: string;

--- a/components/column/configure-column-dialog.tsx
+++ b/components/column/configure-column-dialog.tsx
@@ -27,6 +27,12 @@ import { getColumnType } from "@/lib/columns/registry";
 import { useDeckStore } from "@/lib/store/use-deck-store";
 import { parseAlertKeywords } from "@/lib/columns/keyword-match";
 import { validateWebhookUrl, WEBHOOK_URL_MAX } from "@/lib/columns/webhook";
+import {
+  COLOR_SWATCHES,
+  normalizeColumnColor,
+  normalizeTabGroup,
+  TAB_GROUP_MAX,
+} from "@/lib/deck-rules";
 import type { Column } from "@/lib/columns/types";
 
 interface Props {
@@ -36,35 +42,6 @@ interface Props {
 }
 
 const ALERT_KEYWORDS_MAX = 512;
-const TAB_GROUP_MAX = 50;
-const COLOR_HEX_RE = /^#[0-9a-fA-F]{6}$/;
-
-function normalizeTabGroup(raw: string): string {
-  return raw.replace(/\s+/g, " ").trim().slice(0, TAB_GROUP_MAX);
-}
-
-function normalizeHexColor(raw: string): string | null {
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) return null;
-  if (!COLOR_HEX_RE.test(trimmed)) return null;
-  return trimmed.toLowerCase();
-}
-
-// Preset swatches. Tuned to read distinctly against both the light and dark
-// surface tones used elsewhere in the app (no near-whites, no near-blacks).
-// The empty (no-color) state is offered as a "Clear" affordance separately
-// rather than as a swatch — a "no color" swatch and a real color swatch read
-// the same in the row and would confuse the operator.
-const COLOR_SWATCHES: { value: string; label: string }[] = [
-  { value: "#f97316", label: "Orange" }, // DeFi / on-chain default
-  { value: "#22c55e", label: "Green" },  // markets / portfolio
-  { value: "#3b82f6", label: "Blue" },   // dev / GitHub
-  { value: "#a855f7", label: "Purple" }, // social
-  { value: "#ec4899", label: "Pink" },   // creators / video
-  { value: "#eab308", label: "Yellow" }, // news / alerts-adjacent
-  { value: "#06b6d4", label: "Cyan" },   // research / AI
-  { value: "#94a3b8", label: "Slate" },  // archival / low-priority
-];
 
 // Sentinel for the Select value when the operator chooses "Manual only" —
 // Radix's Select disallows empty-string values, so we use a non-numeric token
@@ -194,7 +171,7 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
     // Normalize before the equality check so "#F97316", " #f97316 " and
     // "#f97316" all map to the same canonical value and don't trigger a
     // spurious update.
-    const nextColor = normalizeHexColor(colorDraft) ?? "";
+    const nextColor = normalizeColumnColor(colorDraft) ?? "";
     if (nextColor !== (column.color ?? "")) {
       updateColor(column.id, nextColor);
     }
@@ -202,8 +179,8 @@ export function ConfigureColumnDialog({ open, onOpenChange, column }: Props) {
   }
 
   const colorInputInvalid =
-    colorDraft.trim().length > 0 && normalizeHexColor(colorDraft) === null;
-  const previewColor = normalizeHexColor(colorDraft) ?? "";
+    colorDraft.trim().length > 0 && normalizeColumnColor(colorDraft) === null;
+  const previewColor = normalizeColumnColor(colorDraft) ?? "";
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/components/dialogs/deck-color-dialog.tsx
+++ b/components/dialogs/deck-color-dialog.tsx
@@ -14,32 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-
-// Same 6-hex rule the server enforces (`COLOR_HEX_RE` in app/actions.ts).
-// Matched client-side so the Save button can light up only when the input
-// is in canonical form — the server is still authoritative.
-const COLOR_HEX_RE = /^#[0-9a-fA-F]{6}$/;
-
-function normalizeHexColor(raw: string): string | null {
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) return null;
-  if (!COLOR_HEX_RE.test(trimmed)) return null;
-  return trimmed.toLowerCase();
-}
-
-// Same eight presets as the column-color picker (configure-column-dialog.tsx)
-// — keeps the two color surfaces visually coherent so an operator marking a
-// "DeFi" deck orange picks the same orange they'd use to color a DeFi column.
-const COLOR_SWATCHES: { value: string; label: string }[] = [
-  { value: "#f97316", label: "Orange" },
-  { value: "#22c55e", label: "Green" },
-  { value: "#3b82f6", label: "Blue" },
-  { value: "#a855f7", label: "Purple" },
-  { value: "#ec4899", label: "Pink" },
-  { value: "#eab308", label: "Yellow" },
-  { value: "#06b6d4", label: "Cyan" },
-  { value: "#94a3b8", label: "Slate" },
-];
+import { COLOR_SWATCHES, normalizeColumnColor } from "@/lib/deck-rules";
 
 interface Props {
   open: boolean;
@@ -64,11 +39,11 @@ export function DeckColorDialog({
   }
 
   const previewColor =
-    draft.trim().length === 0 ? "" : (normalizeHexColor(draft) ?? draft);
+    draft.trim().length === 0 ? "" : (normalizeColumnColor(draft) ?? draft);
   const colorInputInvalid =
-    draft.trim().length > 0 && normalizeHexColor(draft) === null;
-  const initialNormalized = normalizeHexColor(initialColor ?? "") ?? "";
-  const draftNormalized = normalizeHexColor(draft) ?? "";
+    draft.trim().length > 0 && normalizeColumnColor(draft) === null;
+  const initialNormalized = normalizeColumnColor(initialColor ?? "") ?? "";
+  const draftNormalized = normalizeColumnColor(draft) ?? "";
   // Save lights up either when the operator picks a different valid color, or
   // when they explicitly clear (initial had a color, draft is now empty).
   const cleared = draft.trim().length === 0 && initialNormalized.length > 0;

--- a/lib/columns/plugins/arxiv/plugin.ts
+++ b/lib/columns/plugins/arxiv/plugin.ts
@@ -26,6 +26,9 @@ export const schema = z.object({
 export type ArxivConfig = z.infer<typeof schema>;
 
 export interface ArxivMeta {
+  // Primary category as reported by arXiv (often more specific than the
+  // user's filter — a cs.AI paper might primary-cat as cs.LG when it's more
+  // ML than agentic, useful signal for the renderer).
   primaryCategory: string;
   categories: string[];
   authors: string[];
@@ -34,7 +37,14 @@ export interface ArxivMeta {
   arxivId: string;
   publishedAt: string;
   updatedAt: string;
+  // Distinguishes a freshly published paper from a v2/v3 revision — useful
+  // for picking out genuinely new work in `updated` mode.
   isRevision: boolean;
+  // Free-form `<arxiv:comment>` from the Atom entry. Authors typically use it
+  // for venue acceptance ("Accepted to ICML 2026", "SIGGRAPH 2026"), code
+  // links ("Code: https://github.com/..."), or page count ("33 pages"). ~56%
+  // of recent cs.LG entries populate it; the renderer hides the line when
+  // empty.
   comment?: string;
 }
 

--- a/lib/columns/plugins/coingecko/client.tsx
+++ b/lib/columns/plugins/coingecko/client.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { Activity, ArrowDownRight, ArrowUpRight } from "lucide-react";
+import { Activity } from "lucide-react";
 import { RelativeTime } from "@/components/relative-time";
+import { formatPriceUsd } from "@/lib/columns/shared/format";
+import { PctChangePill } from "@/lib/columns/shared/pct-change-pill";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -73,16 +75,6 @@ function ConfigForm({ value, onChange }: ConfigFormProps<CoingeckoConfig>) {
   );
 }
 
-function formatPriceUsd(n: number): string {
-  if (!Number.isFinite(n) || n <= 0) return "$0";
-  if (n >= 1000) return `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
-  if (n >= 1) return `$${n.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
-  if (n >= 0.01) return `$${n.toFixed(4)}`;
-  // Sub-cent prices need more precision — drop trailing zeros so a $0.0010
-  // doesn't render as `$0.001000`.
-  return `$${n.toPrecision(3).replace(/0+$/, "").replace(/\.$/, "")}`;
-}
-
 function Sparkline({ values }: { values: number[] }) {
   if (values.length < 2) return null;
   const min = Math.min(...values);
@@ -141,7 +133,6 @@ function ItemRenderer({ item }: ItemRendererProps<CoingeckoMeta>) {
   const sparkline = m?.sparkline7d ?? [];
   const imageUrl = m?.imageUrl;
   const name = item.content;
-  const up = pct >= 0;
 
   return (
     <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
@@ -201,17 +192,7 @@ function ItemRenderer({ item }: ItemRendererProps<CoingeckoMeta>) {
         <span className="tabular-nums text-foreground/90">
           {formatPriceUsd(priceUsd)}
         </span>
-        <span
-          className="inline-flex items-center gap-0.5 tabular-nums"
-          style={{ color: up ? "#10b981" : "#ef4444" }}
-        >
-          {up ? (
-            <ArrowUpRight className="size-3" />
-          ) : (
-            <ArrowDownRight className="size-3" />
-          )}
-          {pct.toFixed(2)}%
-        </span>
+        <PctChangePill value={pct} />
         {sparkline.length > 1 && <Sparkline values={sparkline} />}
         {marketCap > 0 && (
           <>

--- a/lib/columns/plugins/defillama/client.tsx
+++ b/lib/columns/plugins/defillama/client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Layers, ArrowDownRight, ArrowUpRight } from "lucide-react";
+import { Layers } from "lucide-react";
 import { RelativeTime } from "@/components/relative-time";
+import { PctChangePill } from "@/lib/columns/shared/pct-change-pill";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -107,7 +108,6 @@ function ItemRenderer({ item }: ItemRendererProps<DefillamaMeta>) {
   const mcap = m?.marketCapUsd;
   const imageUrl = m?.imageUrl;
   const name = item.content;
-  const up = pct >= 0;
   const isChain = m?.kind === "chain";
 
   return (
@@ -166,19 +166,7 @@ function ItemRenderer({ item }: ItemRendererProps<DefillamaMeta>) {
         <span className="tabular-nums text-foreground/90">
           TVL ${formatCompactCount(tvl)}
         </span>
-        {!isChain && (
-          <span
-            className="inline-flex items-center gap-0.5 tabular-nums"
-            style={{ color: up ? "#10b981" : "#ef4444" }}
-          >
-            {up ? (
-              <ArrowUpRight className="size-3" />
-            ) : (
-              <ArrowDownRight className="size-3" />
-            )}
-            {pct.toFixed(2)}%
-          </span>
-        )}
+        {!isChain && <PctChangePill value={pct} />}
         {!isChain && typeof pct7d === "number" && (
           <>
             <span className="text-muted-foreground/50">·</span>

--- a/lib/columns/plugins/defillama/plugin.ts
+++ b/lib/columns/plugins/defillama/plugin.ts
@@ -16,14 +16,23 @@ export const schema = z.object({
 export type DefillamaConfig = z.infer<typeof schema>;
 
 export interface DefillamaMeta {
+  /** Display symbol or chain ticker (e.g. "AAVE", "ETH"). May be empty. */
   symbol: string;
+  /** Hosted protocol/chain logo URL when available. */
   imageUrl?: string;
+  /** Current TVL in USD (already in USD — DeFiLlama normalises). */
   tvlUsd: number;
+  /** Percent change over 24h (+/-). */
   tvlChange24h: number;
+  /** Percent change over 7d (+/-). */
   tvlChange7d?: number;
+  /** Protocol category (DeFiLlama's taxonomy, e.g. "Lending", "Dexs"). */
   category?: string;
+  /** Comma-joined chain list from DeFiLlama (e.g. "Ethereum, Base"). */
   chains?: string;
+  /** Market cap of the protocol token in USD, when DeFiLlama has it. */
   marketCapUsd?: number;
+  /** "protocol" or "chain" — lets the renderer style the row differently. */
   kind: "protocol" | "chain";
 }
 

--- a/lib/columns/plugins/dexscreener/client.tsx
+++ b/lib/columns/plugins/dexscreener/client.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { ArrowDownRight, ArrowUpRight, CandlestickChart } from "lucide-react";
+import { CandlestickChart } from "lucide-react";
 import { RelativeTime } from "@/components/relative-time";
+import { formatPriceUsd } from "@/lib/columns/shared/format";
+import { PctChangePill } from "@/lib/columns/shared/pct-change-pill";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -82,16 +84,6 @@ function ConfigForm({ value, onChange }: ConfigFormProps<DexscreenerConfig>) {
   );
 }
 
-function formatPriceUsd(n: number): string {
-  if (!Number.isFinite(n) || n <= 0) return "$0";
-  if (n >= 1000) return `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
-  if (n >= 1) return `$${n.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
-  if (n >= 0.01) return `$${n.toFixed(4)}`;
-  // Sub-cent meme-coin prices need more significant figures — drop trailing
-  // zeros so $0.0000234 doesn't render as $0.00002340.
-  return `$${n.toPrecision(3).replace(/0+$/, "").replace(/\.$/, "")}`;
-}
-
 function ItemRenderer({ item }: ItemRendererProps<DexscreenerMeta>) {
   const m = item.meta;
   const pair = item.content;
@@ -104,7 +96,6 @@ function ItemRenderer({ item }: ItemRendererProps<DexscreenerMeta>) {
   const baseName = m?.baseName;
   const imageUrl = m?.imageUrl;
   const txns = m?.txns24h;
-  const up = pct >= 0;
 
   return (
     <div className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60">
@@ -173,17 +164,7 @@ function ItemRenderer({ item }: ItemRendererProps<DexscreenerMeta>) {
         <span className="tabular-nums text-foreground/90">
           {formatPriceUsd(priceUsd)}
         </span>
-        <span
-          className="inline-flex items-center gap-0.5 tabular-nums"
-          style={{ color: up ? "#10b981" : "#ef4444" }}
-        >
-          {up ? (
-            <ArrowUpRight className="size-3" />
-          ) : (
-            <ArrowDownRight className="size-3" />
-          )}
-          {pct.toFixed(2)}%
-        </span>
+        <PctChangePill value={pct} />
         {liquidity > 0 && (
           <>
             <span className="text-muted-foreground/50">·</span>

--- a/lib/columns/plugins/github-actions/plugin.ts
+++ b/lib/columns/plugins/github-actions/plugin.ts
@@ -15,6 +15,25 @@ export const schema = z.object({
 
 export type GHActionsConfig = z.infer<typeof schema>;
 
+export type GHActionStatus =
+  | "queued"
+  | "in_progress"
+  | "completed"
+  | "waiting"
+  | "pending"
+  | "requested";
+
+export type GHActionConclusion =
+  | "success"
+  | "failure"
+  | "cancelled"
+  | "neutral"
+  | "skipped"
+  | "timed_out"
+  | "action_required"
+  | "stale"
+  | "startup_failure";
+
 export interface GHActionsMeta {
   kind: "run";
   repo: string;
@@ -22,30 +41,19 @@ export interface GHActionsMeta {
   runNumber: number;
   workflowName: string;
   workflowPath?: string;
-  status:
-    | "queued"
-    | "in_progress"
-    | "completed"
-    | "waiting"
-    | "pending"
-    | "requested";
-  conclusion?:
-    | "success"
-    | "failure"
-    | "cancelled"
-    | "neutral"
-    | "skipped"
-    | "timed_out"
-    | "action_required"
-    | "stale"
-    | "startup_failure";
+  status: GHActionStatus;
+  /** undefined while status != "completed" */
+  conclusion?: GHActionConclusion;
   branch?: string;
   event?: string;
   sha?: string;
   shortSha?: string;
+  /** "<owner>/<repo>" form; useful for the renderer when displaying the row */
   fullRepo: string;
   startedAt?: string;
+  /** Duration in ms; undefined when the run hasn't ended yet */
   durationMs?: number;
+  /** Commit message first-line, when available */
   commitMessage?: string;
 }
 

--- a/lib/columns/plugins/github-actions/server.ts
+++ b/lib/columns/plugins/github-actions/server.ts
@@ -2,7 +2,6 @@ import "server-only";
 
 import {
   defineColumnServer,
-  type FeedItem,
   type ServerFetcher,
 } from "@/lib/columns/types";
 import { fetchWorkflowRuns } from "@/lib/integrations/github";
@@ -16,6 +15,9 @@ const fetch: ServerFetcher<GHActionsConfig, GHActionsMeta> = async (
   const repo = config.repo.trim();
   if (!repo) throw new Error("Repository is required (owner/repo).");
   const page = cursor ? Number(cursor) || 1 : 1;
+  // The integration returns FeedItem<GHActionRunMeta>, which is now an alias of
+  // GHActionsMeta (the renderer contract this plugin owns and the integration
+  // imports), so the items flow through with no cast.
   const { items, hasMore } = await fetchWorkflowRuns(
     repo,
     config.workflow,
@@ -23,14 +25,8 @@ const fetch: ServerFetcher<GHActionsConfig, GHActionsMeta> = async (
     PAGE_SIZE,
     page,
   );
-  // The integration returns FeedItem<GHActionRunMeta>; that type is structurally
-  // identical to GHActionsMeta (the renderer contract owned by this plugin).
-  // The cast is safe because the two interfaces describe the same shape; we
-  // could re-export the integration type, but a one-line cast keeps the
-  // ownership clear: the plugin owns the renderer contract, the integration
-  // owns the fetch shape.
   return {
-    items: items as unknown as FeedItem<GHActionsMeta>[],
+    items,
     nextCursor: hasMore ? String(page + 1) : undefined,
   };
 };

--- a/lib/columns/plugins/github-discussions/server.ts
+++ b/lib/columns/plugins/github-discussions/server.ts
@@ -30,7 +30,7 @@ const fetch: ServerFetcher<GHDiscussionsConfig, GHDiscussionsMeta> = async (
   // renderer contract, integration owns the fetch shape — same pattern
   // github-actions uses.
   return sliceForPage(
-    items as unknown as FeedItem<GHDiscussionsMeta>[],
+    items as FeedItem<GHDiscussionsMeta>[],
     cursor,
   );
 };

--- a/lib/columns/plugins/producthunt/plugin.ts
+++ b/lib/columns/plugins/producthunt/plugin.ts
@@ -12,8 +12,14 @@ export type ProductHuntConfig = z.infer<typeof schema>;
 export interface ProductHuntMeta {
   source: string;
   feedTitle?: string;
+  // The product slug extracted from the post URL (e.g. "linear-3"). Useful for
+  // dedupe across days when the same product re-appears in the rolling window.
   slug?: string;
+  // The product name (left half of the "{name} — {tagline}" title split). Kept
+  // separately so the renderer can highlight it without re-parsing every row.
   productName?: string;
+  // The tagline (right half of the title split). Often empty if the publisher
+  // didn't add an em-dash; falls back to feed description in that case.
   tagline?: string;
 }
 

--- a/lib/columns/plugins/pypi/plugin.ts
+++ b/lib/columns/plugins/pypi/plugin.ts
@@ -10,9 +10,13 @@ export const schema = z.object({
 export type PypiConfig = z.infer<typeof schema>;
 
 export interface PypiMeta {
+  /** Version string when known (always for updates, never for new-packages). */
   version?: string;
+  /** 30-day downloads when known (top-30d mode); 0 otherwise. */
   monthlyDownloads: number;
+  /** Last-week downloads via pypistats.org; 0 on failure. */
   weeklyDownloads: number;
+  /** PyPI author/maintainer login if surfaced by the feed. */
   author?: string;
 }
 

--- a/lib/columns/shared/format.ts
+++ b/lib/columns/shared/format.ts
@@ -1,0 +1,22 @@
+// Shared numeric formatters for crypto/market plugin renderers.
+
+/**
+ * Format a USD price for a market row. Five bands by magnitude:
+ *   - non-finite / non-positive → "$0"
+ *   - ≥ 1000 → no decimals (thousands grouping)
+ *   - ≥ 1    → up to 2 decimals
+ *   - ≥ 0.01 → fixed 4 decimals
+ *   - sub-cent → 3 significant figures with trailing zeros dropped, so a
+ *     micro-cap price like $0.0000234 doesn't render as $0.00002340.
+ *
+ * Used identically by the coingecko and dexscreener renderers. NOTE: this is
+ * deliberately distinct from polymarket/wallet-tx `formatUsd`, which round
+ * differently on purpose — don't fold those in here.
+ */
+export function formatPriceUsd(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "$0";
+  if (n >= 1000) return `$${n.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+  if (n >= 1) return `$${n.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
+  if (n >= 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toPrecision(3).replace(/0+$/, "").replace(/\.$/, "")}`;
+}

--- a/lib/columns/shared/pct-change-pill.tsx
+++ b/lib/columns/shared/pct-change-pill.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+
+/**
+ * Inline percent-change pill used by the crypto/market renderers (coingecko,
+ * dexscreener, defillama). A green up-arrow for non-negative change, a red
+ * down-arrow otherwise, followed by the value to two decimals + "%".
+ *
+ * Excludes wallet-tx's ArrowUpRight, which is a tx-direction icon, not this
+ * pill — don't reuse this there.
+ */
+export function PctChangePill({ value }: { value: number }) {
+  const up = value >= 0;
+  return (
+    <span
+      className="inline-flex items-center gap-0.5 tabular-nums"
+      style={{ color: up ? "#10b981" : "#ef4444" }}
+    >
+      {up ? (
+        <ArrowUpRight className="size-3" />
+      ) : (
+        <ArrowDownRight className="size-3" />
+      )}
+      {value.toFixed(2)}%
+    </span>
+  );
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -25,7 +25,7 @@ export const columns = pgTable("columns", {
     .references(() => decks.id, { onDelete: "cascade" }),
   typeId: text("type_id").notNull(),
   title: text("title").notNull(),
-  config: jsonb("config").notNull().default({}),
+  config: jsonb("config").$type<Record<string, unknown>>().notNull().default({}),
   alertKeywords: text("alert_keywords"),
   notifyWebhookUrl: text("notify_webhook_url"),
   refreshIntervalSeconds: integer("refresh_interval_seconds"),

--- a/lib/deck-rules.ts
+++ b/lib/deck-rules.ts
@@ -35,6 +35,17 @@ export function isAllowedRefreshInterval(
 export const TAB_GROUP_MAX = 50;
 
 /**
+ * Canonicalize a tab-group label: collapse internal whitespace runs to a single
+ * space, trim, and cap at `TAB_GROUP_MAX`. Returns the (possibly empty) string;
+ * callers decide whether an empty result means `null`/`undefined` on the wire.
+ * The same rule runs in `updateColumnTabGroup`, `importDeck`, the client store,
+ * and the configure dialog so "AI", " AI " and "AI  " always bucket together.
+ */
+export function normalizeTabGroup(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim().slice(0, TAB_GROUP_MAX);
+}
+
+/**
  * Hex-color regex applied to every persisted column/deck color. 6-hex form only
  * (`#rrggbb`); the 3-hex shorthand and named CSS colors are deliberately
  * rejected so the stored representation is canonical — round-tripping a
@@ -57,6 +68,28 @@ export function normalizeColumnColor(raw: string | null | undefined): string | n
   if (!COLOR_HEX_RE.test(trimmed)) return null;
   return trimmed.toLowerCase();
 }
+
+/**
+ * The shared preset color palette offered by both the column-color picker
+ * (configure-column-dialog) and the deck-color picker (deck-color-dialog).
+ * Tuned to read distinctly against both the light and dark surface tones used
+ * elsewhere in the app (no near-whites, no near-blacks). The empty (no-color)
+ * state is offered as a "Clear" affordance separately rather than as a swatch —
+ * a "no color" swatch and a real color swatch read the same in the row and
+ * would confuse the operator. Both surfaces share this one const so the column
+ * and deck color rows stay visually coherent (e.g. the same orange for a "DeFi"
+ * deck and a DeFi column).
+ */
+export const COLOR_SWATCHES: { value: string; label: string }[] = [
+  { value: "#f97316", label: "Orange" }, // DeFi / on-chain default
+  { value: "#22c55e", label: "Green" },  // markets / portfolio
+  { value: "#3b82f6", label: "Blue" },   // dev / GitHub
+  { value: "#a855f7", label: "Purple" }, // social
+  { value: "#ec4899", label: "Pink" },   // creators / video
+  { value: "#eab308", label: "Yellow" }, // news / alerts-adjacent
+  { value: "#06b6d4", label: "Cyan" },   // research / AI
+  { value: "#94a3b8", label: "Slate" },  // archival / low-priority
+];
 
 /** Schema version stamped into every exported deck payload. */
 export const DECK_EXPORT_VERSION = 1;

--- a/lib/deck-templates.ts
+++ b/lib/deck-templates.ts
@@ -21,52 +21,35 @@
 //     there's no value in a network round-trip to /templates/<id>.json.
 //   - Imports stay synchronous — no fetch failure modes for the gallery UI.
 
+// Type-only import: erased at build time so this client-imported module never
+// pulls the "use server" actions runtime into the client bundle (same pattern
+// as version-history-dialog's `import type { DeckSnapshotMeta }`).
+import type { DeckExport } from "@/app/actions";
+
 export const DECK_TEMPLATE_VERSION = 1;
 
-export interface DeckTemplateColumn {
-  typeId: string;
-  title: string;
-  config: Record<string, unknown>;
-  alertKeywords?: string;
-  // Optional auto-refresh cadence in seconds. When set, the column re-fetches
-  // on this cadence after import. Allowed values are whitelisted server-side
-  // to {60, 300, 900, 3600}; anything else is dropped during importDeck.
-  refreshIntervalSeconds?: number;
-  // Optional include/exclude item filters (comma/space-separated). Let a
-  // starter template ship a pre-focused column — e.g. a security feed that
-  // only surfaces items mentioning "CVE". Round-trip through importDeck.
-  filterKeywords?: string;
-  excludeKeywords?: string;
-  // Optional tab-group label. Let a multi-category starter deck ship pre-grouped
-  // (e.g. "DeFi" / "Social" / "Dev") so the tab bar renders on first import
-  // instead of forcing the operator to label each column by hand. Round-trips
-  // through importDeck — same TAB_GROUP_MAX cap, same whitespace normalization.
-  tabGroup?: string;
-  // Optional pin flag. Let a starter template ship with a priority column (e.g.
-  // the project's main GitHub repo, or a token price column) already pinned to
-  // the front of the deck so it stays visible regardless of active tab and DnD
-  // reorder. Round-trips through importDeck.
-  pinned?: boolean;
-  // Optional color label (6-char hex `#rrggbb`). Let a multi-category starter
-  // deck ship with pre-colored lanes (e.g. orange for DeFi, blue for repos,
-  // purple for social) so the visual grouping is immediate on first import.
-  // Round-trips through importDeck — re-validated against the same hex regex
-  // and dropped if it doesn't match.
-  color?: string;
-}
+// Templates ARE DeckExport v1 payloads, so their shape is derived from the
+// canonical `DeckExport` (`z.infer<typeof importedDeckSchema>`) rather than
+// re-declared. This keeps the "templates use the SAME schema as Export/Import/
+// Share" promise above true at the type level: a new persisted column field
+// added to the export schema flows into templates automatically.
+//
+// A template column is an export column WITHOUT `notifyWebhookUrl` — a webhook
+// URL is install-private (often embeds a secret) and a shared starter template
+// has no business shipping one, so it's omitted from the authored shape.
+export type DeckTemplateColumn = Omit<
+  DeckExport["columns"][number],
+  "notifyWebhookUrl"
+>;
 
-export interface DeckTemplatePayload {
+// A template payload is a DeckExport WITHOUT the runtime-only `exportedAt`
+// timestamp (stamped on at import in `templateAsImportJson`) and with the
+// webhook-free column shape above. `version` stays pinned to the template
+// constant, which equals the export version — `z.literal(DECK_EXPORT_VERSION)`.
+export type DeckTemplatePayload = Omit<DeckExport, "exportedAt" | "columns"> & {
   version: typeof DECK_TEMPLATE_VERSION;
-  deckName: string;
-  // Optional deck-level color label (6-char hex `#rrggbb`). Let a multi-category
-  // starter template ship pre-tagged with a deck-identity color (e.g. the
-  // markets pack ships orange, the dev pack ships blue) so the sidebar dot
-  // is meaningful from first import. Round-trips through importDeck — the
-  // same hex normalizer used for the per-column color drops it to null if
-  // the template ships a malformed value, never aborts the import.
-  deckColor?: string;
   columns: DeckTemplateColumn[];
-}
+};
 
 export interface DeckTemplate {
   id: string;
@@ -292,10 +275,6 @@ export const TEMPLATES: DeckTemplate[] = [
   cryptoDefi,
   startupTracker,
 ];
-
-export function getTemplate(id: string): DeckTemplate | undefined {
-  return TEMPLATES.find((t) => t.id === id);
-}
 
 /**
  * Serialize a template's payload as a JSON string compatible with the

--- a/lib/integrations/arxiv.ts
+++ b/lib/integrations/arxiv.ts
@@ -1,5 +1,13 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { ArxivMeta } from "@/lib/columns/plugins/arxiv/plugin";
 import { identiconUrl } from "@/lib/utils";
+import { decodeEntities } from "@/lib/integrations/text";
+
+// `ArxivMeta` is the renderer contract owned by the arxiv plugin; the fetcher
+// here produces `FeedItem<ArxivMeta>` so its meta lines up with what the arxiv
+// renderer reads. Re-exported so call sites that grab ArxivMeta from the
+// integration keep working.
+export type { ArxivMeta };
 
 // arXiv Atom-XML query API — public, no auth, no rate-limit headers documented
 // beyond the polite-crawler advice (≥3 sec between requests, recognisable UA).
@@ -28,45 +36,6 @@ export type ArxivCategory =
   | "math.OC";
 
 export type ArxivMode = "recent" | "updated";
-
-export interface ArxivMeta {
-  // Primary category as reported by arXiv (often more specific than the
-  // user's filter — a cs.AI paper might primary-cat as cs.LG when it's more
-  // ML than agentic, useful signal for the renderer).
-  primaryCategory: string;
-  categories: string[];
-  authors: string[];
-  abstract: string;
-  pdfUrl?: string;
-  arxivId: string;
-  publishedAt: string;
-  updatedAt: string;
-  // Distinguishes a freshly published paper from a v2/v3 revision — useful
-  // for picking out genuinely new work in `updated` mode.
-  isRevision: boolean;
-  // Free-form `<arxiv:comment>` from the Atom entry. Authors typically use it
-  // for venue acceptance ("Accepted to ICML 2026", "SIGGRAPH 2026"), code
-  // links ("Code: https://github.com/..."), or page count ("33 pages"). ~56%
-  // of recent cs.LG entries populate it; the renderer hides the line when
-  // empty.
-  comment?: string;
-}
-
-const NAMED_ENTITIES: Record<string, string> = {
-  "&amp;": "&",
-  "&lt;": "<",
-  "&gt;": ">",
-  "&quot;": '"',
-  "&apos;": "'",
-  "&nbsp;": " ",
-};
-
-function decodeEntities(s: string): string {
-  return s
-    .replace(/&(?:amp|lt|gt|quot|apos|nbsp);/g, (m) => NAMED_ENTITIES[m] ?? m)
-    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)));
-}
 
 function getTag(xml: string, tag: string): string {
   const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/lib/integrations/blockscout.ts
+++ b/lib/integrations/blockscout.ts
@@ -46,16 +46,8 @@ const CHAINS: Record<Chain, ChainInfo> = {
   zksync: { chainId: 324, host: "zksync.blockscout.com", nativeSymbol: "ETH", label: "zkSync" },
 };
 
-export function getChainInfo(chain: Chain): ChainInfo {
-  return CHAINS[chain];
-}
-
 export function explorerTxUrl(chain: Chain, hash: string): string {
   return `https://${CHAINS[chain].host}/tx/${hash}`;
-}
-
-export function explorerAddressUrl(chain: Chain, address: string): string {
-  return `https://${CHAINS[chain].host}/address/${address}`;
 }
 
 interface BSAddressRef {

--- a/lib/integrations/coingecko.ts
+++ b/lib/integrations/coingecko.ts
@@ -1,4 +1,11 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { CoingeckoMeta } from "@/lib/columns/plugins/coingecko/plugin";
+
+// `CoingeckoMeta` is the renderer contract owned by the coingecko plugin; the
+// fetcher here produces `FeedItem<CoingeckoMeta>` so its meta lines up with what
+// the coingecko renderer reads. Re-exported so call sites that grab
+// CoingeckoMeta from the integration keep working.
+export type { CoingeckoMeta };
 
 // CoinGecko public API — keyless for `/search/trending` and `/coins/markets`.
 // The Demo plan (env `COINGECKO_DEMO_API_KEY`) authenticates the same endpoints
@@ -28,19 +35,6 @@ const PUBLIC_BASE = "https://api.coingecko.com/api/v3";
 const PRO_BASE = "https://pro-api.coingecko.com/api/v3";
 
 export type CoingeckoMode = "trending" | "top" | "watchlist";
-
-export interface CoingeckoMeta {
-  symbol: string;
-  imageUrl?: string;
-  priceUsd: number;
-  priceChange24h: number;
-  marketCapUsd: number;
-  marketCapRank?: number;
-  volume24hUsd: number;
-  high24hUsd?: number;
-  low24hUsd?: number;
-  sparkline7d?: number[];
-}
 
 interface TrendingItem {
   item?: {

--- a/lib/integrations/crates.ts
+++ b/lib/integrations/crates.ts
@@ -1,4 +1,11 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { CratesMeta } from "@/lib/columns/plugins/crates/plugin";
+
+// `CratesMeta` is the renderer contract owned by the crates plugin; the fetcher
+// here produces `FeedItem<CratesMeta>` so its meta lines up with what the crates
+// renderer reads. Re-exported so call sites that grab CratesMeta from the
+// integration keep working.
+export type { CratesMeta };
 
 // crates.io public REST API — fully keyless, generously rate-limited for
 // anonymous polling. One rule the docs are explicit about: every request
@@ -27,19 +34,6 @@ export type CratesSort =
   | "recent-updates"
   | "new"
   | "alpha";
-
-export interface CratesMeta {
-  version: string;
-  totalDownloads: number;
-  recentDownloads: number;
-  keywords: string[];
-  description: string;
-  homepage?: string;
-  documentation?: string;
-  repository?: string;
-  updatedAt: string;
-  exactMatch: boolean;
-}
 
 interface CratesApiCrate {
   id?: string;

--- a/lib/integrations/defillama.ts
+++ b/lib/integrations/defillama.ts
@@ -1,4 +1,11 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { DefillamaMeta } from "@/lib/columns/plugins/defillama/plugin";
+
+// `DefillamaMeta` is the renderer contract owned by the defillama plugin; the
+// fetcher here produces `FeedItem<DefillamaMeta>` so its meta lines up with what
+// the defillama renderer reads. Re-exported so call sites that grab
+// DefillamaMeta from the integration keep working.
+export type { DefillamaMeta };
 
 // DeFiLlama public API — keyless. Two endpoints cover all three column modes:
 //
@@ -24,27 +31,6 @@ import type { FeedItem } from "@/lib/columns/types";
 const API_BASE = "https://api.llama.fi";
 
 export type DefillamaMode = "top" | "gainers" | "chains";
-
-export interface DefillamaMeta {
-  /** Display symbol or chain ticker (e.g. "AAVE", "ETH"). May be empty. */
-  symbol: string;
-  /** Hosted protocol/chain logo URL when available. */
-  imageUrl?: string;
-  /** Current TVL in USD (already in USD — DeFiLlama normalises). */
-  tvlUsd: number;
-  /** Percent change over 24h (+/-). */
-  tvlChange24h: number;
-  /** Percent change over 7d (+/-). */
-  tvlChange7d?: number;
-  /** Protocol category (DeFiLlama's taxonomy, e.g. "Lending", "Dexs"). */
-  category?: string;
-  /** Comma-joined chain list from DeFiLlama (e.g. "Ethereum, Base"). */
-  chains?: string;
-  /** Market cap of the protocol token in USD, when DeFiLlama has it. */
-  marketCapUsd?: number;
-  /** "protocol" or "chain" — lets the renderer style the row differently. */
-  kind: "protocol" | "chain";
-}
 
 interface DefillamaProtocol {
   id?: string;

--- a/lib/integrations/devto.ts
+++ b/lib/integrations/devto.ts
@@ -1,4 +1,11 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { DevtoMeta } from "@/lib/columns/plugins/devto/plugin";
+
+// `DevtoMeta` is the renderer contract owned by the devto plugin; the fetcher
+// here produces `FeedItem<DevtoMeta>` so its meta lines up with what the devto
+// renderer reads. Re-exported so call sites that grab DevtoMeta from the
+// integration keep working.
+export type { DevtoMeta };
 
 // DEV.to public REST API — keyless for read endpoints.
 // https://developers.forem.com/api/v1#tag/articles
@@ -55,15 +62,6 @@ interface DevtoArticle {
   tags?: string;
   user?: DevtoUser;
   organization?: DevtoOrganization;
-}
-
-export interface DevtoMeta {
-  reactions: number;
-  comments: number;
-  readingTimeMinutes: number;
-  tags: string[];
-  organization?: { name: string; slug: string; avatarUrl?: string };
-  coverImage?: string;
 }
 
 function normaliseTagFilter(tag: string): string[] {

--- a/lib/integrations/dexscreener.ts
+++ b/lib/integrations/dexscreener.ts
@@ -1,4 +1,11 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { DexscreenerMeta } from "@/lib/columns/plugins/dexscreener/plugin";
+
+// `DexscreenerMeta` is the renderer contract owned by the dexscreener plugin;
+// the fetcher here produces `FeedItem<DexscreenerMeta>` so its meta lines up
+// with what the dexscreener renderer reads. Re-exported so call sites that grab
+// DexscreenerMeta from the integration keep working.
+export type { DexscreenerMeta };
 
 // Dexscreener public API — keyless for the two endpoints this column uses.
 // Dexscreener indexes DEX trading pairs across every major chain (Ethereum,
@@ -27,22 +34,6 @@ const MAX_WATCHLIST = 30;
 const MAX_ITEMS = 60;
 
 export type DexscreenerMode = "search" | "watchlist";
-
-export interface DexscreenerMeta {
-  chainId: string;
-  dexId: string;
-  baseSymbol: string;
-  quoteSymbol: string;
-  baseName?: string;
-  imageUrl?: string;
-  priceUsd: number;
-  priceChange24h: number;
-  volume24hUsd: number;
-  liquidityUsd: number;
-  fdvUsd?: number;
-  marketCapUsd?: number;
-  txns24h?: { buys: number; sells: number };
-}
 
 interface DexPair {
   chainId?: string;

--- a/lib/integrations/farcaster.ts
+++ b/lib/integrations/farcaster.ts
@@ -1,8 +1,7 @@
 import type { FeedItem } from "@/lib/columns/types";
 
-// Farcaster via Neynar. USER + SEARCH modes are exposed; TRENDING and CHANNEL
-// require Neynar Starter+ ($9/mo, returns 402 on the free tier) and are kept
-// below as `fetchTrending` / `fetchChannel` for re-enable.
+// Farcaster via Neynar. Only USER and SEARCH modes are exposed — TRENDING and
+// CHANNEL require Neynar Starter+ ($9/mo, return 402 on the free tier).
 //
 // Search relies on a trick: Neynar publishes a public demo key
 // (`NEYNAR_API_DOCS`) used in their docs that responds to /cast/search even
@@ -14,9 +13,6 @@ import type { FeedItem } from "@/lib/columns/types";
 // keyless path.
 
 const NEYNAR = "https://api.neynar.com";
-
-export type FCMode = "trending" | "channel" | "user" | "search";
-export type FCWindow = "1h" | "6h" | "24h" | "7d" | "30d";
 
 interface NeynarAuthor {
   fid?: number;
@@ -189,45 +185,6 @@ export async function fetchFarcasterUser(
   return mapCasts(casts, limit);
 }
 
-// Paid-tier helpers — not currently exported. All three return 402 on Neynar's
-// free tier; kept here so the re-enable path stays a one-liner in route.ts.
-
-async function fetchTrending(
-  windowSize: FCWindow,
-  channelId: string,
-  limit: number,
-): Promise<FeedItem[]> {
-  const params = new URLSearchParams({
-    limit: String(limit),
-    time_window: windowSize,
-  });
-  if (channelId.trim()) params.set("channel_id", channelId.trim());
-  const json = await neynar<NeynarCastsResponse>(
-    `/v2/farcaster/feed/trending?${params}`,
-  );
-  const casts = json.casts ?? json.result?.casts ?? [];
-  return mapCasts(casts, limit);
-}
-
-async function fetchChannel(
-  channelId: string,
-  limit: number,
-): Promise<FeedItem[]> {
-  const id = channelId.trim().replace(/^\//, "").toLowerCase();
-  if (!id) throw new Error("Channel id is required (e.g. dev, design, base).");
-  const params = new URLSearchParams({
-    feed_type: "filter",
-    filter_type: "channel_id",
-    channel_id: id,
-    limit: String(limit),
-  });
-  const json = await neynar<NeynarCastsResponse>(
-    `/v2/farcaster/feed?${params}`,
-  );
-  const casts = json.casts ?? json.result?.casts ?? [];
-  return mapCasts(casts, limit);
-}
-
 export async function fetchFarcasterSearch(
   query: string,
   limit = 12,
@@ -244,41 +201,3 @@ export async function fetchFarcasterSearch(
   const casts = json.casts ?? json.result?.casts ?? [];
   return mapCasts(casts, limit);
 }
-
-async function fetchSearch(query: string, limit: number): Promise<FeedItem[]> {
-  return fetchFarcasterSearch(query, limit);
-}
-
-// Multi-mode dispatcher — wire this back up in route.ts when the plan is upgraded.
-async function fetchFarcaster(
-  mode: FCMode,
-  config: {
-    channelId?: string;
-    username?: string;
-    query?: string;
-    window?: string;
-  },
-  limit = 12,
-): Promise<FeedItem[]> {
-  switch (mode) {
-    case "channel":
-      return fetchChannel(config.channelId ?? "", limit);
-    case "user":
-      return fetchFarcasterUser(config.username ?? "", limit);
-    case "search":
-      return fetchSearch(config.query ?? "", limit);
-    case "trending":
-    default: {
-      const w = (config.window === "1h" ||
-      config.window === "6h" ||
-      config.window === "7d" ||
-      config.window === "30d"
-        ? config.window
-        : "24h") as FCWindow;
-      return fetchTrending(w, config.channelId ?? "", limit);
-    }
-  }
-}
-
-// Suppress "declared but never read" — these are intentionally kept for re-enable.
-void fetchFarcaster;

--- a/lib/integrations/github.ts
+++ b/lib/integrations/github.ts
@@ -1,12 +1,15 @@
 import type { FeedItem } from "@/lib/columns/types";
 import type { GHPRMeta } from "@/lib/columns/plugins/github-prs/plugin";
+import type {
+  GHActionsMeta,
+  GHActionStatus,
+  GHActionConclusion,
+} from "@/lib/columns/plugins/github-actions/plugin";
 import { identiconUrl, truncateText } from "@/lib/utils";
 
 // `GHPRMeta` is the renderer contract owned by the github-prs plugin; the
 // fetcher below produces `FeedItem<GHPRMeta>` so its meta lines up with what
-// the plugin's renderer reads. Re-exported under the legacy `GHPRItemMeta`
-// name in case external callers grew an import on it.
-export type { GHPRMeta as GHPRItemMeta };
+// the plugin's renderer reads.
 
 const API = "https://api.github.com";
 
@@ -629,7 +632,10 @@ function parseLastPage(linkHeader: string | null): number | undefined {
         const u = new URL(m[1]);
         const p = u.searchParams.get("page");
         if (p) return Number(p);
-      } catch {}
+      } catch {
+        // The Link-header URL is matched by regex; a malformed match shouldn't
+        // be fatal — fall through and let pagination return undefined.
+      }
     }
   }
   return undefined;
@@ -869,47 +875,13 @@ export async function fetchForks(
 
 // ---- Actions / workflow runs (used by the github-actions plugin) -----------
 
-export type GHActionStatus =
-  | "queued"
-  | "in_progress"
-  | "completed"
-  | "waiting"
-  | "pending"
-  | "requested";
-
-export type GHActionConclusion =
-  | "success"
-  | "failure"
-  | "cancelled"
-  | "neutral"
-  | "skipped"
-  | "timed_out"
-  | "action_required"
-  | "stale"
-  | "startup_failure";
-
-export interface GHActionRunMeta {
-  kind: "run";
-  repo: string;
-  runId: number;
-  runNumber: number;
-  workflowName: string;
-  workflowPath?: string;
-  status: GHActionStatus;
-  /** undefined while status != "completed" */
-  conclusion?: GHActionConclusion;
-  branch?: string;
-  event?: string;
-  sha?: string;
-  shortSha?: string;
-  /** "<owner>/<repo>" form; useful for the renderer when displaying the row */
-  fullRepo: string;
-  startedAt?: string;
-  /** Duration in ms; undefined when the run hasn't ended yet */
-  durationMs?: number;
-  /** Commit message first-line, when available */
-  commitMessage?: string;
-}
+// `GHActionsMeta` (+ its `GHActionStatus` / `GHActionConclusion` field unions)
+// is the renderer contract owned by the github-actions plugin; the fetcher
+// below produces `FeedItem<GHActionsMeta>` so its meta lines up with what the
+// github-actions renderer reads. Re-exported (and aliased as `GHActionRunMeta`)
+// so call sites that grab these from the integration keep working.
+export type { GHActionsMeta, GHActionStatus, GHActionConclusion };
+export type GHActionRunMeta = GHActionsMeta;
 
 interface GHWorkflowRun {
   id: number;

--- a/lib/integrations/huggingface.ts
+++ b/lib/integrations/huggingface.ts
@@ -1,5 +1,12 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { HuggingfaceMeta } from "@/lib/columns/plugins/huggingface/plugin";
 import { identiconUrl } from "@/lib/utils";
+
+// `HuggingfaceMeta` is the renderer contract owned by the huggingface plugin;
+// the fetcher here produces `FeedItem<HuggingfaceMeta>` so its meta lines up
+// with what the huggingface renderer reads. Re-exported so call sites that grab
+// HuggingfaceMeta from the integration keep working.
+export type { HuggingfaceMeta };
 
 // Hugging Face Hub REST API — public, no auth, generous rate limits for
 // anonymous list endpoints. https://huggingface.co/docs/hub/api
@@ -15,18 +22,6 @@ const FETCH_BATCH = 50; // upstream cap is 1000, but 50 is plenty for slice-pagi
 
 export type HuggingfaceResource = "models" | "datasets" | "spaces";
 export type HuggingfaceMode = "trending" | "most-likes" | "newest";
-
-export interface HuggingfaceMeta {
-  resource: HuggingfaceResource;
-  likes: number;
-  downloads?: number;
-  trendingScore?: number;
-  pipelineTag?: string;
-  libraryName?: string;
-  sdk?: string;
-  tags: string[];
-  gated: boolean;
-}
 
 interface HFRepo {
   _id?: string;

--- a/lib/integrations/lobsters.ts
+++ b/lib/integrations/lobsters.ts
@@ -1,5 +1,13 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { LobstersMeta } from "@/lib/columns/plugins/lobsters/plugin";
 import { identiconUrl } from "@/lib/utils";
+import { stripHtml } from "@/lib/integrations/text";
+
+// `LobstersMeta` is the renderer contract owned by the lobsters plugin; the
+// fetcher here produces `FeedItem<LobstersMeta>` so its meta lines up with what
+// the lobsters renderer reads. Re-exported so call sites that grab LobstersMeta
+// from the integration keep working.
+export type { LobstersMeta };
 
 // Lobsters JSON API — public, no auth, generous rate limits.
 // https://lobste.rs/about — Active, hottest, newest, and per-tag feeds all
@@ -60,22 +68,6 @@ function unwrapAuthor(s: LobstersStory): string {
   return u.username ?? "anonymous";
 }
 
-function stripHtml(html: string): string {
-  // Lobsters returns sanitised fragments — links, paragraphs, code, em — so a
-  // targeted regex strip is safe without pulling in a full HTML parser.
-  return html
-    .replace(/<\/(p|div|li|br|h[1-6])>/gi, "\n")
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/<[^>]+>/g, "")
-    .replace(/&#x27;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
 function mapStory(s: LobstersStory): FeedItem<LobstersMeta> | null {
   // Schema-drift safe — without an id or a comments URL there's nothing to
   // render or link to, so drop rather than emit a dead row.
@@ -111,14 +103,6 @@ function mapStory(s: LobstersStory): FeedItem<LobstersMeta> | null {
       tags: Array.isArray(s.tags) ? s.tags : [],
     },
   };
-}
-
-export interface LobstersMeta {
-  score: number;
-  comments: number;
-  commentsUrl: string;
-  externalUrl?: string;
-  tags: string[];
 }
 
 export async function fetchLobstersPage(

--- a/lib/integrations/npm.ts
+++ b/lib/integrations/npm.ts
@@ -1,4 +1,11 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { NpmMeta } from "@/lib/columns/plugins/npm/plugin";
+
+// `NpmMeta` is the renderer contract owned by the npm plugin; the fetcher here
+// produces `FeedItem<NpmMeta>` so its meta lines up with what the npm renderer
+// reads. Re-exported so call sites that grab NpmMeta from the integration keep
+// working.
+export type { NpmMeta };
 
 // npm public registry + downloads API — both keyless, both rate-limited
 // generously enough for anonymous polling. The two surfaces:
@@ -20,23 +27,6 @@ const REGISTRY_BASE = "https://registry.npmjs.org";
 const DOWNLOADS_BASE = "https://api.npmjs.org";
 
 export type NpmMode = "popularity" | "quality" | "maintenance" | "combined";
-
-export interface NpmMeta {
-  version: string;
-  weeklyDownloads: number;
-  keywords: string[];
-  score: number;
-  scoreDetail: {
-    quality: number;
-    popularity: number;
-    maintenance: number;
-  };
-  publisher?: { username?: string; email?: string };
-  homepage?: string;
-  repository?: string;
-  license?: string;
-  deprecated: boolean;
-}
 
 interface NpmSearchObject {
   package: {

--- a/lib/integrations/polymarket.ts
+++ b/lib/integrations/polymarket.ts
@@ -1,5 +1,13 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { PolymarketMeta } from "@/lib/columns/plugins/polymarket/plugin";
 import { identiconUrl } from "@/lib/utils";
+import { stripHtml } from "@/lib/integrations/text";
+
+// `PolymarketMeta` is the renderer contract owned by the polymarket plugin; the
+// fetcher here produces `FeedItem<PolymarketMeta>` so its meta lines up with
+// what the polymarket renderer reads. Re-exported so call sites that grab
+// PolymarketMeta from the integration keep working.
+export type { PolymarketMeta };
 
 // Polymarket Gamma API — public, no auth, generous rate limits.
 // https://docs.polymarket.com/#markets-1 documents the markets endpoint.
@@ -48,16 +56,6 @@ interface GammaMarket {
   conditionId?: string;
   groupItemTitle?: string;
   events?: GammaMarketEvent[];
-}
-
-export interface PolymarketMeta {
-  outcomes: { label: string; price: number }[];
-  volume24hUsd: number;
-  liquidityUsd: number;
-  endDate?: string;
-  category?: string;
-  conditionId?: string;
-  imageUrl?: string;
 }
 
 function parseJsonArray(raw: string | undefined): string[] {
@@ -121,23 +119,6 @@ function permalinkFor(m: GammaMarket): string {
   if (eventSlug) return `https://polymarket.com/event/${eventSlug}`;
   if (m.slug) return `https://polymarket.com/market/${m.slug}`;
   return "https://polymarket.com";
-}
-
-function stripHtml(html: string): string {
-  // Gamma `description` is plain text in practice, but a minority of imported
-  // markets carry over light HTML from upstream sources — strip it the same
-  // way Lobsters does to stay safe without a parser dependency.
-  return html
-    .replace(/<\/(p|div|li|br|h[1-6])>/gi, "\n")
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/<[^>]+>/g, "")
-    .replace(/&#x27;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
 }
 
 function mapMarket(m: GammaMarket, now: number): FeedItem<PolymarketMeta> | null {

--- a/lib/integrations/producthunt.ts
+++ b/lib/integrations/producthunt.ts
@@ -1,5 +1,12 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { ProductHuntMeta } from "@/lib/columns/plugins/producthunt/plugin";
 import { fetchFeed } from "@/lib/integrations/rss";
+
+// `ProductHuntMeta` is the renderer contract owned by the producthunt plugin;
+// the fetcher here produces `FeedItem<ProductHuntMeta>` so its meta lines up
+// with what the producthunt renderer reads. Re-exported so call sites that grab
+// ProductHuntMeta from the integration keep working.
+export type { ProductHuntMeta };
 
 // Product Hunt RSS feed — keyless, public. The frontpage feed
 // (https://www.producthunt.com/feed) lists every product launched today plus a
@@ -16,20 +23,6 @@ import { fetchFeed } from "@/lib/integrations/rss";
 const FEED_URL = "https://www.producthunt.com/feed";
 
 export type ProductHuntMode = "today" | "topic";
-
-export interface ProductHuntMeta {
-  source: string;
-  feedTitle?: string;
-  // The product slug extracted from the post URL (e.g. "linear-3"). Useful for
-  // dedupe across days when the same product re-appears in the rolling window.
-  slug?: string;
-  // The product name (left half of the "{name} — {tagline}" title split). Kept
-  // separately so the renderer can highlight it without re-parsing every row.
-  productName?: string;
-  // The tagline (right half of the title split). Often empty if the publisher
-  // didn't add an em-dash; falls back to feed description in that case.
-  tagline?: string;
-}
 
 interface FeedRowMeta {
   source?: string;

--- a/lib/integrations/pypi.ts
+++ b/lib/integrations/pypi.ts
@@ -1,4 +1,11 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { PypiMeta } from "@/lib/columns/plugins/pypi/plugin";
+
+// `PypiMeta` is the renderer contract owned by the pypi plugin; the fetcher
+// here produces `FeedItem<PypiMeta>` so its meta lines up with what the pypi
+// renderer reads. Re-exported so call sites that grab PypiMeta from the
+// integration keep working.
+export type { PypiMeta };
 
 // PyPI exposes three keyless surfaces this column draws from:
 //
@@ -36,17 +43,6 @@ const PYPI_PROJECT_BASE = "https://pypi.org/project";
 const UA = "minitor/1.0 (+https://github.com/aaronjmars/minitor)";
 
 export type PypiMode = "updates" | "new-packages" | "top-30d";
-
-export interface PypiMeta {
-  /** Version string when known (always for updates, never for new-packages). */
-  version?: string;
-  /** 30-day downloads when known (top-30d mode); 0 otherwise. */
-  monthlyDownloads: number;
-  /** Last-week downloads via pypistats.org; 0 on failure. */
-  weeklyDownloads: number;
-  /** PyPI author/maintainer login if surfaced by the feed. */
-  author?: string;
-}
 
 interface RssItem {
   title: string;

--- a/lib/integrations/rss.ts
+++ b/lib/integrations/rss.ts
@@ -1,5 +1,6 @@
 import type { FeedItem } from "@/lib/columns/types";
 import { identiconUrl, truncateText } from "@/lib/utils";
+import { decodeEntities } from "@/lib/integrations/text";
 
 interface ParsedItem {
   id: string;
@@ -14,22 +15,6 @@ interface ParsedItem {
 interface ParsedFeed {
   title: string;
   items: ParsedItem[];
-}
-
-const NAMED_ENTITIES: Record<string, string> = {
-  "&amp;": "&",
-  "&lt;": "<",
-  "&gt;": ">",
-  "&quot;": '"',
-  "&apos;": "'",
-  "&nbsp;": " ",
-};
-
-function decodeEntities(s: string): string {
-  return s
-    .replace(/&(?:amp|lt|gt|quot|apos|nbsp);/g, (m) => NAMED_ENTITIES[m] ?? m)
-    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)));
 }
 
 function stripCdata(s: string): string {

--- a/lib/integrations/stackoverflow.ts
+++ b/lib/integrations/stackoverflow.ts
@@ -1,4 +1,11 @@
 import type { FeedItem } from "@/lib/columns/types";
+import type { StackOverflowMeta } from "@/lib/columns/plugins/stack-overflow/plugin";
+
+// `StackOverflowMeta` is the renderer contract owned by the stack-overflow
+// plugin; the fetcher here produces `FeedItem<StackOverflowMeta>` so its meta
+// lines up with what the stack-overflow renderer reads. Re-exported so call
+// sites that grab StackOverflowMeta from the integration keep working.
+export type { StackOverflowMeta };
 
 // Stack Exchange API 2.3 — public, no auth, generous quota.
 // https://api.stackexchange.com/docs/questions
@@ -42,16 +49,6 @@ interface SOResponse {
   quota_remaining?: number;
   error_id?: number;
   error_message?: string;
-}
-
-export interface StackOverflowMeta {
-  score: number;
-  answers: number;
-  views: number;
-  isAnswered: boolean;
-  hasAccepted: boolean;
-  tags: string[];
-  questionId: number;
 }
 
 function sortFor(mode: StackOverflowMode): string {

--- a/lib/integrations/text.ts
+++ b/lib/integrations/text.ts
@@ -1,0 +1,50 @@
+// Shared server-side text helpers for the integration fetchers. These run on
+// raw upstream payloads (RSS/Atom XML, Gamma/Lobsters HTML fragments) before
+// the data crosses into renderer-facing `FeedItem`s.
+
+const NAMED_ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&apos;": "'",
+  "&nbsp;": " ",
+};
+
+/**
+ * Decode the handful of named entities plus numeric (`&#NN;`) and hex
+ * (`&#xNN;`) character references that show up in RSS/Atom feed text. Shared
+ * by the `rss` and `arxiv` parsers (byte-identical in both).
+ *
+ * Note: `stackoverflow.ts` and `pypi.ts` keep narrower bespoke variants —
+ * those are intentionally not routed through here.
+ */
+export function decodeEntities(s: string): string {
+  return s
+    .replace(/&(?:amp|lt|gt|quot|apos|nbsp);/g, (m) => NAMED_ENTITIES[m] ?? m)
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCharCode(parseInt(n, 16)));
+}
+
+/**
+ * Strip a sanitised HTML fragment down to plain text, preserving block breaks
+ * as newlines and decoding the few entities that survive. Targeted regex strip
+ * rather than a full parser — safe because the upstreams (Lobsters story
+ * descriptions, Polymarket Gamma market descriptions) only emit a small,
+ * well-formed tag set. Shared by `lobsters` and `polymarket` (byte-identical).
+ *
+ * Note: `mastodon.ts` keeps a richer `<a>`/`<p>`-aware variant — not this one.
+ */
+export function stripHtml(html: string): string {
+  return html
+    .replace(/<\/(p|div|li|br|h[1-6])>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/lib/store/use-deck-store.ts
+++ b/lib/store/use-deck-store.ts
@@ -322,21 +322,10 @@ function importedDeckPatch(
 ): Partial<DeckState> {
   const cols = { ...s.columns };
   for (const c of result.columns) {
-    cols[c.id] = {
-      id: c.id,
-      typeId: c.typeId,
-      title: c.title,
-      config: c.config,
-      alertKeywords: c.alertKeywords,
-      notifyWebhookUrl: c.notifyWebhookUrl,
-      refreshIntervalSeconds: c.refreshIntervalSeconds,
-      filterKeywords: c.filterKeywords,
-      excludeKeywords: c.excludeKeywords,
-      tabGroup: c.tabGroup,
-      pinned: c.pinned,
-      color: c.color,
-      items: [],
-    };
+    // `ImportedDeckColumn` is exactly `Column` minus the runtime-only `items` /
+    // `lastFetchedAt`, so spreading it and seeding empty items reconstructs the
+    // full `Column` — no field-by-field copy to keep in lockstep with `Column`.
+    cols[c.id] = { ...c, items: [] };
   }
   return {
     decks: {


### PR DESCRIPTION
Multi-pass code-quality cleanup across 8 dimensions (dedup/DRY, type consolidation, unused code, circular deps, weak types, try/catch, legacy/fallback, AI slop). **No behavior changes.**

## Verified
- `npx tsc --noEmit` → **0 errors** (baseline preserved)
- `npm run build` → **compiles clean**
- `npx eslint .` → **unchanged at baseline** (no new lint)
- Plugin manifest/registry parity invariants intact

## Highlights
- **Type consolidation** — each `*Meta` renderer contract moved into its owning plugin and re-exported for back-compat; `DeckTemplateColumn`/`ImportedDeckColumn` derived from canonical `DeckExport`/`Column` via `Omit`.
- **DRY** — extracted `lib/columns/shared/format.ts`, `lib/columns/shared/pct-change-pill.tsx`, `lib/integrations/text.ts`; color dialogs import shared constants from `lib/deck-rules.ts`.
- **Dead code/legacy** — removed farcaster paid-tier "kept for re-enable" scaffolding, unused `getTemplate()`, speculative `GHPRItemMeta` alias (each verified 0 refs).
- **Weak types** — dropped unnecessary `as Record<string, unknown>` casts; strengthened plugin meta types.
- **try/catch** — audited all 40 blocks; all judged justified external-I/O, **none removed**.

Per-dimension critical assessments included as `*_ASSESSMENT.md` (separate commit; drop if undesired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)