### PR TITLE
feat: add github-commits column plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 </p>
 
 > **Monitor the current thing. Your dashboard for the internet.**
-> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm + PyPI + crates.io packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / Actions / Discussions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, CoinGecko crypto trending + prices, DeFiLlama TVL leaderboard, Dexscreener DEX pair search + watchlist, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
+> Build a deck, pack it with columns, refresh on demand. Each column is a plugin: X, Bluesky, Reddit, Hacker News, Lobsters, Stack Overflow, DEV.to, npm + PyPI + crates.io packages, Hugging Face (models / datasets / spaces), arXiv (CS / stat / math.OC papers), GitHub (trending / issues / PRs / stars / forks / backlinks / search / releases / commits / Actions / Discussions), Farcaster, Mastodon, YouTube, RSS, Google News, Bing, Substack, LinkedIn, Facebook, Instagram, Apple + Google Play reviews, on-chain wallet activity, Polymarket prediction markets, CoinGecko crypto trending + prices, DeFiLlama TVL leaderboard, Dexscreener DEX pair search + watchlist, and the six biggest Chinese platforms (Weibo / Zhihu / Douyin / Bilibili / Toutiao / Baidu).
 
 ### What it does
 
 - You name a deck. Minitor packs it with whatever you're watching.
-- 48 column types out of the box — social feeds, news, GitHub (including CI runs and Discussions), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, CoinGecko prices, DeFiLlama TVL, Dexscreener DEX pairs, Chinese hot boards.
+- 49 column types out of the box — social feeds, news, GitHub (including commits, CI runs, and Discussions), Hugging Face, arXiv, DEV.to, Product Hunt, npm + PyPI + crates.io packages, app reviews, on-chain transactions, prediction markets, CoinGecko prices, DeFiLlama TVL, Dexscreener DEX pairs, Chinese hot boards.
 - Refresh per column or auto-fetch on creation. Load more pages 10 at a time.
 - Shape the signal per column — highlight items with alert keywords, or filter the feed to "show only" / "hide" by keyword so a firehose column shows just what matters.
 - ⌘K command palette over every deck, column, and action. Drag to reorder.
