### PR TITLE
security: bump postcss (Dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9827,9 +9827,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -9846,7 +9846,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9868,9 +9868,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "vitest": "^4.1.10"
   },
   "overrides": {
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.25",
     "sharp": "^0.35.0",
     "@hono/node-server": "^2.0.5",
     "@esbuild-kit/core-utils": {


### PR DESCRIPTION
## Summary

Remediates the two open Dependabot alerts on **postcss** in `aeonfun/minitor`.

postcss is a transitive dependency (pulled in via tailwindcss / next) and is already pinned through the repo's existing `overrides` block. This bumps that override so the resolved version clears both advisories.

| Package | Old | New |
|---|---|---|
| postcss | 8.5.13 | 8.5.25 |

Override range: `^8.5.10` -> `^8.5.25`.

## Alerts cleared

- **GHSA-r28c-9q8g-f849** (high) - first patched in 8.5.18
- **GHSA-fxqj-rqcc-2cmp** (medium) - first patched in 8.5.23

8.5.25 is >= both patched versions, so it clears both GHSAs.

## Notes

- Only `package.json` (override bump) and `package-lock.json` changed.
- Lockfile regenerated with the pinned `npm@10.9.8` (`npm install --package-lock-only`); `npm audit` reports 0 vulnerabilities.
- Incidental: postcss's own nested `nanoid` moved 3.3.12 -> 3.3.17 (in-range patch), no other tree changes.
