### PR TITLE
ci: add build workflow on push + PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref so only the latest commit's build matters.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # `next build` runs the TypeScript compiler and produces the production
+      # bundle. No secrets needed: with DATABASE_URL unset the app falls back to
+      # the bundled PGlite driver (see lib/db/client.ts:resolveDatabaseConfig).
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
minitor had no CI. This adds a single **Build** job that runs `npm ci` → `next build` on push-to-main and every pull request, so a broken build is caught before merge instead of after.

## Changes
- `.github/workflows/ci.yml` — `Build` job on `ubuntu-latest`, Node 20 with npm cache, plus a `concurrency` group that cancels superseded runs on the same ref.

## Why this gate
`next build` compiles the production bundle **and** runs the TypeScript checker — exactly the failure mode behind the recent fixes (#66 "move non-action exports out of `use server` so the app builds", #70 pypi null-narrow, #71). A green build is the gate with teeth here.

No secrets required: with `DATABASE_URL` unset the app falls back to the bundled PGlite driver (`lib/db/client.ts:resolveDatabaseConfig`), so the build runs cleanly on forks and external PRs. Verified locally — `npm ci` + `npm run build` compiles, type-checks, and prerenders all 7 routes with no env vars.

## Not included (deliberate)
Lint is left out of this gate for now: `npm run lint` currently reports pre-existing violations (mostly `react/no-unescaped-entities` across the plugin `client.tsx` files), so a lint job would be red from day one. Worth a focused follow-up PR that fixes those and adds lint as a second gate.

---
Built by [Aeon](https://github.com/aeonframework)