@@ -60,7 +60,7 @@ For Grok / X / News / Web / Farcaster columns, paste your **[xAI API key](https:
 | Category | Columns |
 |----------|---------|
 | **Social — X / Bluesky / Reddit / HN / Farcaster / Mastodon** (7) | `x-search`, `x-trending`, `bluesky`, `reddit`, `hacker-news`, `farcaster`, `mastodon` |
-| **GitHub** (10) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-stars`, `github-forks`, `github-search`, `github-backlinks`, `github-actions`, `github-discussions` |
+| **GitHub** (11) | `github-trending`, `github-releases`, `github-issues`, `github-prs`, `github-commits`, `github-stars`, `github-forks`, `github-search`, `github-backlinks`, `github-actions`, `github-discussions` |
 | **News & web** (11) | `bing` (Web search), `google-news`, `news-search`, `rss`, `lobsters`, `stack-overflow`, `devto`, `npm`, `pypi`, `crates`, `producthunt` |
 | **AI / ML** (2) | `huggingface` (trending models, datasets, spaces), `arxiv` (CS / stat / math.OC papers) |
 | **Long-form & video** (3) | `substack`, `youtube`, `linkedin` |

--- a/lib/columns/plugins/github-commits/client.tsx
+++ b/lib/columns/plugins/github-commits/client.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { GitCommitHorizontal } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  defineColumnUI,
+  type ConfigFormProps,
+  type ItemRendererProps,
+} from "@/lib/columns/types";
+import { meta, type GHCommitsConfig, type GHCommitsMeta } from "./plugin";
+
+function ConfigForm({ value, onChange }: ConfigFormProps<GHCommitsConfig>) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghco-repo">Repository</Label>
+        <Input
+          id="ghco-repo"
+          placeholder="vercel/next.js"
+          value={value.repo}
+          onChange={(e) => onChange({ ...value, repo: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          <code>owner/repo</code> or full GitHub URL.
+        </p>
+      </div>
+      <div className="grid gap-1.5">
+        <Label htmlFor="ghco-branch">Branch</Label>
+        <Input
+          id="ghco-branch"
+          placeholder="(default branch)"
+          value={value.branch}
+          onChange={(e) => onChange({ ...value, branch: e.target.value })}
+        />
+        <p className="text-xs text-muted-foreground">
+          Branch, tag, or commit SHA. Leave empty for the default branch.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ItemRenderer({ item }: ItemRendererProps<GHCommitsMeta>) {
+  const m = item.meta;
+  const repo = m?.repo ?? "";
+  const shortSha = m?.shortSha ?? "";
+
+  // Commits come in as `${subject}\n\n${body?}` from the integration layer.
+  const [title, ...rest] = item.content.split("\n\n");
+  const body = rest.join("\n\n").trim();
+
+  return (
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group/item block border-b border-border px-3.5 py-3 transition-colors hover:bg-surface/60"
+    >
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-muted-foreground">
+        <span
+          className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 font-medium text-foreground ring-1 ring-black/5"
+          style={{ backgroundColor: "rgba(137, 87, 229, 0.22)" }}
+        >
+          <GitCommitHorizontal className="size-3" />
+          commit
+        </span>
+        {repo && <span className="truncate text-foreground/80">{repo}</span>}
+        {shortSha && (
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="truncate font-mono text-[10.5px] text-foreground/70">
+              {shortSha}
+            </span>
+          </>
+        )}
+        <span className="text-muted-foreground/50">·</span>
+        <span className="truncate text-foreground/70">{item.author.name}</span>
+        <span className="text-muted-foreground/50">·</span>
+        <span className="tabular-nums">
+          <RelativeTime date={item.createdAt} addSuffix />
+        </span>
+      </div>
+      <h3
+        className="mt-1 font-serif text-[16px] leading-[1.3] text-foreground break-words transition-colors group-hover/item:text-[color:var(--brand-hover)]"
+        style={{ letterSpacing: "-0.005em", fontFeatureSettings: '"cswh" 1' }}
+      >
+        {title}
+      </h3>
+      {body && (
+        <p className="mt-1 line-clamp-3 text-[12.5px] leading-snug text-muted-foreground break-words whitespace-pre-line">
+          {body}
+        </p>
+      )}
+    </a>
+  );
+}
+
+export const column = defineColumnUI<GHCommitsConfig, GHCommitsMeta>({
+  ...meta,
+  ConfigForm,
+  ItemRenderer,
+});

--- a/lib/columns/plugins/github-commits/plugin.ts
+++ b/lib/columns/plugins/github-commits/plugin.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { GitCommitHorizontal } from "lucide-react";
+import type { PluginMeta } from "@/lib/columns/types";
+
+export const schema = z.object({
+  repo: z.string().default(""),
+  branch: z.string().default(""),
+});
+
+export type GHCommitsConfig = z.infer<typeof schema>;
+
+export interface GHCommitsMeta {
+  kind?: "commit";
+  repo?: string;
+  sha?: string;
+  shortSha?: string;
+}
+
+export const meta: PluginMeta<GHCommitsConfig, GHCommitsMeta> = {
+  id: "github-commits",
+  label: "Repo commits",
+  description: "Latest commits on a GitHub repo branch, newest first.",
+  icon: GitCommitHorizontal,
+  accent: "#8957e5",
+  category: "social",
+  schema,
+  defaultConfig: schema.parse({}),
+  defaultTitle: (c) => {
+    const repo = c.repo.trim();
+    if (!repo) return "GitHub · Commits";
+    const branch = c.branch.trim();
+    return branch ? `Commits · ${repo}@${branch}` : `Commits · ${repo}`;
+  },
+  capabilities: {
+    paginated: true,
+    rateLimitHint: "60 req/hr without GITHUB_TOKEN, 5000 with.",
+  },
+};

--- a/lib/columns/plugins/github-commits/server.ts
+++ b/lib/columns/plugins/github-commits/server.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import {
+  defineColumnServer,
+  type FeedItem,
+  type ServerFetcher,
+} from "@/lib/columns/types";
+import { fetchCommits } from "@/lib/integrations/github";
+import { PAGE_SIZE } from "@/lib/columns/constants";
+import { meta, type GHCommitsConfig, type GHCommitsMeta } from "./plugin";
+
+const fetch: ServerFetcher<GHCommitsConfig, GHCommitsMeta> = async (
+  config,
+  cursor,
+) => {
+  const repo = config.repo.trim();
+  if (!repo) throw new Error("Repository is required (owner/repo).");
+  const page = cursor ? Number(cursor) || 1 : 1;
+  const items = (await fetchCommits(
+    repo,
+    config.branch,
+    PAGE_SIZE,
+    page,
+  )) as FeedItem<GHCommitsMeta>[];
+  return {
+    items,
+    nextCursor: items.length === PAGE_SIZE ? String(page + 1) : undefined,
+  };
+};
+
+export const server = defineColumnServer<GHCommitsConfig, GHCommitsMeta>({
+  meta,
+  fetch,
+});

--- a/lib/columns/plugins/manifest.ts
+++ b/lib/columns/plugins/manifest.ts
@@ -52,6 +52,7 @@ import { meta as coingecko } from "./coingecko/plugin";
 import { meta as githubDiscussions } from "./github-discussions/plugin";
 import { meta as defillama } from "./defillama/plugin";
 import { meta as dexscreener } from "./dexscreener/plugin";
+import { meta as githubCommits } from "./github-commits/plugin";
 
 export const PLUGIN_METAS = [
   xSearch,
@@ -102,6 +103,7 @@ export const PLUGIN_METAS = [
   githubDiscussions,
   defillama,
   dexscreener,
+  githubCommits,
 ];
 
 export const REGISTERED_IDS: ReadonlySet<string> = new Set(

--- a/lib/columns/registry.ts
+++ b/lib/columns/registry.ts
@@ -60,6 +60,7 @@ import { column as coingecko } from "@/lib/columns/plugins/coingecko/client";
 import { column as githubDiscussions } from "@/lib/columns/plugins/github-discussions/client";
 import { column as defillama } from "@/lib/columns/plugins/defillama/client";
 import { column as dexscreener } from "@/lib/columns/plugins/dexscreener/client";
+import { column as githubCommits } from "@/lib/columns/plugins/github-commits/client";
 
 // Keyed by id rather than positional — "use client" boundary means we can't
 // read `column.id` reliably from a server context anyway, so the id has to
@@ -113,6 +114,7 @@ const COLUMNS_BY_ID: Record<string, AnyColumnUI> = {
   "github-discussions": githubDiscussions,
   defillama,
   dexscreener,
+  "github-commits": githubCommits,
 };
 
 // Pre-built ordered list, indexed by manifest order. Built once at module init.

--- a/lib/columns/server-registry.ts
+++ b/lib/columns/server-registry.ts
@@ -56,6 +56,7 @@ import { server as coingecko } from "@/lib/columns/plugins/coingecko/server";
 import { server as githubDiscussions } from "@/lib/columns/plugins/github-discussions/server";
 import { server as defillama } from "@/lib/columns/plugins/defillama/server";
 import { server as dexscreener } from "@/lib/columns/plugins/dexscreener/server";
+import { server as githubCommits } from "@/lib/columns/plugins/github-commits/server";
 
 const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "x-search": xSearch,
@@ -106,6 +107,7 @@ const SERVERS_BY_ID: Record<string, AnyColumnServer> = {
   "github-discussions": githubDiscussions,
   defillama,
   dexscreener,
+  "github-commits": githubCommits,
 };
 
 // Parity check — runs once at server module init. Throws loudly rather than

--- a/lib/integrations/github.ts
+++ b/lib/integrations/github.ts
@@ -359,7 +359,7 @@ export async function fetchCommits(
     return {
       id: `ghc-${c.sha}`,
       author: {
-        name: c.author?.login ?? c.commit.author?.name ?? "unknown",
+        name: handle,
         handle,
         avatarUrl:
           c.author?.avatar_url ??

--- a/lib/integrations/github.ts
+++ b/lib/integrations/github.ts
@@ -318,6 +318,69 @@ export async function fetchPullRequests(
   });
 }
 
+interface GHCommitListItem {
+  sha: string;
+  html_url: string;
+  commit: {
+    message: string;
+    author?: { name?: string; email?: string; date?: string };
+    committer?: { name?: string; email?: string; date?: string };
+  };
+  author?: { login: string; avatar_url?: string } | null;
+}
+
+export async function fetchCommits(
+  repo: string,
+  branch: string,
+  limit: number,
+  page = 1,
+): Promise<FeedItem[]> {
+  const clean = repo.trim().replace(/^https?:\/\/github\.com\//, "");
+  if (!/^[\w.-]+\/[\w.-]+$/.test(clean)) {
+    throw new Error(`Invalid repo "${repo}". Use owner/repo (e.g. vercel/next.js).`);
+  }
+  const params = new URLSearchParams({
+    per_page: String(limit),
+    page: String(page),
+  });
+  // `sha` accepts a branch name, tag, or commit SHA. Empty = the default branch.
+  const ref = branch.trim();
+  if (ref) params.set("sha", ref);
+  const commits = await ghFetch<GHCommitListItem[]>(
+    `${API}/repos/${clean}/commits?${params}`,
+  );
+  return commits.slice(0, limit).map((c) => {
+    const handle =
+      c.author?.login ?? c.commit.author?.name ?? clean.split("/")[0] ?? "github";
+    const message = (c.commit.message ?? "").trim();
+    const [firstLine, ...rest] = message.split("\n");
+    const body = rest.join("\n").trim();
+    const trimmed = truncateText(body, 400);
+    return {
+      id: `ghc-${c.sha}`,
+      author: {
+        name: c.author?.login ?? c.commit.author?.name ?? "unknown",
+        handle,
+        avatarUrl:
+          c.author?.avatar_url ??
+          identiconUrl(handle),
+      },
+      content: trimmed ? `${firstLine}\n\n${trimmed}` : firstLine,
+      url: c.html_url,
+      createdAt:
+        c.commit.author?.date ??
+        c.commit.committer?.date ??
+        new Date().toISOString(),
+      meta: {
+        kind: "commit",
+        repo: clean,
+        sha: c.sha,
+        shortSha: c.sha.slice(0, 7),
+      },
+    } satisfies FeedItem;
+  });
+}
+
 export async function fetchGitHub(
   mode: GHMode,
   config: { language?: string; period?: string; repo?: string; query?: string },


### PR DESCRIPTION
## What
Adds a **`github-commits`** column type — a live feed of the latest commits on a GitHub repository, newest first. You give it `owner/repo` (and optionally a branch, tag, or commit SHA; empty = the default branch) and the column streams in each commit's subject line, body excerpt, author, short SHA, and relative time, with each item linking to the commit on GitHub. Page through history 10 at a time with **Load more**, just like the other GitHub columns.

## Why
The `github-*` family already covers trending, issues, PRs, stars, forks, search, backlinks, releases, Actions, and Discussions — but **not commits**, which is the most direct signal of "is this repo actually moving?" The README's open-source-maintainer use case explicitly calls out watching issues / PRs / stars / forks on a repo; commit activity is the obvious missing lane (watch a dependency's `main`, a competitor's velocity, or a release branch stabilizing). This fills that gap and brings the catalog to **49 column types** (GitHub family: 10 → 11).

## How it works
It follows the established 3-file plugin contract (`plugin.ts` metadata + Zod schema, `client.tsx` ConfigForm + ItemRenderer, `server.ts` fetcher) and is registered in all three id registries (`manifest.ts`, `registry.ts`, `server-registry.ts`) so the init-time parity check passes. The fetcher is a new `fetchCommits()` in `lib/integrations/github.ts` that hits `GET /repos/{owner}/{repo}/commits` through the existing shared `ghFetch`/`headers` client — so it inherits the same keyless-or-`GITHUB_TOKEN` auth and the same 60→5000 req/hr rate-limit profile as the rest of the family (no new env var, no new dependency). The optional branch field maps to the endpoint's `sha` parameter; pagination uses the same page-number cursor pattern as `github-releases`/`github-prs`. Verified with a full `npm run build` (TypeScript clean, parity check passed, static generation OK).

## Changes
- `lib/integrations/github.ts`: new exported `fetchCommits(repo, branch, limit, page)` mapping the commits API to `FeedItem`s (subject/body split, author + avatar, short SHA), mirroring `fetchReleases`/`fetchPullRequests`.
- `lib/columns/plugins/github-commits/{plugin.ts,client.tsx,server.ts}`: the new column — repo + branch config form, commit renderer with a purple "commit" pill, SHA, author, and relative time.
- `lib/columns/plugins/manifest.ts`, `lib/columns/registry.ts`, `lib/columns/server-registry.ts`: register `github-commits` in all three id lists.
- `README.md`: add `github-commits` to the GitHub column row (now 11), bump the headline count to 49, and mention commits in the column-types intro.

---
*Built autonomously by Aeon*
