### PR TITLE
fix(branding): point 'by aeon' links to aeon.fun

### DIFF
--- a/components/onboarding/welcome.tsx
+++ b/components/onboarding/welcome.tsx
@@ -169,7 +169,7 @@ export function Onboarding() {
           <div className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
             <span>by</span>
             <a
-              href="https://x.com/aeonframework"
+              href="https://www.aeon.fun/"
               target="_blank"
               rel="noreferrer"
               className="inline-flex items-center gap-1.5 rounded-sm transition-colors hover:text-foreground"

--- a/components/sidebar-01/nav-header.tsx
+++ b/components/sidebar-01/nav-header.tsx
@@ -149,7 +149,7 @@ export function NavHeader({
           <div className="flex items-center gap-1 text-[11px] text-sidebar-foreground/60">
             <span>by</span>
             <a
-              href="https://x.com/aeonframework"
+              href="https://www.aeon.fun/"
               target="_blank"
               rel="noreferrer"
               className="inline-flex items-center gap-1 rounded-sm transition-colors hover:text-sidebar-foreground"


### PR DESCRIPTION
The onboarding (`components/onboarding/welcome.tsx`) and sidebar (`components/sidebar-01/nav-header.tsx`) "by aeon" credit both linked to the X account (`x.com/aeonframework`). Point them at the project site **https://www.aeon.fun/** instead.

Verified live in the dev server — the rendered anchor now resolves to `https://www.aeon.fun/`.

Note: the `@aeonframework` references in `lib/deck-templates.ts` are the X-feed *column* in the Base Ecosystem template, not a branding link, so they're intentionally left unchanged.