### PR TITLE
refactor: remove the set-state-in-effect suppressions

### DIFF
--- a/components/column/column-card.tsx
+++ b/components/column/column-card.tsx
@@ -83,7 +83,14 @@ export function ColumnCard({ column }: { column: Column }) {
     s.pendingRefreshIds.has(column.id),
   );
   const clearPendingRefresh = useDeckStore((s) => s.clearPendingRefresh);
-  const [searchOpen, setSearchOpen] = useState(false);
+  const searchActive = searchQuery.trim().length > 0;
+  // Seeded from the query rather than hardcoded false: a column that mounts
+  // with a query already in the store (collapse/expand, tab switch) shows its
+  // search row on the first paint instead of flickering it in a frame later.
+  const [searchOpen, setSearchOpen] = useState(searchActive);
+  // Mirrors `searchActive` so the adjustment below can tell a transition from
+  // a steady state. See the comment there for why that distinction matters.
+  const [prevSearchActive, setPrevSearchActive] = useState(searchActive);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   const [isFetchingRaw, setIsFetching] = useState(false);
@@ -140,7 +147,6 @@ export function ColumnCard({ column }: { column: Column }) {
   // never widens past the persisted-filter results, matching the operator's
   // mental model: filters decide what the column *contains*, search decides
   // what they're looking at *right now* inside that subset.
-  const searchActive = searchQuery.trim().length > 0;
   const visibleItems = useMemo(() => {
     if (!searchActive) return filteredItems;
     return filteredItems.filter((it) => itemMatchesSearchQuery(it, searchQuery));
@@ -156,36 +162,37 @@ export function ColumnCard({ column }: { column: Column }) {
   }, [alertTerms, visibleItems]);
   const matchCount = matchedItemIds.size;
 
-  // Auto-open the search row when a query already exists on mount — covers
-  // the case where the operator collapsed/expanded a column or switched tabs
-  // and the search state was preserved in-session. Closing collapses the row
-  // visually but never clears the query, so re-opening shows what they last
-  // typed (until they reload or manually clear).
-  useEffect(() => {
-    // set-state-in-effect is suppressed, not fixed: the open state is sticky
-    // by design, so it can't be derived as `searchOpen || searchActive` —
-    // that would auto-close the row the moment the query is cleared, which is
-    // exactly the behaviour the note below rules out. The cascade is one
-    // bounded extra render on the mount-with-existing-query path.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (searchActive && !searchOpen) setSearchOpen(true);
-    // intentionally only react to searchActive flipping true — don't auto-
-    // close when the operator clears the query mid-type; let them keep the
-    // input visible to keep typing.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchActive]);
+  // Two things force the search row open, and both are state adjustments, so
+  // they run during render rather than from an effect — React re-runs the
+  // component immediately, before paint, with no cascading commit.
+  //
+  // 1. The query going from empty to non-empty. This must be edge-triggered,
+  //    not condition-triggered: the "Esc" button and the toolbar toggle both
+  //    close the row *without* clearing the query, so a plain
+  //    `searchActive && !searchOpen` test would immediately re-open it and
+  //    make the row impossible to dismiss. Comparing against the previous
+  //    value is what keeps it a transition. Deliberately one-way — clearing
+  //    the query mid-type leaves the row up so the operator can keep typing.
+  // 2. The `/` shortcut, routed here by the deck-board listener through
+  //    `pendingSearchOpen`. That signal is one-shot and drained by the effect
+  //    below on the same commit, so it is already edge-shaped.
+  //
+  // The mount case (a query that survived a collapse/expand or a tab switch)
+  // is handled by seeding `searchOpen` from `searchActive` above, not here.
+  if (searchActive !== prevSearchActive) {
+    setPrevSearchActive(searchActive);
+    if (searchActive) setSearchOpen(true);
+  }
+  if (pendingSearchOpen === column.id && !searchOpen) {
+    setSearchOpen(true);
+  }
 
-  // React to the `/` keyboard shortcut routed via the store. The deck-board
-  // listener sets `pendingSearchOpen` to this column's id; we open the search
-  // row, focus the input, then clear the signal so a future `/` keypress
-  // re-fires cleanly.
+  // Left with the two jobs that genuinely belong in an effect: moving DOM
+  // focus, and draining the one-shot signal so a later `/` re-fires. The row
+  // is already committed by the time this runs, because the adjustment above
+  // resolves before React commits the tree.
   useEffect(() => {
     if (pendingSearchOpen !== column.id) return;
-    // Syncing local state from an external store signal is effect-shaped by
-    // nature — the keypress happens outside this component and is routed here
-    // through the store, so there is no render-time value to derive from.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setSearchOpen(true);
     requestAnimationFrame(() => searchInputRef.current?.focus());
     clearPendingSearchOpen(column.id);
   }, [pendingSearchOpen, column.id, clearPendingSearchOpen]);

--- a/components/dialogs/version-history-dialog.tsx
+++ b/components/dialogs/version-history-dialog.tsx
@@ -25,53 +25,6 @@ export function VersionHistoryDialog({ deckId, open, onOpenChange }: Props) {
   const deckName = useDeckStore((s) =>
     deckId ? (s.decks[deckId]?.name ?? "") : "",
   );
-  const loadDeckSnapshots = useDeckStore((s) => s.loadDeckSnapshots);
-  const restoreDeckSnapshot = useDeckStore((s) => s.restoreDeckSnapshot);
-
-  const [snapshots, setSnapshots] = useState<DeckSnapshotMeta[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [restoringId, setRestoringId] = useState<number | null>(null);
-
-  useEffect(() => {
-    if (!open || !deckId) return;
-    let cancelled = false;
-    // Entering the loading state as the fetch is kicked off is the point of
-    // this effect — the data lives outside React and only the dialog opening
-    // can trigger the read. Removing the cascade would mean moving snapshot
-    // loading behind Suspense, which is out of scope here.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setLoading(true);
-    loadDeckSnapshots(deckId)
-      .then((rows) => {
-        if (!cancelled) setSnapshots(rows);
-      })
-      .catch(() => {
-        if (!cancelled) setSnapshots([]);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, deckId, loadDeckSnapshots]);
-
-  async function handleRestore(id: number) {
-    if (restoringId !== null) return;
-    setRestoringId(id);
-    try {
-      const result = await restoreDeckSnapshot(id);
-      toast.success(`Restored "${result.deckName}"`, {
-        description: `${result.columns.length} column${result.columns.length === 1 ? "" : "s"}`,
-      });
-      onOpenChange(false);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Restore failed";
-      toast.error("Restore failed", { description: msg });
-    } finally {
-      setRestoringId(null);
-    }
-  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -94,45 +47,111 @@ export function VersionHistoryDialog({ deckId, open, onOpenChange }: Props) {
           appended — your current deck isn’t touched.
         </p>
 
-        <div className="grid gap-1.5">
-          {loading ? (
-            <p className="py-6 text-center text-sm text-muted-foreground">
-              Loading…
-            </p>
-          ) : snapshots.length === 0 ? (
-            <p className="py-6 text-center text-sm text-muted-foreground">
-              No version history yet. Make a change to this deck and a snapshot
-              will appear here.
-            </p>
-          ) : (
-            snapshots.map((snap) => (
-              <div
-                key={snap.id}
-                className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2"
-              >
-                <div className="min-w-0">
-                  <div className="text-sm">
-                    <RelativeTime date={snap.capturedAt} addSuffix />
-                  </div>
-                  <div className="text-xs text-muted-foreground tabular-nums">
-                    {snap.columnCount} column{snap.columnCount === 1 ? "" : "s"}
-                  </div>
-                </div>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  disabled={restoringId !== null}
-                  onClick={() => handleRestore(snap.id)}
-                >
-                  <RotateCcw className="mr-1.5 size-3.5" />
-                  {restoringId === snap.id ? "Restoring…" : "Restore"}
-                </Button>
-              </div>
-            ))
-          )}
-        </div>
+        {/*
+          The dialog itself stays mounted for the lifetime of the sidebar, so
+          the list is split out and mounted per-open, keyed by deck. That makes
+          `useState`'s initial value the reset: reopening, or switching decks
+          while open, starts from the loading state without an effect having to
+          synchronously roll it back.
+        */}
+        {open && deckId ? (
+          <SnapshotList
+            key={deckId}
+            deckId={deckId}
+            onRestored={() => onOpenChange(false)}
+          />
+        ) : null}
       </DialogContent>
     </Dialog>
+  );
+}
+
+function SnapshotList({
+  deckId,
+  onRestored,
+}: {
+  deckId: string;
+  onRestored: () => void;
+}) {
+  const loadDeckSnapshots = useDeckStore((s) => s.loadDeckSnapshots);
+  const restoreDeckSnapshot = useDeckStore((s) => s.restoreDeckSnapshot);
+
+  // `null` means "not loaded yet" — one state instead of a separate `loading`
+  // flag that had to be raised and lowered around the fetch. It also removes a
+  // flash of the empty-state copy on first paint, which the old `loading`
+  // default of `false` allowed for one render.
+  const [snapshots, setSnapshots] = useState<DeckSnapshotMeta[] | null>(null);
+  const [restoringId, setRestoringId] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadDeckSnapshots(deckId)
+      .then((rows) => {
+        if (!cancelled) setSnapshots(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setSnapshots([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [deckId, loadDeckSnapshots]);
+
+  async function handleRestore(id: number) {
+    if (restoringId !== null) return;
+    setRestoringId(id);
+    try {
+      const result = await restoreDeckSnapshot(id);
+      toast.success(`Restored "${result.deckName}"`, {
+        description: `${result.columns.length} column${result.columns.length === 1 ? "" : "s"}`,
+      });
+      onRestored();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Restore failed";
+      toast.error("Restore failed", { description: msg });
+    } finally {
+      setRestoringId(null);
+    }
+  }
+
+  return (
+    <div className="grid gap-1.5">
+      {snapshots === null ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">
+          Loading…
+        </p>
+      ) : snapshots.length === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">
+          No version history yet. Make a change to this deck and a snapshot will
+          appear here.
+        </p>
+      ) : (
+        snapshots.map((snap) => (
+          <div
+            key={snap.id}
+            className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2"
+          >
+            <div className="min-w-0">
+              <div className="text-sm">
+                <RelativeTime date={snap.capturedAt} addSuffix />
+              </div>
+              <div className="text-xs text-muted-foreground tabular-nums">
+                {snap.columnCount} column{snap.columnCount === 1 ? "" : "s"}
+              </div>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={restoringId !== null}
+              onClick={() => handleRestore(snap.id)}
+            >
+              <RotateCcw className="mr-1.5 size-3.5" />
+              {restoringId === snap.id ? "Restoring…" : "Restore"}
+            </Button>
+          </div>
+        ))
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
Follow-up to #116, which disabled three `react-hooks/set-state-in-effect` reports with rationale rather than fixing them. Each had a real fix that also removes state.

## ColumnCard search row

Two effects existed only to open the row. Opening is a state adjustment, so it now happens during render — React re-runs the component immediately, before paint, with no cascading commit.

**The query-driven open has to stay edge-triggered**, and this is the part worth reviewing. The obvious version —

```js
if (searchActive && !searchOpen) setSearchOpen(true);
```

— is wrong. Both the **"Esc" button** and the **toolbar toggle** close the row *without* clearing the query, so that test re-opens it on the very next render and the row becomes impossible to dismiss. I wrote that version first and caught it reading the close handlers. Comparing against the previous value keeps it a transition, which is what the old `[searchActive]` dep array was really encoding.

The mount case (a query that survived a collapse/expand or tab switch) moves to seeding `searchOpen` from `searchActive`, which also removes a one-frame flicker. The effect is left with the two jobs that genuinely belong in one: moving DOM focus and draining the one-shot `/` signal.

## VersionHistoryDialog

The dialog stays mounted for the lifetime of the sidebar — that was the *only* reason it had to set a loading flag synchronously on open. Splitting the list into a child that mounts per-open and is keyed by deck makes `useState`'s initial value the reset.

`snapshots: DeckSnapshotMeta[] | null` then encodes "not loaded yet" directly, so the separate `loading` boolean disappears — along with a one-render flash of the empty-state copy that the old `loading: false` default allowed on first open.

## Verification

There is **no test coverage for any of this** (the 279 tests don't touch either file), and reasoning alone already produced one bug here, so I exercised it against a live deck in a browser:

| Scenario | Result |
|---|---|
| Close search via "Esc" with active query | stays closed ✅ |
| Query survives close → reopen | `nvidia` retained ✅ |
| Clear query mid-type | row stays open ✅ |
| `/` shortcut | opens **and** focuses input ✅ |
| Version history open | snapshots load ✅ |
| Close → reopen dialog | fresh load, no stale state ✅ |

Console: 0 React errors, 0 warnings — no "cannot update while rendering", no render loop.

`eslint --max-warnings=0` clean · 279/279 tests · `tsc --noEmit` · `next build` all pass. No `set-state-in-effect` disables remain in the codebase.