### PR TITLE
fix(deps): patch @hono/node-server path-traversal (MEDIUM, GHSA-frvp-7c67-39w9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1733,12 +1733,12 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "overrides": {
     "postcss": "^8.5.10",
     "sharp": "^0.35.0",
+    "@hono/node-server": "^2.0.5",
     "@esbuild-kit/core-utils": {
       "esbuild": "^0.25.10"
     }


### PR DESCRIPTION
Closes the last open Dependabot advisory on this repo (the other four — #121, #122, #123 — are already merged).

## Change (transitive-only)
| Package | Before | After | Advisory |
|---------|--------|-------|----------|
| `@hono/node-server` | 1.19.14 | **2.0.11** (`overrides: ^2.0.5`) | GHSA-frvp-7c67-39w9 — path traversal in `serve-static` on Windows via encoded backslash (`%5C`), patched in 2.0.5 |

## Why an override (and why a major bump)
There is **no patched 1.x release** — the fix ships only in the 2.x line. The dependency chain is:

`shadcn` → `@modelcontextprotocol/sdk@1.29.0` (`^1.19.9`) → `@hono/node-server`

Even the **latest** MCP SDK (1.29.0, already installed) still pins `@hono/node-server` to `^1.x`, so bumping the SDK doesn't help — an `overrides` entry is the only way to reach the patched version.

## Blast radius
`@hono/node-server` is reachable only through **shadcn's MCP CLI feature**, not the deployed Next.js app's runtime, and the vuln is Windows-specific. So forcing the 2.x major has minimal risk here.

## Verification
- `npm ci` (pinned `npm@10.9.8`) clean, `eslint` clean, **292/292 vitest tests pass** locally.
- Diff limited to `package.json` + `package-lock.json` (8 lockfile lines); no other dependency changed.