### PR TITLE
ci: bump checkout/setup-node to v5 + read-only token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,18 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Read-only token is all this build needs (checkout); least-privilege by default.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
Follow-up to #76 (the CI build workflow).

## What
- Bump `actions/checkout@v4` → `@v5` and `actions/setup-node@v4` → `@v5`.
- Add a least-privilege top-level `permissions: contents: read` block.

## Why
The `@v4` actions now emit GitHub's runner warning *"Node.js 20 is deprecated… forced to run on Node.js 24"*. Bumping to `@v5` clears it. This is the **action runtime** only — the build target (`node-version: 20`) is unchanged.

The build only needs `checkout`, so a read-only token is sufficient; scoping `permissions` down is best-practice hardening.

## Risk
Minimal — no behavior change to the build itself; CI re-running on this PR confirms it stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)