### PR TITLE
feat: validate non-empty search query in Grok-backed columns

### DIFF
--- a/lib/columns/plugins/facebook/server.ts
+++ b/lib/columns/plugins/facebook/server.ts
@@ -17,10 +17,10 @@ const fetch: ServerFetcher<FacebookConfig, FacebookMeta> = async (
   config,
   cursor,
 ) => {
-  const items = (await grokFacebookSearch(
-    config.query,
-    30,
-  )) as FeedItem<FacebookMeta>[];
+  const q = config.query.trim();
+  if (!q) throw new Error("Search query is required.");
+
+  const items = (await grokFacebookSearch(q, 30)) as FeedItem<FacebookMeta>[];
   return sliceForPage(items, cursor);
 };
 

--- a/lib/columns/plugins/google-news/server.ts
+++ b/lib/columns/plugins/google-news/server.ts
@@ -17,8 +17,11 @@ const fetch: ServerFetcher<GoogleNewsConfig, GoogleNewsMeta> = async (
   config,
   cursor,
 ) => {
+  const q = config.query.trim();
+  if (!q) throw new Error("Search query is required.");
+
   const items = (await fetchFeed(
-    googleNewsUrl(config.query, config.hl, config.gl),
+    googleNewsUrl(q, config.hl, config.gl),
     50,
   )) as FeedItem<GoogleNewsMeta>[];
   return sliceForPage(items, cursor);

--- a/lib/columns/plugins/instagram/server.ts
+++ b/lib/columns/plugins/instagram/server.ts
@@ -16,10 +16,10 @@ const fetch: ServerFetcher<InstagramConfig, InstagramMeta> = async (
   config,
   cursor,
 ) => {
-  const items = (await fetchInstagram(
-    config.query,
-    30,
-  )) as FeedItem<InstagramMeta>[];
+  const q = config.query.trim();
+  if (!q) throw new Error("Search query is required.");
+
+  const items = (await fetchInstagram(q, 30)) as FeedItem<InstagramMeta>[];
   return sliceForPage(items, cursor);
 };
 

--- a/lib/columns/plugins/news-search/server.ts
+++ b/lib/columns/plugins/news-search/server.ts
@@ -13,10 +13,10 @@ const fetch: ServerFetcher<NewsSearchConfig, NewsSearchMeta> = async (
   config,
   cursor,
 ) => {
-  const items = (await grokNewsSearch(
-    config.query,
-    30,
-  )) as FeedItem<NewsSearchMeta>[];
+  const q = config.query.trim();
+  if (!q) throw new Error("Search query is required.");
+
+  const items = (await grokNewsSearch(q, 30)) as FeedItem<NewsSearchMeta>[];
   return sliceForPage(items, cursor);
 };
 

--- a/lib/columns/plugins/x-search/server.ts
+++ b/lib/columns/plugins/x-search/server.ts
@@ -13,7 +13,10 @@ const fetch: ServerFetcher<XSearchConfig, TweetMeta> = async (
   config,
   cursor,
 ) => {
-  const items = (await grokXSearch(config.query, 30)) as FeedItem<TweetMeta>[];
+  const q = config.query.trim();
+  if (!q) throw new Error("Search query is required.");
+
+  const items = (await grokXSearch(q, 30)) as FeedItem<TweetMeta>[];
   return sliceForPage(items, cursor);
 };
 


### PR DESCRIPTION
## What
Five search-backed columns — `x-search`, `news-search`, `facebook`, `instagram`, and `google-news` — now reject empty or whitespace-only queries with a clear `Search query is required.` error before any upstream call, and pass the trimmed query downstream.

## Why
These columns forwarded `config.query` straight to their fetchers with no guard. A blank query fired a wasted Grok API call (xAI spend) that came back as an opaque failure, leaving the user with no idea what went wrong. The sibling `farcaster` and `bing` columns already trim-and-throw on empty input — this brings the rest of the search columns in line with that established pattern.

## Changes
- `lib/columns/plugins/x-search/server.ts`: trim query, throw on empty, pass trimmed value to `grokXSearch`
- `lib/columns/plugins/news-search/server.ts`: same guard before `grokNewsSearch`
- `lib/columns/plugins/facebook/server.ts`: same guard before `grokFacebookSearch`
- `lib/columns/plugins/instagram/server.ts`: same guard before `fetchInstagram`
- `lib/columns/plugins/google-news/server.ts`: same guard before building the Google News RSS URL

---
*Built autonomously by Aeon*
