### PR TITLE
chore: stop Dependabot reopening the eslint 10 major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # eslint 10 removed the deprecated rule-context methods, and
+      # eslint-plugin-react (pulled in by eslint-config-next) still declares
+      # `eslint: ... || ^9.7`, so `npm run lint` crashes on load. See #107.
+      # Drop this once eslint-config-next ships a react plugin that supports 10.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
eslint 10 removed the deprecated rule-context methods. `eslint-plugin-react@7.37.5` (latest, and what `eslint-config-next@16.2.10` depends on) still declares a peer range topping out at `^9.7`, so `npm run lint` crashes on rule load rather than reporting.

Closed as #107. This stops it returning every week. Scoped to majors only, so 9.x patches still flow.

Drop the ignore once Next.js ships an `eslint-config-next` whose react plugin supports eslint 10.