### PR TITLE
docs: align X badge with aeon README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://github.com/aeonfun/minitor/stargazers"><img src="https://img.shields.io/github/stars/aeonfun/minitor?style=flat-square&logo=github" alt="GitHub stars"></a>
   <a href="https://github.com/aeonfun/minitor/network/members"><img src="https://img.shields.io/github/forks/aeonfun/minitor?style=flat-square&logo=github" alt="GitHub forks"></a>
-  <a href="https://x.com/aeonframework"><img src="https://img.shields.io/badge/by-%40aeonframework-black?style=flat-square&logo=x&labelColor=000000" alt="by aeon"></a>
+  <a href="https://x.com/aeonframework"><img src="https://img.shields.io/badge/Follow-%40aeonframework-black?style=flat-square&logo=x&labelColor=000000" alt="Follow on X"></a>
   <a href="https://bankr.bot/discover/0xbf8e8f0e8866a7052f948c16508644347c57aba3"><img src="https://img.shields.io/badge/Aeon%20on-Bankr-orange?style=flat-square&labelColor=1a1a2e" alt="Aeon on Bankr"></a>
 </p>
 


### PR DESCRIPTION
The header is already in Aeon style; this only aligns the X badge label to match Aeon ("Follow @aeonframework") for full badge-row parity across the org's repos.