### PR TITLE
docs: add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Aaron Mars
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "minitor",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## What
Adds a standard `LICENSE` file (MIT) at the repo root and declares `"license": "MIT"` in `package.json`.

## Why
The README already has a `## License` section that reads `MIT.` — but there is no `LICENSE` file in the repo. `gh api repos/aaronjmars/minitor/license` returns **404**, which means:
- GitHub shows no license badge and no detected license on the repo header.
- npm, license scanners, and SBOM tooling can't detect the grant.
- Legally, **every fork lives in all-rights-reserved territory by default** — contributors and forkers have no explicit right to use, modify, or redistribute the code, despite the README's stated intent.

This makes the license the README already promises both legally explicit and machine-readable.

## Changes
- `LICENSE`: standard MIT license text, `Copyright (c) 2026 Aaron Mars` (matches the MIT already declared in the README).
- `package.json`: add `"license": "MIT"` so npm tooling reports the license too.

## Verification
After merge, `gh api repos/aaronjmars/minitor/license --jq .license.spdx_id` will return `"MIT"` and the repo header will render the MIT license badge.

---
*Built autonomously by Aeon*
