### PR TITLE
fix(columns): validate required inputs in linkedin, bluesky, mastodon, youtube

### DIFF
--- a/lib/columns/plugins/bluesky/server.ts
+++ b/lib/columns/plugins/bluesky/server.ts
@@ -13,6 +13,12 @@ const fetch: ServerFetcher<BlueskyConfig, BlueskyMeta> = async (
   config,
   cursor,
 ) => {
+  if (config.mode === "author") {
+    if (!config.handle.trim()) throw new Error("Author handle is required.");
+  } else if (!config.query.trim()) {
+    throw new Error("Search query is required.");
+  }
+
   const r = await fetchBlueskyPage(
     config.mode,
     config.query,

--- a/lib/columns/plugins/linkedin/server.ts
+++ b/lib/columns/plugins/linkedin/server.ts
@@ -17,8 +17,11 @@ const fetch: ServerFetcher<LinkedinConfig, LinkedinMeta> = async (
   config,
   cursor,
 ) => {
+  const q = config.query.trim();
+  if (!q) throw new Error("Search query is required.");
+
   const items = (await searchLinkedinPosts(
-    config.query,
+    q,
     30,
   )) as FeedItem<LinkedinMeta>[];
   return sliceForPage(items, cursor);

--- a/lib/columns/plugins/mastodon/server.ts
+++ b/lib/columns/plugins/mastodon/server.ts
@@ -16,6 +16,12 @@ const fetch: ServerFetcher<MastodonConfig, MastodonMeta> = async (
   config,
   cursor,
 ) => {
+  if (config.mode === "author") {
+    if (!config.handle.trim()) throw new Error("Author handle is required.");
+  } else if (!config.query.trim()) {
+    throw new Error("Hashtag is required.");
+  }
+
   const items =
     config.mode === "author"
       ? await fetchMastodonAuthor(config.instance, config.handle, 30)

--- a/lib/columns/plugins/youtube/server.ts
+++ b/lib/columns/plugins/youtube/server.ts
@@ -14,6 +14,7 @@ import { meta, type YTConfig, type YTMeta } from "./plugin";
 
 const fetch: ServerFetcher<YTConfig, YTMeta> = async (config, cursor) => {
   if (config.mode === "search") {
+    if (!config.query.trim()) throw new Error("Search query is required.");
     const r = await fetchYouTubeSearchPage(
       config.query,
       config.order,
@@ -25,6 +26,10 @@ const fetch: ServerFetcher<YTConfig, YTMeta> = async (config, cursor) => {
       nextCursor: r.nextPageToken,
     };
   }
+  if (config.mode === "channel" && !config.channel.trim())
+    throw new Error("Channel handle or ID is required.");
+  if (config.mode === "playlist" && !config.playlist.trim())
+    throw new Error("Playlist ID is required.");
   const items = (await fetchYouTube(config.mode, {
     query: config.query,
     order: config.order,


### PR DESCRIPTION
## What
Adds the missing required-input validation to four moded social/search columns — `linkedin`, `bluesky`, `mastodon`, and `youtube`. Each now throws a clear error when its required input for the active mode is empty or whitespace-only, before any upstream request goes out.

## Why
These four columns passed `config.query` (and the author/channel/playlist inputs) straight to their upstream APIs with no guard. An empty value fired a **wasted request** — a Grok `web_search` call for `linkedin`, a public-AppView / Mastodon / YouTube fetch for the rest — that came back as an opaque upstream error instead of a clear "input required" message. The user just sees the column fail with no idea why.

`farcaster` and every `github-*` column already trim-and-throw on their required input. PR #78 fixed this same class of bug across the five Grok-backed search columns (`x-search`, `news-search`, `facebook`, `instagram`, `google-news`) but didn't cover these four. This brings the rest in line.

## Changes
- `lib/columns/plugins/linkedin/server.ts`: throw on empty `query` (Grok-backed, single required input); pass the trimmed value through.
- `lib/columns/plugins/bluesky/server.ts`: throw on empty `query` in search mode, empty `handle` in author mode.
- `lib/columns/plugins/mastodon/server.ts`: throw on empty `query` (hashtag) in hashtag mode, empty `handle` in author mode.
- `lib/columns/plugins/youtube/server.ts`: throw on empty `query`/`channel`/`playlist` for the matching mode.

Guard-only — the values passed to the integrations are unchanged (except `linkedin`, which now forwards the trimmed query, matching `farcaster`). No behavior change for valid inputs.

---
*Built autonomously by Aeon*
