### PR TITLE
chore: update attribution to aeonfun / Aeon Inc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for helping build Minitor — the dashboard for the current thing. The mo
 **Prereqs:** Node 20+. That's the whole list — PGlite is bundled (real Postgres compiled to WASM), so there's no Docker, no hosted database, no migrations to wire up by hand.
 
 ```bash
-git clone https://github.com/aaronjmars/minitor.git && cd minitor
+git clone https://github.com/aeonfun/minitor.git && cd minitor
 ./minitor
 ```
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Aaron Mars
+Copyright (c) 2026 Aeon Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">Minitor</h1>
 
 <p align="center">
-  <a href="https://github.com/aaronjmars/minitor/stargazers"><img src="https://img.shields.io/github/stars/aaronjmars/minitor?style=flat-square&logo=github" alt="GitHub stars"></a>
-  <a href="https://github.com/aaronjmars/minitor/network/members"><img src="https://img.shields.io/github/forks/aaronjmars/minitor?style=flat-square&logo=github" alt="GitHub forks"></a>
+  <a href="https://github.com/aeonfun/minitor/stargazers"><img src="https://img.shields.io/github/stars/aeonfun/minitor?style=flat-square&logo=github" alt="GitHub stars"></a>
+  <a href="https://github.com/aeonfun/minitor/network/members"><img src="https://img.shields.io/github/forks/aeonfun/minitor?style=flat-square&logo=github" alt="GitHub forks"></a>
   <a href="https://x.com/aeonframework"><img src="https://img.shields.io/badge/by-%40aeonframework-black?style=flat-square&logo=x&labelColor=000000" alt="by aeon"></a>
   <a href="https://bankr.bot/discover/0xbf8e8f0e8866a7052f948c16508644347c57aba3"><img src="https://img.shields.io/badge/Aeon%20on-Bankr-orange?style=flat-square&labelColor=1a1a2e" alt="Aeon on Bankr"></a>
 </p>
@@ -36,7 +36,7 @@ The recommended path: **one command, `./minitor`.** First column up in under a m
 **Prereqs** — Node 20+. That's it. PGlite is bundled (real Postgres compiled to WASM), so no Docker, no hosted database, no setup.
 
 ```bash
-git clone https://github.com/aaronjmars/minitor.git && cd minitor
+git clone https://github.com/aeonfun/minitor.git && cd minitor
 ./minitor
 ```
 
