### PR TITLE
chore: align the toolchain on Node 22 and pin npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          # Matches the Dockerfile's node:22-alpine, so CI builds what ships.
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,9 @@
         "tailwindcss": "^4",
         "typescript": "^6",
         "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
+  "packageManager": "npm@10.9.8",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
chore: align the toolchain on Node 22 and pin npm

CI built on Node 20, the Dockerfile ships node:22-alpine, and local dev runs
Node 26. CI was validating a runtime we do not deploy.

The split also broke Dependabot. Node 20 and node:22-alpine both bundle npm 10;
a newer npm generates a lockfile tree that npm 10 rejects:

  npm error code EUSAGE
  npm error Missing: esbuild@0.28.1 from lock file

That is why #106, #107 and #111 are red. It is not a fault in those bumps —
their lockfiles were generated by npm 11. The same lockfile would have failed
`npm ci` in the Docker build, so this was heading for a broken image, not just
a red check.

The compatibility runs one way only, which decides the fix:

  lock generated by npm 11  ->  npm 10 FAILS,  npm 11 ok
  lock generated by npm 10  ->  npm 10 ok,     npm 11 ok

So:

- CI node-version 20 -> 22, matching the Dockerfile.
- engines.node ">=22" documents the floor. Deliberately a floor rather than
  "22.x" so local Node 26 does not emit EBADENGINE on every install.
- packageManager "npm@10.9.8" pins the generator, which is what stops
  Dependabot re-introducing an npm 11 lockfile next cycle.

Lockfile regenerated with npm 10.9.8: unchanged at 839 packages, +3 lines for
the engines block. Verified `npm ci` under npm 10.9.8, `next build`, and
vitest (9 files, 279 tests) all pass.

The three Dependabot PRs need their lockfiles regenerated on top of this.

Co-Authored-By: Claude <noreply@anthropic.com>
