### PR TITLE
fix: honest API-key gating in the Add-column dialog

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -9,7 +9,7 @@ import { db } from "@/lib/db/client";
 import { columns, deckSnapshots, decks, feedItems } from "@/lib/db/schema";
 import type { Column, Deck, FeedItem } from "@/lib/columns/types";
 import { MAX_ITEMS_PER_COLUMN } from "@/lib/columns/constants";
-import { ENV_KEYS, ENV_KEY_NAMES } from "@/lib/env-keys";
+import { ENV_KEYS, ENV_KEY_NAMES, isPlaceholderValue } from "@/lib/env-keys";
 import { isHostedDeployment } from "@/lib/hosted";
 import {
   parseAlertKeywords,
@@ -56,7 +56,10 @@ export async function getKeyAvailability(
   const out: Record<string, boolean> = {};
   for (const k of keys) {
     if (!/^[A-Z][A-Z0-9_]*$/.test(k)) continue;
-    out[k] = Boolean(process.env[k]);
+    // Treat blank / `.env.example` placeholders as unset, matching `doctor`
+    // and the fetchers — otherwise a placeholder greys nothing and the column
+    // looks ready but fails on refresh.
+    out[k] = !isPlaceholderValue(process.env[k]);
   }
   return out;
 }
@@ -973,7 +976,8 @@ export interface EnvKeyStatus {
 export async function getEnvKeysStatus(): Promise<EnvKeyStatus[]> {
   return ENV_KEYS.map(({ key }) => {
     const v = process.env[key] ?? "";
-    if (!v) return { key, set: false };
+    // A leftover `.env.example` placeholder (e.g. `xai-...`) is not configured.
+    if (isPlaceholderValue(v)) return { key, set: false };
     const preview = v.length >= 4 ? v.slice(-4) : v;
     return { key, set: true, preview };
   });

--- a/lib/columns/plugins/github-discussions/plugin.ts
+++ b/lib/columns/plugins/github-discussions/plugin.ts
@@ -48,6 +48,9 @@ export const meta: PluginMeta<GHDiscussionsConfig, GHDiscussionsMeta> = {
   },
   capabilities: {
     paginated: true,
+    // Hard requirement, not just a rate-limit bump: the GraphQL API gives
+    // unauthenticated requests ~0 quota (403), so surface it for UI dimming.
+    requiresEnv: ["GITHUB_TOKEN"],
     rateLimitHint:
       "Requires GITHUB_TOKEN — the GraphQL API gives unauthenticated requests ~0 quota (403). 5000 req/hr with one.",
   },

--- a/lib/columns/plugins/github-stars/plugin.ts
+++ b/lib/columns/plugins/github-stars/plugin.ts
@@ -26,6 +26,9 @@ export const meta: PluginMeta<GHStarsConfig, GHStarsMeta> = {
   },
   capabilities: {
     paginated: true,
+    // Hard requirement, not just a rate-limit bump: the stargazers list is
+    // auth-gated (401 without a token), so surface it to the UI for dimming.
+    requiresEnv: ["GITHUB_TOKEN"],
     rateLimitHint:
       "Requires GITHUB_TOKEN — GitHub auth-gates the stargazers list (401 without a token). 5000 req/hr with one.",
   },

--- a/lib/env-keys.ts
+++ b/lib/env-keys.ts
@@ -55,3 +55,20 @@ export const ENV_KEYS: EnvKeySpec[] = [
 ];
 
 export const ENV_KEY_NAMES = new Set(ENV_KEYS.map((k) => k.key));
+
+/**
+ * Whether an env value is effectively unset — blank, or a fill-me-in
+ * placeholder like `.env.example`'s `XAI_API_KEY=xai-...`. `./minitor doctor`
+ * rejects the same placeholder, but a naive `Boolean(process.env.X)` counts it
+ * as configured — so the Add-column dialog shows a broken column as ready and
+ * the fetcher ships a bogus key upstream (xAI answers "Incorrect API key").
+ * Pure and client-safe; callers pass `process.env[...]` in from the server.
+ */
+export function isPlaceholderValue(value: string | undefined | null): boolean {
+  if (value == null) return true;
+  const v = value.trim();
+  if (v === "") return true;
+  // Ellipsis (ASCII "..." or unicode "…") is the fill-me-in marker in the
+  // shipped .env.example placeholders. No real API key contains it.
+  return v.includes("...") || v.includes("…");
+}

--- a/lib/integrations/xai.ts
+++ b/lib/integrations/xai.ts
@@ -2,6 +2,7 @@ import { fetchUpstream } from "@/lib/integrations/fetch";
 import { nanoid } from "nanoid";
 import type { FeedItem } from "@/lib/columns/types";
 import { identiconUrl } from "@/lib/utils";
+import { isPlaceholderValue } from "@/lib/env-keys";
 
 const XAI_URL = "https://api.x.ai/v1/responses";
 
@@ -86,8 +87,13 @@ function extractJsonArray(text: string): GrokItem[] {
 
 async function callGrok(options: GrokSearchOptions): Promise<GrokItem[]> {
   const apiKey = process.env.XAI_API_KEY;
-  if (!apiKey) {
-    throw new Error("XAI_API_KEY is not set in .env.local");
+  // Reject the blank/`.env.example` placeholder here too, so a leftover
+  // `xai-...` fails with a clear "not set" message instead of being shipped
+  // upstream and bouncing back as an opaque "Incorrect API key".
+  if (isPlaceholderValue(apiKey)) {
+    throw new Error(
+      "XAI_API_KEY is not set in .env.local (still the .env.example placeholder?)",
+    );
   }
   const model = options.model ?? process.env.XAI_MODEL ?? "grok-4-fast-reasoning";
 

--- a/test/env-keys.test.ts
+++ b/test/env-keys.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { isPlaceholderValue } from "@/lib/env-keys";
+
+describe("isPlaceholderValue", () => {
+  it("treats blank / nullish values as unset", () => {
+    expect(isPlaceholderValue(undefined)).toBe(true);
+    expect(isPlaceholderValue(null)).toBe(true);
+    expect(isPlaceholderValue("")).toBe(true);
+    expect(isPlaceholderValue("   ")).toBe(true);
+  });
+
+  it("treats the shipped .env.example ellipsis placeholders as unset", () => {
+    // .env.example ships `XAI_API_KEY=xai-...`
+    expect(isPlaceholderValue("xai-...")).toBe(true);
+    expect(isPlaceholderValue("your-key-…")).toBe(true);
+  });
+
+  it("accepts a real-looking key", () => {
+    expect(isPlaceholderValue("xai-abc123DEF456ghi789")).toBe(false);
+    expect(isPlaceholderValue("ghp_aBcD1234")).toBe(false);
+    expect(isPlaceholderValue("  xai-realkey  ")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The Add-column picker under-reported which columns need a key. It dimmed a source only from `capabilities.requiresEnv`, and two things were off:

1. **`github-stars` and `github-discussions`** hard-require a `GITHUB_TOKEN` (stargazers list is auth-gated; Discussions GraphQL gives unauthenticated requests ~0 quota) but declared it only in free-text `rateLimitHint` — so they showed as ready and only failed on refresh.
2. **The 6 xAI columns** *did* declare `requiresEnv`, but `.env.example` ships `XAI_API_KEY=xai-...` — a **non-empty placeholder**. `Boolean(process.env.XAI_API_KEY)` counted it as configured, so those columns looked ready but failed on refresh with an opaque xAI `"Incorrect API key"`, and Settings reported the key as set. `./minitor doctor` already rejects the same placeholder.

Net: the UI showed **6** key-gated columns when **8** actually can't fetch without a credential — and even those 6 weren't dimmed when a placeholder was present.

## Fix

- Declare `requiresEnv: ["GITHUB_TOKEN"]` on `github-stars` + `github-discussions`.
- Add a pure, client-safe `isPlaceholderValue()` to `lib/env-keys.ts` (blank or contains an ellipsis `...`/`…`) and route all three key-presence reads through it: `getKeyAvailability` (dialog dimming), `getEnvKeysStatus` (Settings), and `callGrok` (fetch-time).

Now the dialog dims all 8 key-gated columns honestly in every env state, and a leftover placeholder fails with a clear `"XAI_API_KEY is not set"` instead of a bounced upstream call.

## Verification

- Live UI: **8** columns now dim with the key icon (6 xAI + stars + discussions), verified via DOM.
- `x-trending` with the placeholder key → `"XAI_API_KEY is not set in .env.local (still the .env.example placeholder?)"` (was `"Incorrect API key"`).
- Keyless columns unaffected (e.g. hacker-news still returns items).
- `npm test` → **275 pass** (added `test/env-keys.test.ts`); `eslint` clean.