@@ -178,4 +178,4 @@ MIT.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=aaronjmars/minitor&type=Date)](https://www.star-history.com/#aaronjmars/minitor&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=aeonfun/minitor&type=Date)](https://www.star-history.com/#aeonfun/minitor&Date)

--- a/lib/columns/plugins/aeon/plugin.ts
+++ b/lib/columns/plugins/aeon/plugin.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { Bot } from "lucide-react";
 import type { PluginMeta } from "@/lib/columns/types";
 
-// Aeon (github.com/aaronjmars/aeon) is an autonomous agent that runs "skills"
+// Aeon (github.com/aeonfun/aeon) is an autonomous agent that runs "skills"
 // on a cron and commits the results back into its repo. This column surfaces
 // that output. Four interchangeable sources, so it works whether the operator
 // runs the local Aeon dashboard or only has the GitHub fork:

--- a/lib/deck-templates.ts
+++ b/lib/deck-templates.ts
@@ -118,7 +118,7 @@ const aiResearch: DeckTemplate = {
 };
 
 // Base Ecosystem
-// GitHub stars for aaronjmars/aeon + aaronjmars/aeon-agent + CoinGecko AEON
+// GitHub stars for aeonfun/aeon + aaronjmars/aeon-agent + CoinGecko AEON
 // watchlist + DeFiLlama top (operator filters category to Base) + X search
 // for "@aeonframework". No wallet-tx — it requires a wallet address per row
 // and a one-click template can't pick one for the operator.
@@ -137,8 +137,8 @@ const baseEcosystem: DeckTemplate = {
     columns: [
       {
         typeId: "github-stars",
-        title: "Stars · aaronjmars/aeon",
-        config: { repo: "aaronjmars/aeon" },
+        title: "Stars · aeonfun/aeon",
+        config: { repo: "aeonfun/aeon" },
       },
       {
         typeId: "github-stars",

--- a/lib/integrations/aeon.ts
+++ b/lib/integrations/aeon.ts
@@ -1,6 +1,6 @@
 // Aeon integration — consumes the output an Aeon agent fork produces.
 //
-// Aeon (github.com/aaronjmars/aeon) is a GitHub-Actions-native agent: a cron
+// Aeon (github.com/aeonfun/aeon) is a GitHub-Actions-native agent: a cron
 // scheduler dispatches skills, each run commits its results back into the repo
 // and (optionally) serves them from a local dashboard. This client reads that
 // output through four interchangeable sources so the column works whether or

--- a/lib/integrations/arxiv.ts
+++ b/lib/integrations/arxiv.ts
@@ -253,7 +253,7 @@ export async function fetchArxivPage(
       accept: "application/atom+xml, application/xml;q=0.9, text/xml;q=0.9",
       // arXiv's user manual asks scrapers to identify themselves so the
       // operations team can rate-limit cooperatively if needed.
-      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
     },
     cache: "no-store",
   });

--- a/lib/integrations/coingecko.ts
+++ b/lib/integrations/coingecko.ts
@@ -192,7 +192,7 @@ async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetchUpstream(url, {
     headers: {
       accept: "application/json",
-      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
       ...authHeaders(),
     },
     cache: "no-store",

--- a/lib/integrations/crates.ts
+++ b/lib/integrations/crates.ts
@@ -147,7 +147,7 @@ export async function fetchCratesPage(
       // crates.io's User-Agent policy is strict — anonymous requests without
       // a UA get 403. Identifying minitor as the caller keeps us in
       // compliance with the documented expectation.
-      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
     },
     cache: "no-store",
   });

--- a/lib/integrations/defillama.ts
+++ b/lib/integrations/defillama.ts
@@ -144,7 +144,7 @@ async function fetchJson<T>(path: string): Promise<T> {
   const res = await fetchUpstream(`${API_BASE}${path}`, {
     headers: {
       accept: "application/json",
-      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
     },
     cache: "no-store",
   });

--- a/lib/integrations/devto.ts
+++ b/lib/integrations/devto.ts
@@ -185,7 +185,7 @@ export async function fetchDevtoPage(
   const res = await fetchUpstream(url, {
     headers: {
       accept: "application/json",
-      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
     },
     cache: "no-store",
   });

--- a/lib/integrations/dexscreener.ts
+++ b/lib/integrations/dexscreener.ts
@@ -124,7 +124,7 @@ async function fetchPairs(url: string): Promise<DexPair[]> {
   const res = await fetchUpstream(url, {
     headers: {
       accept: "application/json",
-      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
     },
     cache: "no-store",
   });

--- a/lib/integrations/huggingface.ts
+++ b/lib/integrations/huggingface.ts
@@ -163,7 +163,7 @@ export async function fetchHuggingfacePage(
   const res = await fetchUpstream(url, {
     headers: {
       accept: "application/json",
-      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
     },
     cache: "no-store",
   });

--- a/lib/integrations/lobsters.ts
+++ b/lib/integrations/lobsters.ts
@@ -119,7 +119,7 @@ export async function fetchLobstersPage(
       // Lobsters' admins ask scrapers to identify themselves; minitor is a
       // dashboard polling at user-driven cadence so a recognisable UA helps
       // them rate-limit cooperatively if needed.
-      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
     },
     cache: "no-store",
   });

--- a/lib/integrations/npm.ts
+++ b/lib/integrations/npm.ts
@@ -153,7 +153,7 @@ async function fetchWeeklyDownloads(pkgName: string): Promise<number> {
     const res = await fetchUpstream(url, {
       headers: {
         accept: "application/json",
-        "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+        "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
       },
       cache: "no-store",
     });
@@ -226,7 +226,7 @@ export async function fetchNpmPage(
   const res = await fetchUpstream(url, {
     headers: {
       accept: "application/json",
-      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
     },
     cache: "no-store",
   });

--- a/lib/integrations/polymarket.ts
+++ b/lib/integrations/polymarket.ts
@@ -210,7 +210,7 @@ export async function fetchPolymarketPage(
       // Polymarket's Gamma API is openly documented as public; identifying
       // ourselves keeps us in good standing if they ever start enforcing
       // per-client rate limits.
-      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
     },
     cache: "no-store",
   });

--- a/lib/integrations/pypi.ts
+++ b/lib/integrations/pypi.ts
@@ -41,7 +41,7 @@ const TOP_PACKAGES_URL =
 const STATS_BASE = "https://pypistats.org/api/packages";
 const PYPI_PROJECT_BASE = "https://pypi.org/project";
 
-const UA = "minitor/1.0 (+https://github.com/aaronjmars/minitor)";
+const UA = "minitor/1.0 (+https://github.com/aeonfun/minitor)";
 
 export type PypiMode = "updates" | "new-packages" | "top-30d";
 

--- a/lib/integrations/stackoverflow.ts
+++ b/lib/integrations/stackoverflow.ts
@@ -141,7 +141,7 @@ export async function fetchStackOverflowPage(
   const res = await fetchUpstream(url, {
     headers: {
       accept: "application/json",
-      "user-agent": "minitor/1.0 (+https://github.com/aaronjmars/minitor)",
+      "user-agent": "minitor/1.0 (+https://github.com/aeonfun/minitor)",
     },
     cache: "no-store",
   });


### PR DESCRIPTION
Repo was transferred from `aaronjmars` to the `aeonfun` org (owned by **Aeon Inc**). Updates self-referential GitHub links, README badges, clone URLs, integration `user-agent` strings, `lib/deck-templates.ts` widget defaults, and the LICENSE copyright holder (now Aeon Inc).

**Preserved intentionally:** `aaronjmars/aeon-agent` in `lib/deck-templates.ts` (no `aeonfun` equivalent exists).